### PR TITLE
Add log to ClientTxnMultiMapTest::testPutGetRemove To Detect Possible Test Failure

### DIFF
--- a/hazelcast/test/src/txn/ClientTxnMultiMapTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnMultiMapTest.cpp
@@ -38,6 +38,9 @@ namespace hazelcast {
             }
 
             void putGetRemoveTestThread(util::ThreadArgs& args) {
+                util::ILogger &logger = util::ILogger::getLogger();
+                logger.info("[ClientTxnMultiMapTest::putGetRemoveTestThread] Thread started.");
+                
                 MultiMap<std::string, std::string> *mm = (MultiMap<std::string, std::string > *)args.arg0;
                 HazelcastClient *client = (HazelcastClient *)args.arg1;
                 util::CountDownLatch *latch = (util::CountDownLatch *)args.arg2;
@@ -56,6 +59,8 @@ namespace hazelcast {
                 ASSERT_EQ(3, (int)mm->get(key).size());
 
                 latch->countDown();
+
+                logger.info("[ClientTxnMultiMapTest::putGetRemoveTestThread] Thread finished");
             }
 
             TEST_F(ClientTxnMultiMapTest, testRemoveIfExists) {


### PR DESCRIPTION
Added extra logs for the ClientTxnMultiMapTest::testPutGetRemove test to debug if any failure occurs as in the test run. We may see a failure like the folowinf, it may be that the latch timeout is not enough for 10 threads to finish. This log will tell us if so.

17:51:23 [ RUN      ] ClientTxnMultiMapTest.testPutGetRemove
17:51:36 Jun 13, 2016 03:51:36 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] (20160613:0225dc5) LifecycleService::LifecycleEvent STARTING
17:51:38 Jun 13, 2016 03:51:38 PM FINEST: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2732]  Trying to connect to owner node 0. attempt
17:51:38 Jun 13, 2016 03:51:38 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2732] Connected and authenticated by Address[127.0.0.1:5701]. Connection id:1 , socket id:668 as owner connection.
17:51:38 Jun 13, 2016 03:51:38 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2732] LifecycleService::LifecycleEvent CLIENT_CONNECTED
17:51:38 Jun 13, 2016 03:51:38 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2732]
17:51:38 Members [1]  {
17:51:38 	Member[Address[127.0.0.1:5701]]
17:51:38 }
17:51:38
17:51:39 Jun 13, 2016 03:51:39 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] Connected and authenticated by Address[127.0.0.1:5701]. Connection id:2 , socket id:664.
17:51:39 Jun 13, 2016 03:51:39 PM FINEST: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] PartitionService::getInitialPartitions Got 271 initial partitions successfully.
17:51:39 Jun 13, 2016 03:51:39 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] LifecycleService::LifecycleEvent STARTED
17:51:43 C:\jenkins\ope-fs-root\workspace\cpp-windows-nightly\hazelcast\test\src\txn\ClientTxnMultiMapTest.cpp(91): error: Value of: latch.await(1)
17:51:43   Actual: false
17:51:43 Expected: true
17:51:43 Jun 13, 2016 03:51:42 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] LifecycleService::LifecycleEvent SHUTTING_DOWN
17:51:43 Jun 13, 2016 03:51:42 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [4648] [InvocationService::registerAndEnqueue] InvocationService is shutdown. Did not register the promise for message correlation id:0
17:51:43 Jun 13, 2016 03:51:42 PM WARNING: [HazelcastCppClient3.7-SNAPSHOT] [dev] [4648] hz.unnamed is cancelled with exception ExceptionMessage {Invocation service is not open. Can not process the request.} at InvocationService::registerAndEnqueue
17:51:43 Jun 13, 2016 03:51:42 PM WARNING: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] Closing connection (id:1) to Address[127.0.0.1:5701] with socket id 668 as the owner connection.
17:51:43 Jun 13, 2016 03:51:42 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2732] LifecycleService::LifecycleEvent CLIENT_DISCONNECTED
17:51:43 Jun 13, 2016 03:51:42 PM WARNING: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2732] hz.clusterListenerThread is cancelled
17:51:43 Jun 13, 2016 03:51:42 PM WARNING: [HazelcastCppClient3.7-SNAPSHOT] [dev] [3380] hz.heartbeater is cancelled
17:51:47 Jun 13, 2016 03:51:47 PM INFO: [HazelcastCppClient3.7-SNAPSHOT] [dev] [2492] LifecycleService::LifecycleEvent SHUTDOWN
17:51:49 [  FAILED  ] ClientTxnMultiMapTest.testPutGetRemove (25656 ms)