### PR TITLE
Serialization long type incorrect for Linux 32-bit, Add more tests for ReliableTopic for increasing coverage

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/ObjectDataInput.h
+++ b/hazelcast/include/hazelcast/client/serialization/ObjectDataInput.h
@@ -33,9 +33,11 @@
 #include "hazelcast/client/serialization/pimpl/SerializationConstants.h"
 #include "hazelcast/util/IOUtil.h"
 #include "hazelcast/client/serialization/TypeIDS.h"
-#include <vector>
+
 #include <boost/shared_ptr.hpp>
+#include <vector>
 #include <string>
+#include <stdint.h>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -114,7 +116,7 @@ namespace hazelcast {
                 * @return the long read
                 * @throws IOException if it reaches end of file before finish reading
                 */
-                long readLong();
+                int64_t readLong();
 
                 /**
                 * @return the boolean read

--- a/hazelcast/include/hazelcast/client/serialization/ObjectDataOutput.h
+++ b/hazelcast/include/hazelcast/client/serialization/ObjectDataOutput.h
@@ -27,6 +27,8 @@
 #include "hazelcast/util/IOUtil.h"
 #include "hazelcast/client/serialization/TypeIDS.h"
 
+#include<stdint.h>
+
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
 #pragma warning(disable: 4251) //for dll export
@@ -103,7 +105,7 @@ namespace hazelcast {
                 /**
                 * @param value the long value to be written
                 */
-                void writeLong(long value);
+                void writeLong(int64_t value);
 
                 /**
                 * @param value the float value to be written

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
@@ -15,10 +15,6 @@
  */
 //
 // Created by sancar koyunlu on 8/7/13.
-
-
-
-
 #ifndef HAZELCAST_DataInput
 #define HAZELCAST_DataInput
 
@@ -26,10 +22,13 @@
 #include "hazelcast/util/ByteBuffer.h"
 #include "hazelcast/util/Bits.h"
 #include "hazelcast/client/exception/HazelcastSerializationException.h"
+
+#include <boost/smart_ptr/shared_ptr.hpp>
+
 #include <vector>
 #include <string>
 #include <memory>
-#include <boost/smart_ptr/shared_ptr.hpp>
+#include <stdint.h>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -66,7 +65,7 @@ namespace hazelcast {
 
                     int readInt();
 
-                    long long readLong();
+                    int64_t readLong();
 
                     float readFloat();
 

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/DataOutput.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/DataOutput.h
@@ -16,18 +16,15 @@
 //
 // Created by sancar koyunlu on 8/7/13.
 
-
-
-
 #ifndef HAZELCAST_DataOutput
 #define HAZELCAST_DataOutput
-
 
 #include "hazelcast/util/HazelcastDll.h"
 #include "hazelcast/util/ByteBuffer.h"
 #include <memory>
 #include <vector>
 #include <string>
+#include <stdint.h>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -59,7 +56,7 @@ namespace hazelcast {
 
                     void writeInt(int i);
 
-                    void writeLong(long long l);
+                    void writeLong(int64_t l);
 
                     void writeFloat(float v);
 

--- a/hazelcast/include/hazelcast/client/topic/Message.h
+++ b/hazelcast/include/hazelcast/client/topic/Message.h
@@ -82,6 +82,8 @@ namespace hazelcast {
                  * @return the name of the topic for which this message is produced
                  */
                 virtual std::string getName() = 0;
+
+                virtual ~Message() { }
             };
         }
     }

--- a/hazelcast/src/hazelcast/client/serialization/ObjectDataInput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/ObjectDataInput.cpp
@@ -63,8 +63,8 @@ namespace hazelcast {
                 return dataInput.readInt();
             }
 
-            long ObjectDataInput::readLong() {
-                return (long)dataInput.readLong();
+            int64_t ObjectDataInput::readLong() {
+                return dataInput.readLong();
             }
 
             float ObjectDataInput::readFloat() {

--- a/hazelcast/src/hazelcast/client/serialization/ObjectDataOutput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/ObjectDataOutput.cpp
@@ -79,7 +79,7 @@ namespace hazelcast {
                 dataOutput->writeInt(v);
             }
 
-            void ObjectDataOutput::writeLong(long l) {
+            void ObjectDataOutput::writeLong(int64_t l) {
                 if (isEmpty) return;
                 dataOutput->writeLong(l);
             }

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
@@ -93,7 +93,7 @@ namespace hazelcast {
                             (0x000000ff & d);
                 }
 
-                long long DataInput::readLong() {
+                int64_t DataInput::readLong() {
                     byte a = readByte();
                     byte b = readByte();
                     byte c = readByte();
@@ -102,10 +102,10 @@ namespace hazelcast {
                     byte f = readByte();
                     byte g = readByte();
                     byte h = readByte();
-                    return (0xff00000000000000LL & ((long long) (a) << 56)) |
-                            (0x00ff000000000000LL & ((long long) (b) << 48)) |
-                            (0x0000ff0000000000LL & ((long long) (c) << 40)) |
-                            (0x000000ff00000000LL & ((long long) (d) << 32)) |
+                    return (0xff00000000000000LL & ((int64_t) (a) << 56)) |
+                            (0x00ff000000000000LL & ((int64_t) (b) << 48)) |
+                            (0x0000ff0000000000LL & ((int64_t) (c) << 40)) |
+                            (0x000000ff00000000LL & ((int64_t) (d) << 32)) |
                             (0x00000000ff000000LL & (e << 24)) |
                             (0x0000000000ff0000LL & (f << 16)) |
                             (0x000000000000ff00LL & (g << 8)) |

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
@@ -88,7 +88,7 @@ namespace hazelcast {
                     writeByte((byte)v);
                 }
 
-                void DataOutput::writeLong(long long l) {
+                void DataOutput::writeLong(int64_t l) {
                     writeByte((byte)(l >> 56));
                     writeByte((byte)(l >> 48));
                     writeByte((byte)(l >> 40));

--- a/hazelcast/src/hazelcast/client/topic/impl/reliable/ReliableTopicExecutor.cpp
+++ b/hazelcast/src/hazelcast/client/topic/impl/reliable/ReliableTopicExecutor.cpp
@@ -74,7 +74,11 @@ namespace hazelcast {
                                 connection::CallFuture future = ringbuffer->readManyAsync(m.sequence, 1, m.maxCount);
                                 std::auto_ptr<protocol::ClientMessage> responseMsg;
                                 do {
-                                    responseMsg = future.get(1); // every one second
+                                    try {
+                                        responseMsg = future.get(1); // every one second
+                                    } catch (exception::TimeoutException &e) { // suppress timeout exception
+                                        // do nothing
+                                    }
                                 } while (!(*shutdownFlag) && (protocol::ClientMessage *)NULL == responseMsg.get());
 
                                 if (!(*shutdownFlag)) {

--- a/hazelcast/test/src/reliabletopic/ReliableTopicTest.cpp
+++ b/hazelcast/test/src/reliabletopic/ReliableTopicTest.cpp
@@ -69,7 +69,7 @@ namespace hazelcast {
                         const T *object = message->getMessageObject();
                         std::ostringstream out;
                         if (NULL != object) {
-                            out << "[GenericListener::onMessage] Received message: " << message->getMessageObject() <<
+                            out << "[GenericListener::onMessage] Received message: " << *message->getMessageObject() <<
                             " for topic:" << message->getName();
                         } else {
                             out << "[GenericListener::onMessage] Received message with NULL object for topic:" << message->getName();
@@ -345,8 +345,8 @@ namespace hazelcast {
                 ASSERT_EQ(publishedValue, *val);
 
                 topic::Message<int> *message = listener.getMessages().poll();
-                ASSERT_TRUE(timeBeforePublish <= message->getPublishTime());
-                ASSERT_TRUE(timeAfterPublish >= message->getPublishTime());
+                ASSERT_LE(timeBeforePublish, message->getPublishTime());
+                ASSERT_GE(timeAfterPublish, message->getPublishTime());
                 ASSERT_EQ(intTopic->getName(), message->getSource());
                 ASSERT_EQ((Member *)NULL, message->getPublishingMember());
             }

--- a/hazelcast/test/src/reliabletopic/ReliableTopicTest.cpp
+++ b/hazelcast/test/src/reliabletopic/ReliableTopicTest.cpp
@@ -379,7 +379,7 @@ namespace hazelcast {
                 ASSERT_NO_THROW(listenerId = intTopic->addMessageListener(listener));
 
                 ASSERT_TRUE(latch.await(10));
-                ASSERT_EQ(expectedValues.size(), listener.getNumberOfMessagesReceived());
+                ASSERT_EQ((int)expectedValues.size(), listener.getNumberOfMessagesReceived());
                 util::ConcurrentQueue<int> &objects = listener.getObjects();
 
                 for (std::vector<int>::const_iterator it = expectedValues.begin();it != expectedValues.end(); ++it) {


### PR DESCRIPTION
Added more tests for ReliableTopic.
Also a fix is done at ReliableTopicExecutor.

An important fix is done at ObjectDataInput and ObjectDataOutput for handling long type correctly at Linux 32-bit.