### PR TITLE
Code fails to compile with VS 2010

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/WriteHandler.h
+++ b/hazelcast/include/hazelcast/client/connection/WriteHandler.h
@@ -21,6 +21,8 @@
 #ifndef HAZELCAST_WriteHandler
 #define HAZELCAST_WriteHandler
 
+#include <stdint.h>
+
 #include "hazelcast/util/ByteBuffer.h"
 #include "hazelcast/util/ConcurrentQueue.h"
 #include "hazelcast/client/connection/IOHandler.h"

--- a/hazelcast/include/hazelcast/client/protocol/codec/ErrorCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/ErrorCodec.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <stdint.h>
 
 #include "hazelcast/client/protocol/ResponseMessageConst.h"
 #include "hazelcast/client/protocol/codec/StackTraceElement.h"


### PR DESCRIPTION
It was reported that VS2010 compiler fails to compile the source code with the following error:

VS2010 Windows compilation produces (using your dev tools):

"D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\HazelcastClient.sln" (default target) (1) ->
"D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\ALL_BUILD.vcxproj.metaproj" (default target) (2) ->
"D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\examples\distributed-map\locking\AbaProtectedOptimisticUpdate.vcxproj.metaproj" (default target) (3) ->
"D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\HazelcastClient3.7-SNAPSHOT_64.vcxproj.metaproj" (default target) (4) ->

"D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\HazelcastClient3.7-SNAPSHOT_64.vcxproj" (default target) (6) ->

(ClCompile target) ->

D:\Work\Sources_x64\Hazelcast\hazelcast\include\hazelcast/client/connection/WriteHandler.h(65): error C2146: syntax error : missing ';' before identifier 'numBytesWrittenToSocketForMessage' [D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\ HazelcastClient3.7-SNAPSHOT_64.vcxproj]

D:\Work\Sources_x64\Hazelcast\hazelcast\include\hazelcast/client/connection/WriteHandler.h(65): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int [D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\Haze lcastClient3.7-SNAPSHOT_64.vcxproj]

D:\Work\Sources_x64\Hazelcast\hazelcast\include\hazelcast/client/connection/WriteHandler.h(65): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int [D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\Haze lcastClient3.7-SNAPSHOT_64.vcxproj]

D:\Work\Sources_x64\Hazelcast\hazelcast\include\hazelcast/client/connection/WriteHandler.h(66): error C2146: syntax error : missing ';' before identifier 'lastMessageFrameLen' [D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\HazelcastClien t3.7-SNAPSHOT_64.vcxproj]

D:\Work\Sources_x64\Hazelcast\hazelcast\include\hazelcast/client/connection/WriteHandler.h(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int [D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\Haze lcastClient3.7-SNAPSHOT_64.vcxproj]

D:\Work\Sources_x64\Hazelcast\hazelcast\include\hazelcast/client/connection/WriteHandler.h(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int [D:\Work\Sources_x64\Hazelcast\ReleaseStatic64\Haze lcastClient3.7-SNAPSHOT_64.vcxproj]

Added the missing includes so that the code can compile using VS 2010.
