### PR TITLE
The nightly build sometimes fails with segmentation fault in LoadTest::testIntMapDummyClientServerRestart

### DIFF
--- a/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
@@ -357,7 +357,8 @@ namespace hazelcast {
 
             void InvocationService::tryResend(boost::shared_ptr<connection::CallPromise> promise,
                                               const std::string &lastTriedAddress) {
-                if (promise->getRequest()->isRetryable() || isRedoOperation()) {
+                bool serviceOpen = isOpen;
+                if (serviceOpen && (promise->getRequest()->isRetryable() || isRedoOperation())) {
                     resend(promise, lastTriedAddress);
                     return;
                 }

--- a/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
@@ -55,7 +55,7 @@ namespace hazelcast {
                 // Do not take the lock here since it may be needed by the partition listener thread to cancel and
                 // the join to succeed and if the lock is already taken it causes a deadlock.
                 if (partitionListenerThread.get() != NULL) {
-                    partitionListenerThread->cancel();
+                    partitionListenerThread->wakeup();
                     partitionListenerThread->join();
                 }
             }

--- a/hazelcast/src/hazelcast/util/ILogger.cpp
+++ b/hazelcast/src/hazelcast/util/ILogger.cpp
@@ -56,6 +56,7 @@ namespace hazelcast {
                 // std::cout here. outstream flush() function in stdlib 3.4.4 does not handle pthread_cancel call
                 // appropriately.
                 printf("%s SEVERE: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
+                fflush(stdout);
             }
         }
 
@@ -64,6 +65,7 @@ namespace hazelcast {
                 char buffer [TIME_STRING_LENGTH];
                 util::LockGuard l(lockMutex);
                 printf("%s WARNING: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
+                fflush(stdout);
             }
         }
 
@@ -72,6 +74,7 @@ namespace hazelcast {
                 char buffer [TIME_STRING_LENGTH];
                 util::LockGuard l(lockMutex);
                 printf("%s INFO: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
+                fflush(stdout);
             }
         }
 
@@ -81,6 +84,7 @@ namespace hazelcast {
                 char buffer [TIME_STRING_LENGTH];
                 util::LockGuard l(lockMutex);
                 printf("%s FINEST: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
+                fflush(stdout);
             }
         }
 


### PR DESCRIPTION
The test failure at https://hazelcast-l337.ci.cloudbees.com/job/cpp-linux-nightly-64-SHARED-Release/93/console is examined. It is found out that theLoadTest finishes successfully but the test causes "Segmentation fault" on HazelcastClient destructor. The core was being caused due to the usage of thread cancel for PartitionService::shutdown. This somehow messes up with the mutex held by the cancelled thread and it causes segmentation fault. The case can easily be generated by repetitively running the LoadTest (I set up a test build for this where the LoadTest dummy client test running the test in a loop 10 times).

The fix is to not use thread cancel but just set a flag and wakeup the thread.

The commit also contains flushing the logger output when the logs are printed. This way we do not lose any logs if the process crashes.

Also added a control on the invocation service to not retry if the service is shutting down already.