### PR TITLE
IOHandler handleSocketException leaks memory

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/IOHandler.cpp
+++ b/hazelcast/src/hazelcast/client/connection/IOHandler.cpp
@@ -63,6 +63,9 @@ namespace hazelcast {
                         address.getHost().c_str(), address.getPort(), message.c_str());
                 util::ILogger::getLogger().getLogger().warning(msg);
 
+                // release the memory for the message
+                delete [] msg;
+
                 // TODO: This call shall resend pending requests and reregister events, hence it can be off-loaded
                 // to another thread in order not to block the critical IO thread
                 connection.close();


### PR DESCRIPTION
Release memory to prevent memory leak.