### PR TITLE
Heartbeat fails in some tests

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -22,7 +22,7 @@
 #include "hazelcast/client/connection/ReadHandler.h"
 #include "hazelcast/client/connection/WriteHandler.h"
 #include "hazelcast/util/SynchronizedMap.h"
-#include "hazelcast/util/AtomicInt.h"
+#include <hazelcast/util/Atomic.h>
 #include "hazelcast/util/Closeable.h"
 #include "hazelcast/client/protocol/ClientMessageBuilder.h"
 #include "hazelcast/client/protocol/IMessageHandler.h"
@@ -89,7 +89,7 @@ namespace hazelcast {
 
                 void setConnectionId(int connectionId);
 
-                util::AtomicInt lastRead;
+                util::Atomic<time_t> lastRead;
                 util::AtomicBoolean live;
             private:
                 spi::ClientContext& clientContext;

--- a/hazelcast/src/hazelcast/client/connection/HeartBeater.cpp
+++ b/hazelcast/src/hazelcast/client/connection/HeartBeater.cpp
@@ -65,11 +65,14 @@ namespace hazelcast {
                     time_t now = time(NULL);
                     for (it = connections.begin(); it != connections.end(); ++it) {
                         boost::shared_ptr<Connection> connection = *it;
-                        if (now - connection->lastRead > heartBeatTimeoutSeconds) {
+
+                        time_t lastReadTime = connection->lastRead;
+
+                        if (now - lastReadTime > heartBeatTimeoutSeconds) {
                             connection->heartBeatingFailed();
                         }
 
-                        if (now - connection->lastRead > heartBeatIntervalSeconds) {
+                        if (now - lastReadTime > heartBeatIntervalSeconds) {
                             std::auto_ptr<protocol::ClientMessage> request = protocol::codec::ClientPingCodec::RequestParameters::encode();
 
                             clientContext.getInvocationService().invokeOnConnection(request, connection);


### PR DESCRIPTION
The nightly tests were sometimes failing by test timeout and aborting the build. It happened during ClientExpirationListenerTest.notified_afterExpirationOfEntries test (e.g. https://hazelcast-l337.ci.cloudbees.com/job/cpp-linux-nightly-32-STATIC-Release/94/console). The output was:

 06:25:22 [ RUN      ] ClientExpirationListenerTest.notified_afterExpirationOfEntries
 06:25:22 May 03, 2016 1:11:51 PM com.hazelcast.nio.tcp.SocketAcceptorThread
 06:25:22 INFO: [127.0.0.1]:5701 [dev] [3.7-SNAPSHOT] Accepting socket connection from /127.0.0.1:34592
 06:25:22 May 03, 2016 1:11:51 PM com.hazelcast.nio.tcp.TcpIpConnectionManager
 06:25:22 INFO: [127.0.0.1]:5701 [dev] [3.7-SNAPSHOT] Established socket connection between /127.0.0.1:5701 and /127.0.0.1:34592
 06:25:22 May 03, 2016 1:11:51 PM com.hazelcast.client.impl.protocol.task.AuthenticationMessageTask
 06:25:22 INFO: [127.0.0.1]:5701 [dev] [3.7-SNAPSHOT] Received auth from Connection [/127.0.0.1:5701 -> /127.0.0.1:34592], endpoint=null, alive=true, type=CPP_CLIENT, successfully authenticated, principal : ClientPrincipal{uuid='1e87189e-2467-4b40-a6b4-2a12863634d0', ownerUuid='ff709d7b-086d-4c71-9fbb-b1e287c89c14'}, owner connection : false
 06:25:22 May 03, 2016 01:11:51 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [-134727984] Connected and authenticated by Address[127.0.0.1:5701]. Connection id:3 , socket id:10.
 06:26:05 May 03, 2016 01:13:01 PM WARNING: [HazelcastCppClient3.7-SNAPSHOT] [dev] [-522855536] Heartbeat to connection  Address[127.0.0.1:5702] is failed.
 06:30:56 May 03, 2016 1:17:51 PM com.hazelcast.client.impl.ClientHeartbeatMonitor
 06:30:56 WARNING: Client heartbeat is timed out , closing connection to Connection [/127.0.0.1:5701 -> /127.0.0.1:34592], endpoint=Address[127.0.0.1]:34592, alive=true, type=CPP_CLIENT
 06:30:56 May 03, 2016 1:17:51 PM com.hazelcast.nio.tcp.TcpIpConnection
 06:30:56 INFO: [127.0.0.1]:5701 [dev] [3.7-SNAPSHOT] Connection [Address[127.0.0.1]:34592] lost. Reason: Socket explicitly closed
 06:31:06 May 03, 2016 1:18:01 PM com.hazelcast.client.impl.ClientHeartbeatMonitor
 06:31:06 WARNING: Client heartbeat is timed out , closing connection to Connection [0.0.0.0/0.0.0.0:5701 -> null], endpoint=Address[127.0.0.1]:34592, alive=false, type=CPP_CLIENT
 06:31:16 May 03, 2016 1:18:11 PM com.hazelcast.client.impl.ClientHeartbeatMonitor
 06:31:16 WARNING: Client heartbeat is timed out , closing connection to Connection [0.0.0.0/0.0.0.0:5701 -> null], endpoint=Address[127.0.0.1]:34592, alive=false, type=CPP_CLIENT
 06:31:26 May 03, 2016 1:18:21 PM com.hazelcast.client.impl.ClientHeartbeatMonitor

 This indicated that the heartbeat thread was frozen could not send any heartbeat to the remote.

 When the case is examined, i found out that we were trying to send ClientRemoveAllListenersCodec Request on heartbeat failure on the failed connection and this request shall be put at the very back of the connection message queue. It shall wait until all the messages in the queue before this message are consumed. This invocation was not correct. It does not exist at the Java client. Furthermore, the listeners are being re-registered on connection close to another node, hence this was totall wrong.

 I increased the number of puts in the ClientExpirationListenerTest.notified_afterExpirationOfEntries so that we can observe this at local OSX machine as well.

 Furthermore, the time_t was being cast to int which was incorrect, changed this as well.
