### PR TITLE
Queue testTake causes segmentation fault after test passes

### DIFF
--- a/hazelcast/test/src/adaptor/RawPointerQueueTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerQueueTest.cpp
@@ -152,6 +152,8 @@ namespace hazelcast {
                     item = q.take();  //  should block till it gets an item
                     ASSERT_NE((std::string *)NULL, item.get());
                     ASSERT_EQ("item1", *item);
+
+                    t2.join();
                 }
 
                 TEST_F(RawPointerQueueTest, testRemove) {

--- a/hazelcast/test/src/queue/ClientQueueTest.cpp
+++ b/hazelcast/test/src/queue/ClientQueueTest.cpp
@@ -135,6 +135,8 @@ namespace hazelcast {
                 item = q->take();  //  should block till it gets an item
                 ASSERT_NE((std::string *)NULL, item.get());
                 ASSERT_EQ("item1", *item);
+
+                t2.join();
             }
 
             TEST_F(ClientQueueTest, testRemainingCapacity) {


### PR DESCRIPTION
Fix for issue https://github.com/hazelcast/hazelcast-cpp-client/issues/85 . Waits for the thread to finish when the test is successfull.