### PR TITLE
RawPointerMap.getEntryView causes crash due to null pointer access

### DIFF
--- a/hazelcast/include/hazelcast/client/adaptor/RawPointerMap.h
+++ b/hazelcast/include/hazelcast/client/adaptor/RawPointerMap.h
@@ -493,6 +493,9 @@ namespace hazelcast {
                 */
                 std::auto_ptr<MapEntryView<K, V> > getEntryView(const K &key) {
                     std::auto_ptr<map::DataEntryView> dataView = map.getEntryViewData(serializationService.toData<K>(&key));
+                    if ((map::DataEntryView *)NULL == dataView.get()) {
+                        return std::auto_ptr<MapEntryView<K, V> >();
+                    }
                     return std::auto_ptr<MapEntryView<K, V> >(new MapEntryView<K, V>(dataView, serializationService));
                 }
 

--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -500,6 +500,21 @@ namespace hazelcast {
                     imap->forceUnlock("key2");
                 }
 
+                TEST_F(RawPointerMapTest, testGetEntryViewForNonExistentData) {
+                    std::auto_ptr<MapEntryView<std::string, std::string> > view = imap->getEntryView("non-existent");
+
+                    ASSERT_EQ((MapEntryView<std::string, std::string> *)NULL, view.get());
+
+                    // put an entry that will expire in 1 milliseconds
+                    imap->put("short_entry", "short living value", 1);
+
+                    util::sleepmillis(500);
+
+                    view = imap->getEntryView("short_entry");
+
+                    ASSERT_EQ((MapEntryView<std::string, std::string> *)NULL, view.get());
+                }
+
                 TEST_F(RawPointerMapTest, testPutTtl) {
                     util::CountDownLatch dummy(10);
                     util::CountDownLatch evict(1);


### PR DESCRIPTION
Fixes null handling for non-existing data when RawPointerMap.getEntryView is executed. Fixes issue https://github.com/hazelcast/hazelcast-cpp-client/issues/177