### PR TITLE
Heartbeat fail does not close non-owner connection

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -359,8 +359,7 @@ namespace hazelcast {
                 if (smartRouting) {
                     //closing the owner connection if unresponsive so that it can be switched to a healthy one.
                     ownerConnectionFuture.closeIfAddressMatches(connection.getRemoteEndpoint());
-                    // we do not close connection itself since we will continue to send heartbeat ping to this connection.
-                    // IOUtil.closeResource(connection);
+                    util::IOUtil::closeResource(&connection);
                     return;
                 }
 


### PR DESCRIPTION
It was reported that when member is powered off the request is frozen. When examined the client log we see that the client detect heartbeat failure but it does not close the connection. It closes it only after 10 seconds during socket recv. The connection close were for some reason commented out, i uncommented the connection close of non-owner connection when heartbeat fails. Need to check if any side affects of this.
