### PR TITLE
Missing header files in release (Generated codec headers)

### DIFF
--- a/releaseLinux.sh
+++ b/releaseLinux.sh
@@ -26,6 +26,7 @@ mkdir -p ./cpp/Linux_32/external/include
 mkdir -p ./cpp/Linux_32/examples/
 
 cp -R hazelcast/include/hazelcast/* cpp/Linux_32/hazelcast/include/hazelcast/
+cp -R hazelcast/generated-sources/include/hazelcast/* cpp/Linux_32/hazelcast/include/hazelcast/
 cp ReleaseShared32/libHazelcastClient* cpp/Linux_32/hazelcast/lib/
 cp ReleaseStatic32/libHazelcastClient* cpp/Linux_32/hazelcast/lib/
 
@@ -62,6 +63,7 @@ mkdir -p ./cpp/Linux_64/external/include
 mkdir -p ./cpp/Linux_64/examples/
 
 cp -R hazelcast/include/hazelcast/* cpp/Linux_64/hazelcast/include/hazelcast/
+cp -R hazelcast/generated-sources/include/hazelcast/* cpp/Linux_64/hazelcast/include/hazelcast/
 cp ReleaseShared64/libHazelcastClient* cpp/Linux_64/hazelcast/lib/
 cp ReleaseStatic64/libHazelcastClient* cpp/Linux_64/hazelcast/lib/
 

--- a/releaseWindows.bat
+++ b/releaseWindows.bat
@@ -26,6 +26,7 @@ mkdir .\cpp\Windows_32\external\include
 mkdir .\cpp\Windows_32\examples
 
 xcopy /S /Q hazelcast\include\hazelcast\* cpp\Windows_32\hazelcast\include\hazelcast\
+xcopy /S /Q hazelcast\generated-sources\include\hazelcast\* cpp\Windows_32\hazelcast\include\hazelcast\
 
 copy ReleaseShared32\Release\HazelcastClient*  cpp\Windows_32\hazelcast\lib\shared\
 copy ReleaseStatic32\Release\HazelcastClient*  cpp\Windows_32\hazelcast\lib\static\
@@ -65,6 +66,7 @@ mkdir .\cpp\Windows_64\external\include
 mkdir .\cpp\Windows_64\examples
 
 xcopy /S /Q hazelcast\include\hazelcast\* cpp\Windows_64\hazelcast\include\hazelcast\
+xcopy /S /Q hazelcast\generated-sources\include\hazelcast\* cpp\Windows_64\hazelcast\include\hazelcast\
 
 copy ReleaseShared64\Release\HazelcastClient*  cpp\Windows_64\hazelcast\lib\shared\
 copy ReleaseStatic64\Release\HazelcastClient*  cpp\Windows_64\hazelcast\lib\static\

--- a/releaseWindowsDev.bat
+++ b/releaseWindowsDev.bat
@@ -21,6 +21,7 @@ mkdir .\cpp\Windows_64\external\include
 mkdir .\cpp\Windows_64\examples
 
 xcopy /S /Q hazelcast\include\hazelcast\* cpp\Windows_64\hazelcast\include\hazelcast\
+xcopy /S /Q hazelcast\generated-sources\include\hazelcast\* cpp\Windows_64\hazelcast\include\hazelcast\
 
 copy ReleaseShared64\Release\HazelcastClient*  cpp\Windows_64\hazelcast\lib\
 copy ReleaseStatic64\Release\HazelcastClient*  cpp\Windows_64\hazelcast\lib\


### PR DESCRIPTION
Added the missing header files into the release script. Solves the problem reported at https://groups.google.com/forum/#!topic/hazelcast/VvpZL21T2oY .