### PR TITLE
CountDownLatch::awaitMillis fix for the tests.

### DIFF
--- a/hazelcast/src/hazelcast/util/CountDownLatch.cpp
+++ b/hazelcast/src/hazelcast/util/CountDownLatch.cpp
@@ -42,11 +42,13 @@ namespace hazelcast {
         }
 
         bool CountDownLatch::awaitMillis(size_t milliseconds, size_t &elapsed) {
+            // set elapsed to zero in case it returns before sleep
+            elapsed = 0;
+
             if (count <= 0) {
                 return true;
             }
 
-            elapsed = 0;
             do {
                 util::sleepmillis(CHECK_INTERVAL);
                 elapsed += CHECK_INTERVAL;


### PR DESCRIPTION
Resets the elapsed time at the start of the await for early returns from the method without any sleep.