### PR TITLE
Backport #62 Revert the thread usage for partition refreshing

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/PartitionService.h
+++ b/hazelcast/include/hazelcast/client/spi/PartitionService.h
@@ -48,8 +48,6 @@ namespace hazelcast {
 
         namespace serialization {
             namespace pimpl {
-                class SerializationService;
-
                 class Data;
             }
         }
@@ -71,11 +69,6 @@ namespace hazelcast {
                 boost::shared_ptr<Address> getPartitionOwner(int partitionId);
 
                 int getPartitionId(const serialization::pimpl::Data &key);
-
-                /**
-                 * @return The total number of partitions in the cluster.
-                 */
-                int getPartitionCount();
 
                 /**
                  * Refreshes the partition
@@ -100,8 +93,6 @@ namespace hazelcast {
 
                 void runListener(util::Thread* currentThread);
 
-                void runRefresher();
-
                 std::auto_ptr<protocol::ClientMessage> getPartitionsFrom(const Address &address);
 
                 std::auto_ptr<protocol::ClientMessage> getPartitionsFrom();
@@ -109,8 +100,6 @@ namespace hazelcast {
                 bool processPartitionResponse(protocol::ClientMessage &response);
 
                 bool getInitialPartitions();
-
-                static void refreshTask(util::ThreadArgs &args);
             };
         }
     }

--- a/java/src/main/resources/hazelcast.xml
+++ b/java/src/main/resources/hazelcast.xml
@@ -46,7 +46,11 @@
                 <multicast-port>54327</multicast-port>
             </multicast>
             <tcp-ip enabled="true">
-                <interface>127.0.0.1</interface>
+                <interface>127.0.0.1:5701</interface>
+                <interface>127.0.0.1:5702</interface>
+                <interface>127.0.0.1:5703</interface>
+                <interface>127.0.0.1:5704</interface>
+                <interface>127.0.0.1:5705</interface>
             </tcp-ip>
             <aws enabled="false">
                 <access-key>my-access-key</access-key>


### PR DESCRIPTION
Reverted the thread usage for partition refreshing. It should be handled better by using a mechanism such as ExecutorService. The destructor of the thread was blocking on thread join after performing thread_cancel(cancel was not affecting the update) which caused the update to be blocking anyway. The refresh is being called through the cluster listener thread hence it does not block the IOSelector thread.

Added the additional addresses to java server member for some manual tests.