### PR TITLE
CountdownLatchTest failure (https://hazelcast-l337.ci.cloudbees.com/view/Clients/job/cpp-linux-nightly/39)

### DIFF
--- a/hazelcast/test/src/countdownlatch/ICountDownLatchTest.cpp
+++ b/hazelcast/test/src/countdownlatch/ICountDownLatchTest.cpp
@@ -48,6 +48,8 @@ namespace hazelcast {
                 util::Thread t(testLatchThread, l.get());
 
                 ASSERT_TRUE(l->await(10 * 1000));
+
+                t.join();
             }
 
         }


### PR DESCRIPTION
Fix for CountdownLatchTest failure in some runs (e.g.: https://hazelcast-l337.ci.cloudbees.com/view/Clients/job/cpp-linux-nightly/39/ ). This comes out to be a missing thread wait in the test itself.

Related to #76 

The problem is generated under these conditions:

1. OS is centos.
2. Build 64 bit static Release. Debug build can not produce the case.
3. No log before  Future.get: conditionVariable.waitFor(mutex, endTime - time(NULL));
