### PR TITLE
Missing verification step in release scripts

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,129 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+cmake_minimum_required (VERSION 3.1)
+project (HazelcastExamples)
+
+INCLUDE(TestBigEndian)
+
+# if HAZELCAST_INSTALL_DIR option is provided, the examples shall compile with the released library
+if (NOT("${HAZELCAST_INSTALL_DIR}x" STREQUAL "x"))
+    message (STATUS "Using hazelcast installation at ${HAZELCAST_INSTALL_DIR}.")
+
+    if(NOT("${HZ_VERSION}x" MATCHES "x"))
+        message(FATAL_ERROR "Release verification require that this folder is NOT included from a parent CMakeLists.txt.")
+    endif (NOT("${HZ_VERSION}x" MATCHES "x"))
+
+    if ("${HZ_BIT}x" STREQUAL "x")
+        message(FATAL_ERROR "You have to specify HZ_BIT variable!")
+    endif()
+
+    IF(NOT (${HZ_LIB_TYPE} MATCHES "STATIC") AND NOT (${HZ_LIB_TYPE} MATCHES "SHARED") )
+        message( STATUS "Build needs HZ_LIB_TYPE. Setting default as -DHZ_LIB_TYPE=STATIC (other option -DHZ_LIB_TYPE=SHARED)" )
+        set(HZ_LIB_TYPE STATIC)
+    ENDIF(NOT (${HZ_LIB_TYPE} MATCHES "STATIC") AND NOT (${HZ_LIB_TYPE} MATCHES "SHARED") )
+
+    SET(HZ_VERSION 3.7-SNAPSHOT)
+
+    IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        SET(HAZELCAST_PLATFORM_INSTALL_DIR ${HAZELCAST_INSTALL_DIR}\\${CMAKE_SYSTEM_NAME}_${HZ_BIT})
+    ELSE()
+        SET(HAZELCAST_PLATFORM_INSTALL_DIR ${HAZELCAST_INSTALL_DIR}/${CMAKE_SYSTEM_NAME}_${HZ_BIT})
+    ENDIF()
+
+    message(STATUS "Shall try building the examples with installed Hazelcast client at ${HAZELCAST_PLATFORM_INSTALL_DIR}")
+    message(STATUS "Include directories: ${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/include ${HAZELCAST_PLATFORM_INSTALL_DIR}/external/include")
+    message(STATUS "Link directory: ${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/lib")
+
+    #detect endianness
+    TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+    if (${IS_BIG_ENDIAN})
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DHZ_BIG_ENDIAN")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DHZ_BIG_ENDIAN")
+    ENDIF (${IS_BIG_ENDIAN})
+
+    include_directories(${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/include ${HAZELCAST_PLATFORM_INSTALL_DIR}/external/include)
+
+    SET(HZ_LIB_NAME HazelcastClient${HZ_VERSION}_${HZ_BIT})
+
+    ADD_LIBRARY(${HZ_LIB_NAME} ${HZ_LIB_TYPE} IMPORTED)
+
+    message(STATUS "${CMAKE_SYSTEM}")
+
+    IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        message(STATUS "APPLE ENVIRONMENT DETECTED")
+
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall")
+
+        set(HZ_LIB_PATH "")
+        IF (${HZ_LIB_TYPE} MATCHES "STATIC")
+            set(HZ_LIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/lib/lib${HZ_LIB_NAME}.a")
+        ELSE(${HZ_LIB_TYPE} MATCHES "STATIC")
+            set(HZ_LIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/lib/lib${HZ_LIB_NAME}.dylib")
+        ENDIF(${HZ_LIB_TYPE} MATCHES "STATIC")
+
+        message(STATUS "Using ${HZ_LIB_TYPE} library at ${HZ_LIB_PATH}")
+
+        set_property(TARGET ${HZ_LIB_NAME} PROPERTY IMPORTED_LOCATION "${HZ_LIB_PATH}")
+
+        link_libraries(${HZ_LIB_NAME} )
+
+    ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+    IF( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" )
+        message(STATUS "LINUX ENVIRONMENT DETECTED")
+
+        SET(HZ_BIT_FLAG " ")
+        IF(${HZ_BIT} MATCHES "32")
+            SET(HZ_BIT_FLAG " -m32 ")
+        ENDIF(${HZ_BIT} MATCHES "32")
+
+        message(STATUS "${HZ_BIT} Bit")
+
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall ${HZ_BIT_FLAG}")
+
+        set(HZ_LIB_PATH "")
+        IF (${HZ_LIB_TYPE} MATCHES "STATIC")
+            set(HZ_LIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/lib/lib${HZ_LIB_NAME}.a")
+        ELSE(${HZ_LIB_TYPE} MATCHES "STATIC")
+            set(HZ_LIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}/hazelcast/lib/lib${HZ_LIB_NAME}.so")
+        ENDIF(${HZ_LIB_TYPE} MATCHES "STATIC")
+
+        message(STATUS "Using ${HZ_LIB_TYPE} library at ${HZ_LIB_PATH}")
+
+        set_property(TARGET ${HZ_LIB_NAME} PROPERTY IMPORTED_LOCATION "${HZ_LIB_PATH}")
+
+        link_libraries(${HZ_LIB_NAME} pthread rt )
+    ENDIF( ${CMAKE_SYSTEM_NAME} MATCHES "Linux" )
+
+    IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        message(STATUS "WINDOWS ENVIRONMENT DETECTED ${CMAKE_GENERATOR} ${CMAKE_BUILD_TYPE} ")
+
+        add_definitions(-D__WIN${HZ_BIT}__ -DWIN${HZ_BIT} -D_WIN${HZ_BIT})
+
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /EHsc")
+
+        add_definitions(-DHAZELCAST_EXPORTS=0)
+
+        IF (${HZ_LIB_TYPE} MATCHES "STATIC")
+            set(HZ_LIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}\\hazelcast\\lib\\static\\${HZ_LIB_NAME}.lib")
+            set_property(TARGET ${HZ_LIB_NAME} PROPERTY IMPORTED_LOCATION ${HZ_LIB_PATH})
+
+            message(STATUS "Using ${HZ_LIB_TYPE} library at ${HZ_LIB_PATH}")
+        ELSE(${HZ_LIB_TYPE} MATCHES "STATIC")
+            set(HZ_LIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}\\hazelcast\\lib\\shared\\${HZ_LIB_NAME}.dll")
+            set(HZ_LIB_IMPLIB_PATH "${HAZELCAST_PLATFORM_INSTALL_DIR}\\hazelcast\\lib\\shared\\${HZ_LIB_NAME}.lib")
+
+            set_property(TARGET ${HZ_LIB_NAME} PROPERTY IMPORTED_LOCATION ${HZ_LIB_PATH})
+            set_property(TARGET ${HZ_LIB_NAME} PROPERTY IMPORTED_IMPLIB ${HZ_LIB_IMPLIB_PATH})
+
+            message(STATUS "Using ${HZ_LIB_TYPE} library at ${HZ_LIB_PATH}")
+        ENDIF(${HZ_LIB_TYPE} MATCHES "STATIC")
+
+        link_libraries(${HZ_LIB_NAME})
+    ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+endif (NOT("${HAZELCAST_INSTALL_DIR}x" STREQUAL "x"))
+
 add_subdirectory(CommandLineTool)
 add_subdirectory(transactions)
 add_subdirectory(spi)
@@ -24,6 +147,7 @@ add_subdirectory(distributed-topic)
 add_subdirectory(distributed-primitives)
 add_subdirectory(distributed-map)
 add_subdirectory(distributed-collections)
+
 
 
 

--- a/hazelcast/test/CMakeLists.txt
+++ b/hazelcast/test/CMakeLists.txt
@@ -1,2 +1,5 @@
+SET(BUILD_GMOCK OFF)
+SET(BUILD_TEST ON)
+
 add_subdirectory(src)
 add_subdirectory(googletest)

--- a/releaseLinux.sh
+++ b/releaseLinux.sh
@@ -8,14 +8,14 @@ echo "Compiling Static 32bit library"
 mkdir ReleaseStatic32;
 cd ./ReleaseStatic32;
 cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j;
+make -j 4;
 cd ..;
 
 echo "Compiling Shared 32bit library"
 mkdir ReleaseShared32;
 cd ./ReleaseShared32;
 cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j;
+make -j 4;
 cd ..;
 
 
@@ -45,14 +45,14 @@ echo "Compiling Static 64bit library"
 mkdir ReleaseStatic64;
 cd ./ReleaseStatic64;
 cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j;
+make -j 4;
 cd ..;
 
 echo "Compiling Shared 64bit library"
 mkdir ReleaseShared64;
 cd ./ReleaseShared64;
 cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j;
+make -j 4;
 cd ..;
 
 
@@ -77,3 +77,7 @@ find ReleaseStatic64/examples -perm +111 -type f -exec cp {} cpp/Linux_64/exampl
 echo "Clearing temporary 64bit libraries"
 rm -rf ./ReleaseShared64
 rm -rf ./ReleaseStatic64
+
+# Verify release
+scripts/verifyReleaseLinux.sh
+

--- a/releaseWindows.bat
+++ b/releaseWindows.bat
@@ -82,3 +82,5 @@ echo "Clearing tempraroy 64bit librares"
 rm -rf ./ReleaseShared64
 rm -rf ./ReleaseStatic64
 
+@REM Verify release
+call scripts/verifyReleaseWindows.bat || exit /b 1

--- a/releaseWindowsDev.bat
+++ b/releaseWindowsDev.bat
@@ -37,3 +37,12 @@ echo "Clearing tempraroy 64bit librares"
 rm -rf ./ReleaseShared64
 rm -rf ./ReleaseStatic64
 
+cd examples
+rm -rf build
+mkdir build
+cd build
+cmake .. -DHAZELCAST_INSTALL_DIR=../cpp -DHZ_BIT=32
+MSBuild.exe HazelcastClient.sln /m
+cd ..
+rm -rf build
+cd ..

--- a/scripts/verifyReleaseLinux.sh
+++ b/scripts/verifyReleaseLinux.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e #abort the script at first failure
+
+# Verify release
+CURRENT_DIRECTORY=`pwd`
+
+${CURRENT_DIRECTORY}/scripts/verifyReleaseLinuxSingleCase.sh ${CURRENT_DIRECTORY}/cpp 32 STATIC
+
+${CURRENT_DIRECTORY}/scripts/verifyReleaseLinuxSingleCase.sh ${CURRENT_DIRECTORY}/cpp 32 SHARED
+
+${CURRENT_DIRECTORY}/scripts/verifyReleaseLinuxSingleCase.sh ${CURRENT_DIRECTORY}/cpp 64 STATIC
+
+${CURRENT_DIRECTORY}/scripts/verifyReleaseLinuxSingleCase.sh ${CURRENT_DIRECTORY}/cpp 64 SHARED
+
+exit 0
+
+

--- a/scripts/verifyReleaseLinuxSingleCase.sh
+++ b/scripts/verifyReleaseLinuxSingleCase.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e #abort the script at first failure
+
+HZ_INSTALL_DIR=$1
+HZ_BIT_VERSION=$2
+HZ_LIB_TYPE=$3
+
+echo "Verifying the release located at ${HZ_INSTALL_DIR} for ${HZ_LIB_TYPE} ${HZ_BIT_VERSION} bit library."
+
+cd examples
+rm -rf build
+mkdir build
+cd build
+
+cmake .. -DHAZELCAST_INSTALL_DIR=${HZ_INSTALL_DIR} -DHZ_BIT=${HZ_BIT_VERSION} -DHZ_LIB_TYPE=${HZ_LIB_TYPE}
+
+make -j 4
+
+echo "Verification of the release located at ${HZ_INSTALL_DIR} for ${HZ_LIB_TYPE} ${HZ_BIT_VERSION} bit library is finished."
+
+exit 0
+
+

--- a/scripts/verifyReleaseWindows.bat
+++ b/scripts/verifyReleaseWindows.bat
@@ -1,0 +1,14 @@
+# Verify release
+SET CURRENT_DIRECTORY=%cd%
+
+call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 32 STATIC || exit /b 1
+
+call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 32 SHARED || exit /b 1
+
+call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 64 STATIC || exit /b 1
+
+call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 64 SHARED || exit /b 1
+
+exit 0
+
+

--- a/scripts/verifyReleaseWindowsSingleCase.bat
+++ b/scripts/verifyReleaseWindowsSingleCase.bat
@@ -1,0 +1,33 @@
+SET HZ_INSTALL_DIR=%1
+SET HZ_BIT_VERSION=%2
+SET HZ_LIB_TYPE=%3
+
+echo "Verifying the release located at %HZ_INSTALL_DIR% for %HZ_LIB_TYPE% %HZ_BIT_VERSION% bit library."
+
+cd examples
+rm -rf build
+mkdir build
+cd build
+
+SET HZ_BUILD_TYPE=Release
+
+if %HZ_BIT_VERSION% == 32 (
+    set BUILDFORPLATFORM="win32"
+    set SOLUTIONTYPE="Visual Studio 12"
+) else (
+    set BUILDFORPLATFORM="x64"
+    set SOLUTIONTYPE="Visual Studio 12 Win64"
+)
+
+echo "Generating the solution files for compilation"
+cmake .. -G %SOLUTIONTYPE% -DHAZELCAST_INSTALL_DIR=%HZ_INSTALL_DIR% -DHZ_LIB_TYPE=%HZ_LIB_TYPE% -DHZ_BIT=%HZ_BIT_VERSION% -DCMAKE_BUILD_TYPE=%HZ_BUILD_TYPE% || exit /b 1
+
+echo "Building for platform %BUILDFORPLATFORM%"
+
+MSBuild.exe HazelcastExamples.sln /m /p:Flavor=%HZ_BUILD_TYPE%;Configuration=%HZ_BUILD_TYPE%;VisualStudioVersion=12.0;Platform=%BUILDFORPLATFORM%;PlatformTarget=%BUILDFORPLATFORM% || exit /b 1
+
+echo "Verification of the release located at %HZ_INSTALL_DIR% for %HZ_LIB_TYPE% %HZ_BIT_VERSION% bit library is finished."
+
+exit 0
+
+


### PR DESCRIPTION
Added the verification scripts to verify that the released files work correctly. We compile the examples using different versions of the libraries to achieve this. If the builds succeed, then we assume that the release is proper and correct. This will avoid any missing file problem during releases.

Fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/35