### PR TITLE
Add -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON flags to release scripts

### DIFF
--- a/releaseLinux.sh
+++ b/releaseLinux.sh
@@ -1,4 +1,4 @@
-set -e #abort the script at first faiure
+set -e #abort the script at first failure
 
 echo "Cleanup release directories"
 rm -rf ./Release*
@@ -7,14 +7,14 @@ rm -rf ./cpp
 echo "Compiling Static 32bit library"
 mkdir ReleaseStatic32;
 cd ./ReleaseStatic32;
-cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release
+cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 make -j;
 cd ..;
 
 echo "Compiling Shared 32bit library"
 mkdir ReleaseShared32;
 cd ./ReleaseShared32;
-cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release
+cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 make -j;
 cd ..;
 
@@ -44,14 +44,14 @@ rm -rf ./ReleaseStatic32
 echo "Compiling Static 64bit library"
 mkdir ReleaseStatic64;
 cd ./ReleaseStatic64;
-cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
+cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 make -j;
 cd ..;
 
 echo "Compiling Shared 64bit library"
 mkdir ReleaseShared64;
 cd ./ReleaseShared64;
-cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
+cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 make -j;
 cd ..;
 

--- a/releaseWindows.bat
+++ b/releaseWindows.bat
@@ -6,7 +6,7 @@ echo "Compiling Static 32bit library"
 mkdir ReleaseStatic32
 cd .\ReleaseStatic32
 cd
-cmake .. -G "Visual Studio 12" -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32  -DCMAKE_BUILD_TYPE=Release
+cmake .. -G "Visual Studio 12" -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32  -DCMAKE_BUILD_TYPE=Release  -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 MSBuild.exe HazelcastClient.sln /m /property:Configuration=Release /p:VisualStudioVersion=12.0;Flavor=32;Platform=win32;PlatformTarget=win32
 cd ..
 
@@ -14,7 +14,7 @@ echo "Compiling Shared 32bit library"
 mkdir ReleaseShared32
 cd .\ReleaseShared32
 cd;
-cmake .. -G "Visual Studio 12" -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32  -DCMAKE_BUILD_TYPE=Release
+cmake .. -G "Visual Studio 12" -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32  -DCMAKE_BUILD_TYPE=Release  -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 MSBuild.exe HazelcastClient.sln /m /property:Configuration=Release /p:VisualStudioVersion=12.0;Flavor=32;Platform=win32;PlatformTarget=win32
 cd ..
 
@@ -46,7 +46,7 @@ echo "Compiling Static 64bit library"
 mkdir ReleaseStatic64
 cd .\ReleaseStatic64
 cd;
-cmake .. -G "Visual Studio 12 Win64" -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release 
+cmake .. -G "Visual Studio 12 Win64" -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release  -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 MSBuild.exe HazelcastClient.sln /m /property:Configuration=Release /p:VisualStudioVersion=12.0;Flavor=64;Platform=x64;PlatformTarget=x64
 cd ..
 
@@ -54,7 +54,7 @@ echo "Compiling Shared 64bit library"
 mkdir ReleaseShared64
 cd .\ReleaseShared64
 cd;
-cmake .. -G "Visual Studio 12 Win64" -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release 
+cmake .. -G "Visual Studio 12 Win64" -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release  -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 MSBuild.exe HazelcastClient.sln /m /property:Configuration=Release /p:VisualStudioVersion=12.0;Flavor=64;Platform=x64;PlatformTarget=x64
 cd ..
 

--- a/releaseWindowsDev.bat
+++ b/releaseWindowsDev.bat
@@ -2,7 +2,7 @@ echo "Compiling Static 64bit library"
 mkdir ReleaseStatic64
 cd .\ReleaseStatic64
 cd;
-cmake .. -G "Visual Studio 10 Win64" -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release 
+cmake .. -G "Visual Studio 10 Win64" -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release  -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON 
 MSBuild.exe HazelcastClient.sln /property:Configuration=Release 
 cd ..
 
@@ -10,7 +10,7 @@ echo "Compiling Shared 64bit library"
 mkdir ReleaseShared64
 cd .\ReleaseShared64
 cd;
-cmake .. -G "Visual Studio 10 Win64" -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release 
+cmake .. -G "Visual Studio 10 Win64" -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release  -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON 
 MSBuild.exe HazelcastClient.sln /property:Configuration=Release 
 cd ..
 


### PR DESCRIPTION
The newly added -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON are added to the release scripts.