### PR TITLE
Change the HazelcastClient to return shared_ptr for Ringbuffer and ReliableTopic

### DIFF
--- a/examples/distributed-collections/ringbuffer/RingbufferExample.cpp
+++ b/examples/distributed-collections/ringbuffer/RingbufferExample.cpp
@@ -22,7 +22,7 @@ int main() {
     hazelcast::client::ClientConfig config;
     hazelcast::client::HazelcastClient hz(config);
 
-    std::auto_ptr<hazelcast::client::Ringbuffer<std::string> > rb = hz.getRingbuffer<std::string>("myringbuffer");
+    boost::shared_ptr<hazelcast::client::Ringbuffer<std::string> > rb = hz.getRingbuffer<std::string>("myringbuffer");
 
     std::cout << "Capacity of the ringbuffer is:" << rb->capacity() << std::endl;
 

--- a/examples/distributed-topic/reliabletopic/Publisher.cpp
+++ b/examples/distributed-topic/reliabletopic/Publisher.cpp
@@ -22,7 +22,7 @@ void publishWithDefaultConfig() {
     hazelcast::client::ClientConfig config;
     hazelcast::client::HazelcastClient client(config);
 
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>("MyReliableTopic");
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>("MyReliableTopic");
     std::string message("My first message");
     topic->publish(&message);
 }
@@ -35,7 +35,7 @@ void publishWithNonDefaultConfig() {
     clientConfig.addReliableTopicConfig(reliableTopicConfig);
     hazelcast::client::HazelcastClient client(clientConfig);
 
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
 
     std::string message("My first message");
 

--- a/examples/distributed-topic/reliabletopic/Subscriber.cpp
+++ b/examples/distributed-topic/reliabletopic/Subscriber.cpp
@@ -74,7 +74,7 @@ void listenWithDefaultConfig() {
     hazelcast::client::HazelcastClient client(config);
 
     std::string topicName("MyReliableTopic");
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
     
     MyListener listener;
     const std::string &listenerId = topic->addMessageListener(listener);
@@ -100,7 +100,7 @@ void listenWithConfig() {
     clientConfig.addReliableTopicConfig(reliableTopicConfig);
     hazelcast::client::HazelcastClient client(clientConfig);
 
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
 
     MyListener listener;
     const std::string &listenerId = topic->addMessageListener(listener);

--- a/hazelcast/include/hazelcast/client/HazelcastClient.h
+++ b/hazelcast/include/hazelcast/client/HazelcastClient.h
@@ -558,11 +558,11 @@ namespace hazelcast {
             * @return distributed topic instance with the specified name
             */
             template<typename E>
-            std::auto_ptr<ReliableTopic<E> > getReliableTopic(const std::string& name) {
-                std::auto_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb =
+            boost::shared_ptr<ReliableTopic<E> > getReliableTopic(const std::string& name) {
+                boost::shared_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb =
                         getRingbuffer<topic::impl::reliable::ReliableTopicMessage>(TOPIC_RB_PREFIX + name);
-                return std::auto_ptr<ReliableTopic<E> >(new ReliableTopic<E>(name, &clientContext, rb));
-            };
+                return boost::shared_ptr<ReliableTopic<E> >(new ReliableTopic<E>(name, &clientContext, rb));
+            }
 
             /**
             * Creates cluster-wide unique IDs. Generated IDs are long type primitive values
@@ -626,8 +626,8 @@ namespace hazelcast {
              * @return distributed RingBuffer instance with the specified name
              */
             template <typename E>
-            std::auto_ptr<Ringbuffer<E> > getRingbuffer(const std::string& name) {
-                return std::auto_ptr<Ringbuffer<E> >(new proxy::RingbufferImpl<E>(name, &clientContext));
+            boost::shared_ptr<Ringbuffer<E> > getRingbuffer(const std::string& name) {
+                return boost::shared_ptr<Ringbuffer<E> >(new proxy::RingbufferImpl<E>(name, &clientContext));
             }
 
             /**

--- a/hazelcast/include/hazelcast/client/ReliableTopic.h
+++ b/hazelcast/include/hazelcast/client/ReliableTopic.h
@@ -117,7 +117,7 @@ namespace hazelcast {
                 ringbuffer->destroy();
             }
         private:
-            ReliableTopic(const std::string &instanceName, spi::ClientContext *context, std::auto_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb)
+            ReliableTopic(const std::string &instanceName, spi::ClientContext *context, boost::shared_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb)
                     : proxy::ReliableTopicImpl(instanceName, context, rb) {
             }
 

--- a/hazelcast/include/hazelcast/client/config/ReliableTopicConfig.h
+++ b/hazelcast/include/hazelcast/client/config/ReliableTopicConfig.h
@@ -56,14 +56,9 @@ namespace hazelcast {
                  * if there are more available, then it will try to get more to increase throughput. The minimal read
                  * batch size can be influenced using the read batch size.
                  *
-                 * Apart from influencing the number of messages to download, the readBatchSize also determines how many
-                 * messages will be processed by the thread running the MessageListener before it returns back to the pool
-                 * to look for other MessageListeners that need to be processed. The problem with returning to the pool and
-                 * looking for new work is that interacting with an Executor is quite expensive due to contention on the
-                 * work-queue. The more work that can be done without retuning to the pool, the smaller the overhead.
                  *
                  * If the readBatchSize is 10 and there are 50 messages available, 10 items are retrieved and processed
-                 * consecutively before the thread goes back to the pool and helps out with the processing of other messages.
+                 * consecutively.
                  *
                  * If the readBatchSize is 10 and there are 2 items available, 2 items are retrieved and processed consecutively.
                  *

--- a/hazelcast/include/hazelcast/client/proxy/ReliableTopicImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReliableTopicImpl.h
@@ -31,6 +31,8 @@
 #include "hazelcast/client/topic/impl/reliable/ReliableTopicExecutor.h"
 #include "hazelcast/client/config/ReliableTopicConfig.h"
 
+#include <boost/shared_ptr.hpp>
+
 #include <string>
 #include <stdint.h>
 
@@ -45,12 +47,12 @@ namespace hazelcast {
             class HAZELCAST_API ReliableTopicImpl : public proxy::ProxyImpl {
             protected:
                 ReliableTopicImpl(const std::string &instanceName, spi::ClientContext *context,
-                                  std::auto_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb);
+                                  boost::shared_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb);
 
                 void publish(const serialization::pimpl::Data &data);
 
             protected:
-                std::auto_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > ringbuffer;
+                boost::shared_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > ringbuffer;
                 util::ILogger &logger;
                 const config::ReliableTopicConfig *config;
             };

--- a/hazelcast/src/hazelcast/client/proxy/ReliableTopicImpl.cpp
+++ b/hazelcast/src/hazelcast/client/proxy/ReliableTopicImpl.cpp
@@ -28,7 +28,7 @@ namespace hazelcast {
     namespace client {
         namespace proxy {
             ReliableTopicImpl::ReliableTopicImpl(const std::string &instanceName, spi::ClientContext *context,
-                                                 std::auto_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb)
+                                                 boost::shared_ptr<Ringbuffer<topic::impl::reliable::ReliableTopicMessage> > rb)
                     : proxy::ProxyImpl("hz:impl:topicService", instanceName, context), ringbuffer(rb),
                       logger(util::ILogger::getLogger()), config(context->getClientConfig().getReliableTopicConfig(instanceName)) {
             }

--- a/hazelcast/test/src/reliabletopic/ReliableTopicTest.cpp
+++ b/hazelcast/test/src/reliabletopic/ReliableTopicTest.cpp
@@ -163,7 +163,7 @@ namespace hazelcast {
             HazelcastClient *ReliableTopicTest::client = NULL;
 
             TEST_F(ReliableTopicTest, testBasics) {
-                std::auto_ptr<ReliableTopic<Employee> > rt;
+                boost::shared_ptr<ReliableTopic<Employee> > rt;
                 ASSERT_NO_THROW(rt = client->getReliableTopic<Employee>("testBasics"));
 
                 ASSERT_EQ("testBasics", rt->getName());
@@ -191,7 +191,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, testListenerSequence) {
-                std::auto_ptr<ReliableTopic<Employee> > rt;
+                boost::shared_ptr<ReliableTopic<Employee> > rt;
                 ASSERT_NO_THROW(rt = client->getReliableTopic<Employee>("testListenerSequence"));
 
                 Employee empl1("first", 10);
@@ -217,7 +217,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, removeMessageListener_whenExisting) {
-                std::auto_ptr<ReliableTopic<Employee> > rt;
+                boost::shared_ptr<ReliableTopic<Employee> > rt;
                 ASSERT_NO_THROW(rt = client->getReliableTopic<Employee>("removeMessageListener_whenExisting"));
 
                 Employee empl1("first", 10);
@@ -238,7 +238,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, removeMessageListener_whenNonExisting) {
-                std::auto_ptr<ReliableTopic<Employee> > rt;
+                boost::shared_ptr<ReliableTopic<Employee> > rt;
                 ASSERT_NO_THROW(rt = client->getReliableTopic<Employee>("removeMessageListener_whenNonExisting"));
 
                 // remove listener
@@ -246,7 +246,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, publishNull) {
-                std::auto_ptr<ReliableTopic<int> > intTopic;
+                boost::shared_ptr<ReliableTopic<int> > intTopic;
                 ASSERT_NO_THROW(intTopic = client->getReliableTopic<int>("publishNull"));
 
                 util::CountDownLatch latch(1);
@@ -264,7 +264,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, publishMultiple) {
-                std::auto_ptr<ReliableTopic<std::string> > topic;
+                boost::shared_ptr<ReliableTopic<std::string> > topic;
                 ASSERT_NO_THROW(topic = client->getReliableTopic<std::string>("publishMultiple"));
 
                 util::CountDownLatch latch(5);
@@ -298,7 +298,7 @@ namespace hazelcast {
                 clientConfig.addReliableTopicConfig(relConfig);
                 HazelcastClient configClient(clientConfig);
 
-                std::auto_ptr<ReliableTopic<std::string> > topic;
+                boost::shared_ptr<ReliableTopic<std::string> > topic;
                 ASSERT_NO_THROW(topic = configClient.getReliableTopic<std::string>("testConfig"));
 
                 util::CountDownLatch latch(5);
@@ -325,7 +325,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, testMessageFieldSetCorrectly) {
-                std::auto_ptr<ReliableTopic<int> > intTopic;
+                boost::shared_ptr<ReliableTopic<int> > intTopic;
                 ASSERT_NO_THROW(intTopic = client->getReliableTopic<int>("testMessageFieldSetCorrectly"));
 
                 util::CountDownLatch latch(1);
@@ -354,7 +354,7 @@ namespace hazelcast {
             // makes sure that when a listener is register, we don't see any messages being published before
             // it got registered. We'll only see the messages after it got registered.
             TEST_F(ReliableTopicTest, testAlwaysStartAfterTail) {
-                std::auto_ptr<ReliableTopic<int> > intTopic;
+                boost::shared_ptr<ReliableTopic<int> > intTopic;
                 ASSERT_NO_THROW(intTopic = client->getReliableTopic<int>("testAlwaysStartAfterTail"));
 
                 int publishedValue = 1;

--- a/hazelcast/test/src/ringbuffer/RingBufferTest.cpp
+++ b/hazelcast/test/src/ringbuffer/RingBufferTest.cpp
@@ -37,16 +37,14 @@ namespace hazelcast {
                     clientConfig = new ClientConfig();
                     clientConfig->addAddress(Address(g_srvFactory->getServerAddress(), 5701));
                     client = new HazelcastClient(*clientConfig);
-                    rb = client->getRingbuffer<Employee>("rb-1").release();
+                    rb = client->getRingbuffer<Employee>("rb-1");
                 }
 
                 static void TearDownTestCase() {
-                    delete rb;
                     delete client;
                     delete clientConfig;
                     delete instance;
 
-                    rb = NULL;
                     client = NULL;
                     clientConfig = NULL;
                     instance = NULL;
@@ -55,7 +53,7 @@ namespace hazelcast {
                 static HazelcastServer *instance;
                 static ClientConfig *clientConfig;
                 static HazelcastClient *client;
-                static Ringbuffer<Employee> *rb;
+                static boost::shared_ptr<Ringbuffer<Employee> > rb;
 
                 static const int64_t CAPACITY;
             };
@@ -65,7 +63,7 @@ namespace hazelcast {
             HazelcastServer *RingbufferTest::instance = NULL;
             ClientConfig *RingbufferTest::clientConfig = NULL;
             HazelcastClient *RingbufferTest::client = NULL;
-            Ringbuffer<Employee> *RingbufferTest::rb = NULL;
+            boost::shared_ptr<Ringbuffer<Employee> > RingbufferTest::rb = boost::shared_ptr<Ringbuffer<Employee> >();
 
             TEST_F(RingbufferTest, testAPI) {
                 ASSERT_EQ(CAPACITY, rb->capacity());

--- a/manual/src/CPlusClient.md
+++ b/manual/src/CPlusClient.md
@@ -253,7 +253,7 @@ This example query returns the values between 5 and 10, inclusive. You can find 
 You can benefit from Hazelcast Ringbuffer using the C++ client library. You can start by obtaining the Ringbuffer using the `HazelcastClient` as usual, as shown below:
 
 ```
-std::auto_ptr<hazelcast::client::Ringbuffer<std::string> > rb = client.getRingbuffer<std::string>("myringbuffer");
+boost::shared_ptr<hazelcast::client::Ringbuffer<std::string> > rb = client.getRingbuffer<std::string>("myringbuffer");
 ```
 
 Ringbuffer interface allows you to add a new item to the Ringbuffer or read an entry at a sequence number.
@@ -583,7 +583,7 @@ In addition to this rich set of built-in predicates, you can also write your own
 ### Ringbuffer Example
 
 ```
-    std::auto_ptr<hazelcast::client::Ringbuffer<std::string> > rb = client.getRingbuffer<std::string>("myringbuffer");
+    boost::shared_ptr<hazelcast::client::Ringbuffer<std::string> > rb = client.getRingbuffer<std::string>("myringbuffer");
 
     std::cout << "Capacity of the ringbuffer is:" << rb->capacity() << std::endl;
 
@@ -613,7 +613,7 @@ void publishWithDefaultConfig() {
     hazelcast::client::ClientConfig config;
     hazelcast::client::HazelcastClient client(config);
 
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>("MyReliableTopic");
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>("MyReliableTopic");
     std::string message("My first message");
     topic->publish(&message);
 }
@@ -626,7 +626,7 @@ void publishWithNonDefaultConfig() {
     clientConfig.addReliableTopicConfig(reliableTopicConfig);
     hazelcast::client::HazelcastClient client(clientConfig);
 
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
 
     std::string message("My first message");
 
@@ -698,7 +698,7 @@ void listenWithDefaultConfig() {
     hazelcast::client::HazelcastClient client(config);
 
     std::string topicName("MyReliableTopic");
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
 
     MyListener listener;
     const std::string &listenerId = topic->addMessageListener(listener);
@@ -724,7 +724,7 @@ void listenWithConfig() {
     clientConfig.addReliableTopicConfig(reliableTopicConfig);
     hazelcast::client::HazelcastClient client(clientConfig);
 
-    std::auto_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
+    boost::shared_ptr<hazelcast::client::ReliableTopic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
 
     MyListener listener;
     const std::string &listenerId = topic->addMessageListener(listener);


### PR DESCRIPTION
Changed the getRingbuffer and getReliableTopic interfaces of HazelcastClient to return boost::shared_ptr instead of std::auto_ptr. This was done so that when the ProxyManager is implemented, we can just return a reference to existing proxy instead of duplicating the proxy.