### PR TITLE
Uncommented the test code and resend future set correction

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/CallPromise.h
+++ b/hazelcast/include/hazelcast/client/connection/CallPromise.h
@@ -60,6 +60,7 @@ namespace hazelcast {
 
                 int incrementAndGetResendCount();
 
+                void resetFuture();
             private:
                 util::Future<std::auto_ptr<protocol::ClientMessage> > future;
                 std::auto_ptr<protocol::ClientMessage> request;

--- a/hazelcast/include/hazelcast/util/Future.h
+++ b/hazelcast/include/hazelcast/util/Future.h
@@ -48,7 +48,6 @@ namespace hazelcast {
                 LockGuard guard(mutex);
                 if (exceptionReady || resultReady) {
                     util::ILogger::getLogger().warning(std::string("Future.set_value should not be called twice"));
-                    return;
                 }
                 sharedObject = value;
                 resultReady = true;
@@ -59,7 +58,6 @@ namespace hazelcast {
                 LockGuard guard(mutex);
                 if (exceptionReady || resultReady) {
                     util::ILogger::getLogger().warning(std::string("Future.set_exception should not be called twice : details ") + exceptionDetails);
-                    return;
                 }
                 this->exceptionName = exceptionName;
                 this->exceptionDetails = exceptionDetails;
@@ -108,6 +106,12 @@ namespace hazelcast {
                 throw client::exception::TimeoutException("Future::get(timeInSeconds)", "Wait is timed out");
             };
 
+            void reset() {
+                LockGuard guard(mutex);
+
+                resultReady = false;
+                exceptionReady = false;
+            }
         private:
             bool resultReady;
             bool exceptionReady;

--- a/hazelcast/src/hazelcast/client/connection/CallPromise.cpp
+++ b/hazelcast/src/hazelcast/client/connection/CallPromise.cpp
@@ -61,6 +61,10 @@ namespace hazelcast {
             int CallPromise::incrementAndGetResendCount() {
                 return ++resendCount;
             }
+
+            void CallPromise::resetFuture() {
+                future.reset();
+            }
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
@@ -211,6 +211,8 @@ namespace hazelcast {
                                                 " to connection " +
                                                 util::IOUtil::to_string<Address>(connection->getRemoteEndpoint()));
 
+                promise->resetFuture();
+
                 return registerAndEnqueue(connection, promise, -1);
             }
 

--- a/hazelcast/test/cluster/ClusterTest.cpp
+++ b/hazelcast/test/cluster/ClusterTest.cpp
@@ -47,7 +47,7 @@ namespace hazelcast {
             void ClusterTest::addTests() {
                 addTest(&ClusterTest::testClusterListeners, "testClusterListeners");
                 addTest(&ClusterTest::testClusterListenersFromConfig, "testClusterListenersFromConfig");
-//                addTest(&ClusterTest::testListenersWhenClusterDown, "testListenersWhenClusterDown");
+                addTest(&ClusterTest::testListenersWhenClusterDown, "testListenersWhenClusterDown");
                 addTest(&ClusterTest::testBehaviourWhenClusterNotFound, "testBehaviourWhenClusterNotFound");
             }
 
@@ -244,9 +244,11 @@ namespace hazelcast {
 
                 HazelcastServer instance2(hazelcastInstanceFactory);
                 assertTrue(lifecycleLatch.await(120), "Lifecycle latch await timed out!");
+                // Let enough time for the client to re-register the failed listeners
+                util::sleep(1);
                 m.put("sample", "entry");
                 assertTrue(countDownLatch.await(60), "Await timed out !");
-                assertTrue(hazelcastClient.removeLifecycleListener(&lifecycleListener), "Listener could not removed");
+                assertTrue(hazelcastClient.removeLifecycleListener(&lifecycleListener), "Listener could not be removed");
             }
 
             void ClusterTest::testBehaviourWhenClusterNotFound() {

--- a/hazelcast/test/map/ClientMapTest.cpp
+++ b/hazelcast/test/map/ClientMapTest.cpp
@@ -45,7 +45,6 @@ namespace hazelcast {
             }
 
             void ClientMapTest::addTests() {
-/*
                 addTest(&ClientMapTest::testContains, "testContains");
                 addTest(&ClientMapTest::testGet, "testGet");
                 addTest(&ClientMapTest::testRemoveAndDelete, "testRemoveAndDelete");
@@ -72,7 +71,6 @@ namespace hazelcast {
                 addTest(&ClientMapTest::testMapWithPortable, "testMapWithPortable");
                 addTest(&ClientMapTest::testMapStoreRelatedRequests, "testMapStoreRelatedRequests");
                 addTest(&ClientMapTest::testKeySetAndValuesWithPredicates, "testKeySetAndValuesWithPredicates");
-*/
                 addTest(&ClientMapTest::testExecuteOnKey, "testExecuteOnKey");
                 addTest(&ClientMapTest::testExecuteOnEntries, "testExecuteOnEntries");
             }
@@ -695,7 +693,7 @@ namespace hazelcast {
             };
 
             void ClientMapTest::testExecuteOnKey() {
-                IMap<int, Employee> employees = client->getMap<int, Employee>("employees");
+                IMap<int, Employee> employees = client->getMap<int, Employee>("executeOnKey");
 
                 Employee empl1("ahmet", 35);
                 Employee empl2("mehmet", 21);
@@ -712,7 +710,7 @@ namespace hazelcast {
             }
 
             void ClientMapTest::testExecuteOnEntries() {
-                IMap<int, Employee> employees = client->getMap<int, Employee>("employees");
+                IMap<int, Employee> employees = client->getMap<int, Employee>("testExecuteOnEntries");
 
                 Employee empl1("ahmet", 35);
                 Employee empl2("mehmet", 21);


### PR DESCRIPTION
Uncommented the mistakenly commented out test code and a minor correction on a new test. Eliminated the warning during the invocation resend operations by fixing the promise future into correct state before making the re-invocation of the request.