### PR TITLE
Test machine runs out of disk space

### DIFF
--- a/testLinux.sh
+++ b/testLinux.sh
@@ -96,6 +96,10 @@ then
     exit 1
 fi
 
+# Remove the release related folder
+rm -rf ./Release*
+rm -rf ./cpp
+
 echo "All tests PASSED"
 
 exit 0

--- a/testLinuxSingleCase.sh
+++ b/testLinuxSingleCase.sh
@@ -99,4 +99,7 @@ else
     echo "Test FAILED. Result:${result}"
 fi
 
+echo "Removing the build folder(${BUILD_DIR})"
+rm -rf ${BUILD_DIR}
+
 exit ${result}

--- a/testWindows.bat
+++ b/testWindows.bat
@@ -76,6 +76,10 @@ if %errorlevel% NEQ 0 (
     exit /b 1
 )
 
+echo "Cleaning up release directories"
+rm -rf ./Release*
+rm -rf ./cpp
+
 echo "All Tests PASSED"
 exit /b 0
 

--- a/testWindowsSingleCase.bat
+++ b/testWindowsSingleCase.bat
@@ -84,3 +84,6 @@ SET PATH=%BUILD_DIR%\%HZ_BUILD_TYPE%;%PATH%
 %BUILD_DIR%\hazelcast\test\%HZ_BUILD_TYPE%\%EXECUTABLE_NAME% || exit /b 1
 
 taskkill /F /FI "WINDOWTITLE eq cpp-java"
+
+echo "Removing the build folder(%BUILD_DIR%)"
+rm -rf %BUILD_DIR%


### PR DESCRIPTION
Added cleanup to test scripts to prevent build machine from running out of disk space. The test related folders are removed when test is successful.