### PR TITLE
Backport of #53: When directory path includes spaces windows release verification script fails

### DIFF
--- a/scripts/verifyReleaseWindows.bat
+++ b/scripts/verifyReleaseWindows.bat
@@ -1,13 +1,13 @@
-# Verify release
+REM Verify release
 SET CURRENT_DIRECTORY=%cd%
 
-call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 32 STATIC || exit /b 1
+call scripts\verifyReleaseWindowsSingleCase.bat "%CURRENT_DIRECTORY%\cpp" 32 STATIC || exit /b 1
 
-call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 32 SHARED || exit /b 1
+call scripts\verifyReleaseWindowsSingleCase.bat "%CURRENT_DIRECTORY%\cpp" 32 SHARED || exit /b 1
 
-call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 64 STATIC || exit /b 1
+call scripts\verifyReleaseWindowsSingleCase.bat "%CURRENT_DIRECTORY%\cpp" 64 STATIC || exit /b 1
 
-call scripts\verifyReleaseWindowsSingleCase.bat %CURRENT_DIRECTORY%\cpp 64 SHARED || exit /b 1
+call scripts\verifyReleaseWindowsSingleCase.bat "%CURRENT_DIRECTORY%\cpp" 64 SHARED || exit /b 1
 
 exit 0
 


### PR DESCRIPTION
Fix for release script error when there is space in directory path.