### PR TITLE
Backport of PR #70

### DIFF
--- a/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
@@ -52,7 +52,8 @@ namespace hazelcast {
             }
 
             void PartitionService::shutdown() {
-                util::LockGuard lg(lock);
+                // Do not take the lock here since it may be needed by the partition listener thread to cancel and
+                // the join to succeed and if the lock is already taken it causes a deadlock.
                 if (partitionListenerThread.get() != NULL) {
                     partitionListenerThread->cancel();
                     partitionListenerThread->join();


### PR DESCRIPTION
Removed the lock usage in PartitionService shutdown, since it was causing deadlock in Windows environment maintenance nightly builds.