### PR TITLE
Tests fail with latest hazelcast snapshot

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.8-SNAPSHOT</version>
+            <version>3.7.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Change the tests server version to 3.7.2 temporarily until the problem at the java server side is fixed (util PR https://github.com/hazelcast/hazelcast/pull/9273 is merged). Will put back the snapshot once the problem is fixed.