### PR TITLE
Map put with ttl does not work as expected for server configured map ttl 

### DIFF
--- a/hazelcast/include/hazelcast/client/IMap.h
+++ b/hazelcast/include/hazelcast/client/IMap.h
@@ -101,7 +101,22 @@ namespace hazelcast {
             * then returns NULL in shared_ptr.
             */
             boost::shared_ptr<V> put(const K &key, const V &value) {
-                return boost::shared_ptr<V>(toObject<V>(proxy::IMapImpl::putData(toData(key), toData(value))));
+                return put(key, value, -1);
+            }
+
+            /**
+            * Puts an entry into this map with a given ttl (time to live) value.
+            * Entry will expire and get evicted after the ttl. If ttl is 0, then
+            * the entry lives forever.
+            *
+            * @param key              key of the entry
+            * @param value            value of the entry
+            * @param ttlInMillis      maximum time for this entry to stay in the map in milliseconds,0 means infinite.
+            * @return the previous value in shared_ptr, if there is no mapping for key
+            * then returns NULL in shared_ptr.
+            */
+            boost::shared_ptr<V> put(const K &key, const V &value, long ttlInMillis) {
+                return boost::shared_ptr<V>(toObject<V>(proxy::IMapImpl::putData(toData(key), toData(value), ttlInMillis)));
             }
 
             /**
@@ -175,21 +190,6 @@ namespace hazelcast {
             }
 
             /**
-            * Puts an entry into this map with a given ttl (time to live) value.
-            * Entry will expire and get evicted after the ttl. If ttl is 0, then
-            * the entry lives forever.
-            *
-            * @param key              key of the entry
-            * @param value            value of the entry
-            * @param ttlInMillis      maximum time for this entry to stay in the map in milliseconds,0 means infinite.
-            * @return the previous value in shared_ptr, if there is no mapping for key
-            * then returns NULL in shared_ptr.
-            */
-            boost::shared_ptr<V> put(const K &key, const V &value, long ttlInMillis) {
-                return boost::shared_ptr<V>(toObject<V>(proxy::IMapImpl::putData(toData(key), toData(value), ttlInMillis)));
-            }
-
-            /**
             * Same as put(K, V, long, TimeUnit) but MapStore, if defined,
             * will not be called to store/persist the entry.  If ttl is 0, then
             * the entry lives forever.
@@ -249,19 +249,6 @@ namespace hazelcast {
             */
             boost::shared_ptr<V> replace(const K &key, const V &value) {
                 return boost::shared_ptr<V>(toObject<V>(proxy::IMapImpl::replaceData(toData(key), toData(value))));
-            }
-
-            /**
-            * Puts an entry into this map.
-            * Similar to put operation except that set
-            * doesn't return the old value which is more efficient.
-            * @param key key with which the specified value is associated
-            * @param value
-            * @param ttl maximum time in milliseconds for this entry to stay in the map
-            0 means infinite.
-            */
-            void set(const K &key, const V &value, long ttl) {
-                proxy::IMapImpl::set(toData(key), toData(value), ttl);
             }
 
             /**
@@ -958,6 +945,19 @@ namespace hazelcast {
             */
             void set(const K &key, const V &value) {
                 set(key, value, -1);
+            }
+
+            /**
+            * Puts an entry into this map.
+            * Similar to put operation except that set
+            * doesn't return the old value which is more efficient.
+            * @param key key with which the specified value is associated
+            * @param value
+            * @param ttl maximum time in milliseconds for this entry to stay in the map
+            0 means infinite.
+            */
+            void set(const K &key, const V &value, long ttl) {
+                proxy::IMapImpl::set(toData(key), toData(value), ttl);
             }
 
             /**

--- a/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
@@ -42,8 +42,6 @@ namespace hazelcast {
 
                 std::auto_ptr<serialization::pimpl::Data> getData(const serialization::pimpl::Data& key);
 
-                std::auto_ptr<serialization::pimpl::Data> putData(const serialization::pimpl::Data& key, const serialization::pimpl::Data& value);
-
                 std::auto_ptr<serialization::pimpl::Data> removeData(const serialization::pimpl::Data& key);
 
                 bool remove(const serialization::pimpl::Data& key, const serialization::pimpl::Data& value);

--- a/hazelcast/src/hazelcast/client/proxy/IMapImpl.cpp
+++ b/hazelcast/src/hazelcast/client/proxy/IMapImpl.cpp
@@ -111,18 +111,6 @@ namespace hazelcast {
                         request, partitionId);
             }
 
-            std::auto_ptr<serialization::pimpl::Data> IMapImpl::putData(const serialization::pimpl::Data &key,
-                                                                    const serialization::pimpl::Data &value) {
-                int partitionId = getPartitionId(key);
-
-                std::auto_ptr<protocol::ClientMessage> request =
-                        protocol::codec::MapPutCodec::RequestParameters::encode(getName(), key, value,
-                                                                                util::getThreadId(), 0);
-
-                return invokeAndGetResult<std::auto_ptr<serialization::pimpl::Data>, protocol::codec::MapPutCodec::ResponseParameters>(
-                        request, partitionId);
-            }
-
             std::auto_ptr<serialization::pimpl::Data> IMapImpl::removeData(const serialization::pimpl::Data &key) {
                 int partitionId = getPartitionId(key);
                 std::auto_ptr<protocol::ClientMessage> request =

--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -509,11 +509,33 @@ namespace hazelcast {
                     imap->put("key1", "value1", 2000);
                     std::auto_ptr<std::string> temp = imap->get("key1");
                     ASSERT_EQ(*temp, "value1");
-                    ASSERT_TRUE(evict.await(20 * 1000));
+                    util::sleep(2);
+                    // trigger eviction
                     std::auto_ptr<std::string> temp2 = imap->get("key1");
                     ASSERT_EQ(temp2.get(), (std::string *) NULL);
+                    ASSERT_TRUE(evict.await(20));
 
                     ASSERT_TRUE(imap->removeEntryListener(id));
+                }
+
+                TEST_F(RawPointerMapTest, testPutConfigTtl) {
+                    IMap<std::string, std::string> oneSecMap = client->getMap<std::string, std::string>("OneSecondTtlMap");
+                    hazelcast::client::adaptor::RawPointerMap<std::string, std::string> map(oneSecMap);
+                    util::CountDownLatch dummy(10);
+                    util::CountDownLatch evict(1);
+                    CountdownListener<std::string, std::string> sampleEntryListener(dummy, dummy, dummy, evict);
+                    std::string id = map.addEntryListener(sampleEntryListener, false);
+
+                    map.put("key1", "value1");
+                    std::auto_ptr<std::string> temp = map.get("key1");
+                    ASSERT_EQ(*temp, "value1");
+                    util::sleep(2);
+                    // trigger eviction
+                    std::auto_ptr<std::string> temp2 = map.get("key1");
+                    ASSERT_EQ(temp2.get(), (std::string *) NULL);
+                    ASSERT_TRUE(evict.await(5));
+
+                    ASSERT_TRUE(map.removeEntryListener(id));
                 }
 
                 TEST_F(RawPointerMapTest, testPutIfAbsent) {
@@ -541,6 +563,46 @@ namespace hazelcast {
                     ASSERT_EQ("value3", *(imap->get("key1")));
 
                     ASSERT_NULL_EVENTUALLY(imap->get("key1").get());
+                }
+
+                TEST_F(RawPointerMapTest, testSetTtl) {
+                    IMap<std::string, std::string> oneSecMap = client->getMap<std::string, std::string>("OneSecondTtlMap");
+                    hazelcast::client::adaptor::RawPointerMap<std::string, std::string> map(oneSecMap);
+                    util::CountDownLatch dummy(10);
+                    util::CountDownLatch evict(1);
+                    CountdownListener<std::string, std::string> sampleEntryListener(dummy, dummy, dummy, evict);
+                    std::string id = map.addEntryListener(sampleEntryListener, false);
+
+                    map.set("key1", "value1", 1000);
+                    std::auto_ptr<std::string> temp = map.get("key1");
+                    ASSERT_EQ(*temp, "value1");
+                    util::sleep(2);
+                    // trigger eviction
+                    std::auto_ptr<std::string> temp2 = map.get("key1");
+                    ASSERT_EQ(temp2.get(), (std::string *) NULL);
+                    ASSERT_TRUE(evict.await(5));
+
+                    ASSERT_TRUE(map.removeEntryListener(id));
+                }
+
+                TEST_F(RawPointerMapTest, testSetConfigTtl) {
+                    IMap<std::string, std::string> oneSecMap = client->getMap<std::string, std::string>("OneSecondTtlMap");
+                    hazelcast::client::adaptor::RawPointerMap<std::string, std::string> map(oneSecMap);
+                    util::CountDownLatch dummy(10);
+                    util::CountDownLatch evict(1);
+                    CountdownListener<std::string, std::string> sampleEntryListener(dummy, dummy, dummy, evict);
+                    std::string id = map.addEntryListener(sampleEntryListener, false);
+
+                    map.set("key1", "value1");
+                    std::auto_ptr<std::string> temp = map.get("key1");
+                    ASSERT_EQ(*temp, "value1");
+                    util::sleep(2);
+                    // trigger eviction
+                    std::auto_ptr<std::string> temp2 = map.get("key1");
+                    ASSERT_EQ(temp2.get(), (std::string *) NULL);
+                    ASSERT_TRUE(evict.await(5));
+
+                    ASSERT_TRUE(map.removeEntryListener(id));
                 }
 
                 TEST_F(RawPointerMapTest, testLock) {

--- a/java/src/main/resources/hazelcast.xml
+++ b/java/src/main/resources/hazelcast.xml
@@ -200,6 +200,10 @@
         <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
     </map>
 
+    <map name="OneSecondTtlMap">
+        <time-to-live-seconds>1</time-to-live-seconds>
+    </map>
+
     <multimap name="default">
         <backup-count>1</backup-count>
         <value-collection-type>SET</value-collection-type>


### PR DESCRIPTION
Fixes the map put API so that it works correctly with the server configured ttl for the map. Previously, we were sending 0 for ttl which meant infinite time, but we now send -1 to mean that it shall use the map configuration for ttl.

Originally reported at http://stackoverflow.com/questions/38064997/hazelcast-c-client-map-and-ttl/38079955#38079955 