### PR TITLE
64-bit compilation fails due to static variable initialization

### DIFF
--- a/hazelcast/test/src/ringbuffer/RingBufferTest.cpp
+++ b/hazelcast/test/src/ringbuffer/RingBufferTest.cpp
@@ -18,13 +18,11 @@
 
 #include "hazelcast/client/exception/ProtocolExceptions.h"
 #include "hazelcast/client/HazelcastClient.h"
-#include "hazelcast/client/ClientConfig.h"
 
-#include "serialization/Employee.h"
-#include "ClientTestSupport.h"
-#include "HazelcastServer.h"
-#include "hazelcast/client/Ringbuffer.h"
-#include "HazelcastServerFactory.h"
+#include "../HazelcastServerFactory.h"
+#include "../ClientTestSupport.h"
+#include "../HazelcastServer.h"
+#include "../serialization/Employee.h"
 
 namespace hazelcast {
     namespace client {
@@ -59,8 +57,10 @@ namespace hazelcast {
                 static HazelcastClient *client;
                 static Ringbuffer<Employee> *rb;
 
-                static const int64_t CAPACITY = 10;
+                static const int64_t CAPACITY;
             };
+
+            const int64_t RingbufferTest::CAPACITY = 10;
 
             HazelcastServer *RingbufferTest::instance = NULL;
             ClientConfig *RingbufferTest::clientConfig = NULL;


### PR DESCRIPTION
The failing test log: https://hazelcast-l337.ci.cloudbees.com/job/cpp-linux-nightly-64-SHARED-Debug/111/changes

Failure:
03:40:59 /appdisk/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/hazelcast/test/src/ringbuffer/RingBufferTest.cpp:71: undefined reference to `hazelcast::client::test::RingbufferTest::CAPACITY'
03:40:59 /appdisk/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/hazelcast/test/src/ringbuffer/RingBufferTest.cpp:75: undefined reference to `hazelcast::client::test::RingbufferTest::CAPACITY'
03:40:59 /appdisk/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/hazelcast/test/src/ringbuffer/RingBufferTest.cpp:83: undefined reference to `hazelcast::client::test::RingbufferTest::CAPACITY'
03:40:59 /appdisk/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/hazelcast/test/src/ringbuffer/RingBufferTest.cpp:84: undefined reference to `hazelcast::client::test::RingbufferTest::CAPACITY'
03:40:59 /appdisk/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/hazelcast/test/src/ringbuffer/RingBufferTest.cpp:92: undefined reference to `hazelcast::client::test::RingbufferTest::CAPACITY'
03:40:59 CMakeFiles/clientTest_SHARED_64.dir/ringbuffer/RingBufferTest.cpp.o:/appdisk/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/hazelcast/test/src/ringbuffer/RingBufferTest.cpp:93: more undefined references to `hazelcast::client::test::RingbufferTest::CAPACITY' follow

Corrected the static variable initialization in the test. Also fixed the include paths for the ringbuffer test.