### PR TITLE
ClientMapTest.testListenerWithInstanceOfPredicate failed by printing GBs of logs in busy loop

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/CallPromise.h
+++ b/hazelcast/include/hazelcast/client/connection/CallPromise.h
@@ -42,6 +42,8 @@ namespace hazelcast {
 
                 void setException(std::auto_ptr<exception::IException> exception);
 
+                void resetException(std::auto_ptr<exception::IException> exception);
+
                 void setRequest(std::auto_ptr<protocol::ClientMessage> request);
 
                 protocol::ClientMessage *getRequest() const;

--- a/hazelcast/include/hazelcast/util/Future.h
+++ b/hazelcast/include/hazelcast/util/Future.h
@@ -66,6 +66,14 @@ namespace hazelcast {
                 conditionVariable.notify_all();
             };
 
+            void reset_exception(std::auto_ptr<client::exception::IException> exception) {
+                LockGuard guard(mutex);
+
+                this->exception = exception;
+                exceptionReady = true;
+                conditionVariable.notify_all();
+            };
+
             T get() {
                 LockGuard guard(mutex);
                 if (resultReady) {

--- a/hazelcast/src/hazelcast/client/connection/CallPromise.cpp
+++ b/hazelcast/src/hazelcast/client/connection/CallPromise.cpp
@@ -37,6 +37,10 @@ namespace hazelcast {
                 future.set_exception(exception);
             }
 
+            void CallPromise::resetException(std::auto_ptr<exception::IException> exception) {
+                future.reset_exception(exception);
+            }
+
             void CallPromise::setRequest(std::auto_ptr<protocol::ClientMessage> request) {
                 this->request = request;
             }

--- a/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
@@ -364,8 +364,9 @@ namespace hazelcast {
                     resend(promise, lastTriedAddress);
                     return;
                 }
-                promise->setException(exception);
-
+                // At this point the exception may have been already set at the promise, hence we need to reset it
+                // and set the exception
+                promise->resetException(exception);
             }
 
             boost::shared_ptr<connection::CallPromise> InvocationService::getEventHandlerPromise(

--- a/hazelcast/src/hazelcast/client/spi/ServerListenerService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ServerListenerService.cpp
@@ -16,6 +16,7 @@
 //
 // Created by sancar koyunlu on 6/24/13.
 
+#include "hazelcast/util/Util.h"
 #include "hazelcast/client/protocol/ClientMessage.h"
 #include "hazelcast/client/spi/ServerListenerService.h"
 #include "hazelcast/client/serialization/pimpl/SerializationService.h"
@@ -60,12 +61,12 @@ namespace hazelcast {
 
                 boost::shared_ptr<impl::listener::EventRegistration> registration = registrationIdMap.get(
                         registrationId);
-                if (NULL != registration.get()) {
+                if ((impl::listener::EventRegistration *)NULL != registration.get()) {
                     // registration exists, just change the alias
                     boost::shared_ptr<std::string> alias(
                             new std::string(registration->getAddCodec()->decodeResponse(*response)));
                     boost::shared_ptr<const std::string> oldAlias = registrationAliasMap.put(registrationId, alias);
-                    if (oldAlias.get() != NULL) {
+                    if (oldAlias.get() != (const std::string *)NULL) {
                         registrationIdMap.remove(*oldAlias);
                         registration->setCorrelationId(response->getCorrelationId());
                         registrationIdMap.put(*alias, registration);
@@ -75,25 +76,32 @@ namespace hazelcast {
 
             bool ServerListenerService::deRegisterListener(protocol::codec::IRemoveListenerCodec &removeListenerCodec) {
                 boost::shared_ptr<const std::string> uuid = registrationAliasMap.remove(removeListenerCodec.getRegistrationId());
-                if (uuid != NULL) {
+                if ((const std::string *)NULL != uuid.get()) {
                     boost::shared_ptr<impl::listener::EventRegistration> registration = registrationIdMap.remove(*uuid);
 
-                    clientContext.getInvocationService().removeEventHandler(registration->getCorrelationId());
+                    if ((impl::listener::EventRegistration *)NULL != registration.get()) {
+                        clientContext.getInvocationService().removeEventHandler(registration->getCorrelationId());
 
-                    // send a remove listener request
-                    removeListenerCodec.setRegistrationId(*uuid);
-                    std::auto_ptr<protocol::ClientMessage> request = removeListenerCodec.encodeRequest();
-                    try {
-                        connection::CallFuture future = clientContext.getInvocationService().invokeOnTarget(
-                                request, registration->getMemberAddress());
+                        // send a remove listener request
+                        removeListenerCodec.setRegistrationId(*uuid);
+                        std::auto_ptr<protocol::ClientMessage> request = removeListenerCodec.encodeRequest();
+                        try {
+                            connection::CallFuture future = clientContext.getInvocationService().invokeOnTarget(
+                                    request, registration->getMemberAddress());
 
-                        std::auto_ptr<protocol::ClientMessage> response = future.get();
-                    } catch (exception::IException &e) {
-                        //if invocation cannot be done that means connection is broken and listener is already removed
-						(void)e; // suppress the unused variable warning
+                            std::auto_ptr<protocol::ClientMessage> response = future.get();
+                        } catch (exception::IException &e) {
+                            //if invocation cannot be done that means connection is broken and listener is already removed
+                            (void)e; // suppress the unused variable warning
+                        }
+
+                        return true;
+                    } else {
+                        char msg[200];
+                        util::snprintf(msg, 200, "[ServerListenerService::deRegisterListener] Listener with id %s is "
+                                "already removed from the registration map.", *uuid);
+                        util::ILogger::getLogger().info(msg);
                     }
-
-                    return true;
                 }
                 return false;
             }
@@ -104,7 +112,7 @@ namespace hazelcast {
                     InvocationService &invocationService = clientContext.getInvocationService();
                     boost::shared_ptr<connection::Connection> result =
                             invocationService.resend(listenerPromise, "internalRetryOfUnkownAddress");
-                    if (NULL == result.get()) {
+                    if ((connection::Connection *)NULL == result.get()) {
                         util::LockGuard lockGuard(failedListenerLock);
                         failedListeners.push_back(listenerPromise);
                     }
@@ -124,8 +132,8 @@ namespace hazelcast {
                     try {
                         boost::shared_ptr<connection::Connection> result =
                                 invocationService.resend(*it, "internalRetryOfUnkownAddress");
-
-                        if (NULL == result.get()) { // resend failed
+                        // resend failed
+                        if ((connection::Connection *)NULL == result.get()) {
                             newFailedListeners.push_back(*it);
                         }
                     } catch (exception::IOException &) {
@@ -156,7 +164,6 @@ namespace hazelcast {
 
                 return registrationId;
             }
-
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/spi/ServerListenerService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ServerListenerService.cpp
@@ -99,7 +99,7 @@ namespace hazelcast {
                     } else {
                         char msg[200];
                         util::snprintf(msg, 200, "[ServerListenerService::deRegisterListener] Listener with id %s is "
-                                "already removed from the registration map.", *uuid);
+                                "already removed from the registration map.", uuid->c_str());
                         util::ILogger::getLogger().info(msg);
                     }
                 }


### PR DESCRIPTION
When we got the logs and examined, we see the following:

Jun 16, 2016 12:23:05 AM INFO: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [4140] [entryUpdated] Key:1^M
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.^M
Jun 16, 2016 12:24:09 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [4368] Heartbeat to connection  Address[127.0.0.1:5702] is failed. ^M
Jun 16, 2016 12:24:09 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [4368] Heartbeat to connection  Address[127.0.0.1:5701] is failed. ^M
Jun 16, 2016 12:24:09 AM FINEST: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [4368] Closing owner connection to Address[127.0.0.1:5701]^M
Jun 16, 2016 12:24:09 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [4368] Closing connection (id:1) to Address[127.0.0.1:5701] with socket id 664 as the owner connection.^M
Jun 16, 2016 12:24:29 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [3240] [IOHandler::handleSocketException] Closing socket to endpoint 127.0.0.1:5702, Cause:ExceptionMessage {Error socket send No error} at Socket::send ^M
^M
Jun 16, 2016 12:24:29 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [3240] Closing connection (id:2) to Address[127.0.0.1:5702] with socket id 572.^M
Jun 16, 2016 12:24:29 AM INFO: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [3240] [cleanResources] There are 9 waiting promises on connection with id:2 (Address[127.0.0.1:5702]) ^M
Jun 16, 2016 12:25:05 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [3376] Future.set_exception should not be called twice : details ExceptionMessage {Wait is timed out} at Future::get(timeInSeconds)


Fixes the following errors seen during ClientMapTest.testListenerWithInstanceOfPredicate test at Windows environment:

1. unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.

2. The following log being written in busy loop: Jun 16, 2016 12:25:05 AM WARNING: [HazelcastCppClient3.6.4-SNAPSHOT] [dev] [3376] Future.set_exception should not be called twice : details ExceptionMessage {Wait is timed out} at Future::get(timeInSeconds)