### PR TITLE
Backport PR #167

### DIFF
--- a/testWindowsSingleCase.bat
+++ b/testWindowsSingleCase.bat
@@ -56,7 +56,7 @@ echo "Waiting for the test server to start. Timeout: %timeout% seconds"
 :loop
     netstat -an  | findstr /C::%SERVER_PORT%
     if %errorlevel% == 0 (
-        set /a remainingTime = %DEFAULT_TIMEOUT% - %timeout%
+        set /a remainingTime = DEFAULT_TIMEOUT - timeout
         echo "Server started in %remainingTime% seconds"
         goto server_started
     ) else (
@@ -64,7 +64,7 @@ echo "Waiting for the test server to start. Timeout: %timeout% seconds"
 
         if %timeout% gtr 0 (
             echo "Sleeping 1 second. Remaining %timeout% seconds"
-            ping 1.1.1.1 -n 1 -w 1000 >NUL
+            CHOICE /c x /D x /T 1 > NUL
             goto loop
         ) else (
             goto server_failed_to_start


### PR DESCRIPTION
Backports PR #167

Fixes the sleep problem in windows test script while starting the server. 

Fixes the sleep problem in windows test script while starting the server. The original ping command does not sleep but returns immediately with the following message: C:\jenkins\ope-fs-root\workspace\cpp-pr-builder-windows>ping 1.1.1.1 -n 1 -w 500
00

Pinging 1.1.1.1 with 32 bytes of data:
Reply from 168.143.191.25: Destination net unreachable.

Ping statistics for 1.1.1.1:
    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),

C:\jenkins\ope-fs-root\workspace\cpp-pr-builder-windows>

Hence, change it with CHOICE command.