### PR TITLE
Add release method to obtain raw pointer from shared_ptr

### DIFF
--- a/hazelcast/test/src/map/ClientMapTest.cpp
+++ b/hazelcast/test/src/map/ClientMapTest.cpp
@@ -151,9 +151,13 @@ namespace hazelcast {
                     key += util::IOUtil::to_string(i);
                     boost::shared_ptr<std::string> temp = imap->get(key);
 
-                   std::string value = "value";
+                    std::string value = "value";
                     value += util::IOUtil::to_string(i);
                     ASSERT_EQ(*temp, value);
+                    
+                    // test hazelcast::util::release method also here
+                    std::auto_ptr<std::string> rawPtr(hazelcast::util::release<std::string>(temp));
+                    ASSERT_EQ(*rawPtr, value);
                 }
             }
 

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -23,6 +23,7 @@
 
 #include <ctime>
 #include <gtest/gtest.h>
+#include <boost/smart_ptr/shared_ptr.hpp>
 
 namespace hazelcast {
     namespace client {
@@ -156,6 +157,14 @@ namespace hazelcast {
                 thread.join();
                 time_t end = time(NULL);
                 ASSERT_NEAR((int)(end - beg), wakeUpTime , 1);
+            }
+
+            TEST_F (ClientUtilTest, testSharedPtrRelease) {
+                boost::shared_ptr<std::string> myStr(new std::string("Test string"));
+
+                std::auto_ptr<std::string> rawPtr(hazelcast::util::release<std::string>(myStr));
+
+                ASSERT_STREQ("Test string", rawPtr->c_str());
             }
         }
     }


### PR DESCRIPTION
Added a utility method to obtain the raw pointer from a shared pointer. It is not a desired way but in case the raw pointer is needed without keeping the shared_ptr this may be a work around.