### PR TITLE
Nightly release build failed due to recent change in examples CmakeLists

### DIFF
--- a/releaseOSX.sh
+++ b/releaseOSX.sh
@@ -57,3 +57,6 @@ cd ../../../../
 echo "Removing temporary files"
 rm -rf ./ReleaseShared
 rm -rf ./ReleaseStatic
+
+# Verify release
+scripts/verifyReleaseMac.sh

--- a/scripts/verifyReleaseLinuxSingleCase.sh
+++ b/scripts/verifyReleaseLinuxSingleCase.sh
@@ -3,6 +3,7 @@
 set -e #abort the script at first failure
 
 HZ_INSTALL_DIR=$1
+HZ_VERSION="3.7-SNAPSHOT"
 HZ_BIT_VERSION=$2
 HZ_LIB_TYPE=$3
 
@@ -13,11 +14,11 @@ rm -rf build
 mkdir build
 cd build
 
-cmake .. -DHAZELCAST_INSTALL_DIR=${HZ_INSTALL_DIR} -DHZ_BIT=${HZ_BIT_VERSION} -DHZ_LIB_TYPE=${HZ_LIB_TYPE}
+cmake .. -DHAZELCAST_INSTALL_DIR=${HZ_INSTALL_DIR} -DHZ_VERSION=${HZ_VERSION} -DHZ_BIT=${HZ_BIT_VERSION} -DHZ_LIB_TYPE=${HZ_LIB_TYPE}
 
 make -j 4
 
-echo "Verification of the release located at ${HZ_INSTALL_DIR} for ${HZ_LIB_TYPE} ${HZ_BIT_VERSION} bit library is finished."
+echo "Verification of the release located at ${HZ_INSTALL_DIR} for version ${HZ_VERSION} ${HZ_LIB_TYPE} ${HZ_BIT_VERSION}-bit library is finished."
 
 exit 0
 

--- a/scripts/verifyReleaseWindowsSingleCase.bat
+++ b/scripts/verifyReleaseWindowsSingleCase.bat
@@ -1,8 +1,9 @@
 SET HZ_INSTALL_DIR=%1
+SET HZ_VERSION="3.7-SNAPSHOT"
 SET HZ_BIT_VERSION=%2
 SET HZ_LIB_TYPE=%3
 
-echo "Verifying the release located at %HZ_INSTALL_DIR% for %HZ_LIB_TYPE% %HZ_BIT_VERSION% bit library."
+echo "Verifying the release located at %HZ_INSTALL_DIR% for version %HZ_VERSION% %HZ_LIB_TYPE% %HZ_BIT_VERSION%-bit library."
 
 cd examples
 rm -rf build
@@ -20,13 +21,13 @@ if %HZ_BIT_VERSION% == 32 (
 )
 
 echo "Generating the solution files for compilation"
-cmake .. -G %SOLUTIONTYPE% -DHAZELCAST_INSTALL_DIR=%HZ_INSTALL_DIR% -DHZ_LIB_TYPE=%HZ_LIB_TYPE% -DHZ_BIT=%HZ_BIT_VERSION% -DCMAKE_BUILD_TYPE=%HZ_BUILD_TYPE% || exit /b 1
+cmake .. -G %SOLUTIONTYPE% -DHAZELCAST_INSTALL_DIR=%HZ_INSTALL_DIR% -DHZ_LIB_TYPE=%HZ_LIB_TYPE% -DHZ_VERSION=${HZ_VERSION} -DHZ_BIT=%HZ_BIT_VERSION% -DCMAKE_BUILD_TYPE=%HZ_BUILD_TYPE% || exit /b 1
 
 echo "Building for platform %BUILDFORPLATFORM%"
 
 MSBuild.exe HazelcastExamples.sln /m /p:Flavor=%HZ_BUILD_TYPE%;Configuration=%HZ_BUILD_TYPE%;VisualStudioVersion=12.0;Platform=%BUILDFORPLATFORM%;PlatformTarget=%BUILDFORPLATFORM% || exit /b 1
 
-echo "Verification of the release located at %HZ_INSTALL_DIR% for %HZ_LIB_TYPE% %HZ_BIT_VERSION% bit library is finished."
+echo "Verification of the release located at %HZ_INSTALL_DIR% for version %HZ_VERSION% %HZ_LIB_TYPE% %HZ_BIT_VERSION%-bit library is finished."
 
 exit 0
 


### PR DESCRIPTION
Corrected verify release script to include the version after the last fix for relaase scripts.