### PR TITLE
Test server detection fails if port 65430 is in use

### DIFF
--- a/testLinuxSingleCase.sh
+++ b/testLinuxSingleCase.sh
@@ -82,7 +82,7 @@ echo "Waiting for the test server to start"
 
 while [ ${timeout} -gt 0 ]
 do
-    netstat -an  | grep ${SERVER_PORT}
+    netstat -an  | grep ":${SERVER_PORT} "
     if [ $? -eq 0 ]; then
         break
     fi

--- a/testWindowsSingleCase.bat
+++ b/testWindowsSingleCase.bat
@@ -54,7 +54,7 @@ SET timeout=%DEFAULT_TIMEOUT%
 echo "Waiting for the test server to start. Timeout: %timeout% seconds"
 
 :loop
-    netstat -an  | findstr /C::%SERVER_PORT%
+    netstat -an  | findstr /C:":%SERVER_PORT% "
     if %errorlevel% == 0 (
         set /a remainingTime = DEFAULT_TIMEOUT - timeout
         echo "Server started in %remainingTime% seconds"


### PR DESCRIPTION
Fix for handling detection of server start more correctly. It should only catch te server started at port 6543 but not 65430 or similar.