### PR TITLE
Backport of PR #26 - ICountdownLatch test failure

### DIFF
--- a/hazelcast/test/src/countdownlatch/ICountDownLatchTest.cpp
+++ b/hazelcast/test/src/countdownlatch/ICountDownLatchTest.cpp
@@ -48,6 +48,8 @@ namespace hazelcast {
                 util::Thread t(testLatchThread, l.get());
 
                 ASSERT_TRUE(l->await(10 * 1000));
+
+                t.join();
             }
 
         }


### PR DESCRIPTION
Backport of PR #26. Added the thread join for the latch test so that the countdown finishes gracefully without thread cancellation.