### PR TITLE
Missing test - executeOnKey for non-existent key

### DIFF
--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -2753,6 +2753,15 @@ namespace hazelcast {
                     ASSERT_EQ(4 * processor.getMultiplier(), *result);
                 }
 
+                TEST_F(RawPointerMapTest, testExecuteOnNonExistentKey) {
+                    EntryMultiplier processor(4);
+
+                    std::auto_ptr<int> result = employees->executeOnKey<int, EntryMultiplier>(17, processor);
+
+                    ASSERT_NE((int *) NULL, result.get());
+                    ASSERT_EQ(-1, *result);
+                }
+
                 TEST_F(RawPointerMapTest, testExecuteOnEntries) {
                     Employee empl1("ahmet", 35);
                     Employee empl2("mehmet", 21);

--- a/hazelcast/test/src/map/ClientMapTest.cpp
+++ b/hazelcast/test/src/map/ClientMapTest.cpp
@@ -2424,6 +2424,15 @@ namespace hazelcast {
                 ASSERT_EQ(4 * processor.getMultiplier(), *result);
             }
 
+            TEST_F(ClientMapTest, testExecuteOnNonExistentKey) {
+                EntryMultiplier processor(4);
+
+                boost::shared_ptr<int> result = employees->executeOnKey<int, EntryMultiplier>(17, processor);
+
+                ASSERT_NE((int *) NULL, result.get());
+                ASSERT_EQ(-1, *result);
+            }
+
             TEST_F(ClientMapTest, testExecuteOnEntries) {
                 Employee empl1("ahmet", 35);
                 Employee empl2("mehmet", 21);

--- a/java/src/main/java/CppClientListener.java
+++ b/java/src/main/java/CppClientListener.java
@@ -204,6 +204,9 @@ class KeyMultiplier implements IdentifiedDataSerializable, EntryProcessor<Intege
 
     @Override
     public Object process(Map.Entry<Integer, Employee> entry) {
+        if (null == entry.getValue()) {
+            return -1;
+        }
         return multiplier * entry.getKey();
     }
 


### PR DESCRIPTION
Added a test for testing executeOnKey for non-existent key.