### PR TITLE
Basic travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo: required
+dist: precise
+language: cpp
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
+          packages:
+            - g++-4.9
+            - cmake
+            - cmake-data
+      env: COMPILER=g++-4.9
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+            - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
+          packages:
+            - clang-3.7
+            - cmake
+            - cmake-data
+      env: COMPILER=clang++-3.7
+
+before_install:
+  - sudo apt-get update -qq
+
+script:
+   - (mkdir build && cd build && cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release && make)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ sudo: required
 dist: precise
 language: cpp
 
+# Handle git submodules yourself
+git:
+    submodules: false
+# Use sed to replace the SSH URL with the public URL, then initialize submodules
+before_install:
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+    - git submodule update --init --recursive
+
 matrix:
   include:
     - compiler: gcc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Hazelcast C++ Client
 
+[![Build Status](https://travis-ci.org/maxbeutel/hazelcast-cpp-client.svg?branch=upstream-pr-travis-ci)](https://travis-ci.org/maxbeutel/hazelcast-cpp-client)
 
 C++ client implementation for [Hazelcast](https://github.com/hazelcast/hazelcast), the open source in-memory data grid. A comparison of features supported by the C++ Client vs the Java client can be found [here](http://docs.hazelcast.org/docs/latest-dev/manual/html-single/index.html#hazelcast-clients-feature-comparison).
 


### PR DESCRIPTION
I'm working on C bindings for Hazelcast (wrapping the C++ client) and for my project I created a travis CI integration (https://travis-ci.org). As there are no .deb packages available for the Hazelcast C++ client, I do a build of a selected Hazelcast C++ client anyway during my project.

I decided to split that part out and contribute it back to you guys, are you interested? 

- Currently I run the build against two compilers, clang and g++. We can easily add more versions of the two. 
- I think it also makes sense to run the unit tests on travis, but I haven't looked into that yet, if you also think that's a good idea, I'm happy to add that to this PR. 
- In order for this to work, you need to enable travis CI integration in this Github project, as described here: https://docs.travis-ci.com/user/getting-started/

How a build looks like can be seen here: https://travis-ci.org/maxbeutel/hazelcast-cpp-client

The build is triggered with every commit to any branch. 

**NOTE** the Build Status Icon shows the status of my forked repository, so you can get an idea of how it will look like. The URL should be changed when merging into master to point to `hazelcast/hazelcast-cpp-client` repository. 

**EDIT** I haven't signed the contributors agreement yet, can do so on Monday if this PR has a chance of being merged.