### PR TITLE
PartitionService shutdown causes deadlock in windows

### DIFF
--- a/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
@@ -52,7 +52,8 @@ namespace hazelcast {
             }
 
             void PartitionService::shutdown() {
-                util::LockGuard lg(lock);
+                // Do not take the lock here since it may be needed by the partition listener thread to cancel and
+                // the join to succeed and if the lock is already taken it causes a deadlock.
                 if (partitionListenerThread.get() != NULL) {
                     partitionListenerThread->cancel();
                     partitionListenerThread->join();


### PR DESCRIPTION
Removed the lock usage in PartitionService shutdown, since it was causing deadlock in Windows environment maintenance nightly builds ( https://hazelcast-l337.ci.cloudbees.com/view/C++/job/cpp_windows%20-%20maintenance%20-%20nightly/65/console ).

Steps that cause deadlock:

1. shutdown gets the lock.
2. refreshPartitions needs the lock to update the partition list before the thread terminates and the deadlock occurs.
