### PR TITLE
Added the capability to return NearCachedMapProxy wrapped IMap

### DIFF
--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -37,6 +37,10 @@
 
 namespace hazelcast {
     namespace client {
+        namespace config {
+            class NearCacheConfig;
+        }
+
         class MembershipListener;
 
         class InitialMembershipListener;
@@ -343,6 +347,15 @@ namespace hazelcast {
              * @return the found config. If none is found, a default configured one is returned.
              */
             const config::ReliableTopicConfig *getReliableTopicConfig(const std::string &name);
+
+            /**
+             * Gets the {@link NearCacheConfig} configured for the map / cache with name
+             *
+             * @param name name of the map / cache
+             * @return Configured {@link NearCacheConfig}
+             * @see com.hazelcast.config.NearCacheConfig
+             */
+            const config::NearCacheConfig *getNearCacheConfig(const std::string &name);
         private:
 
             GroupConfig groupConfig;
@@ -380,6 +393,12 @@ namespace hazelcast {
             std::auto_ptr<Credentials> defaultCredentials;
 
             std::map<std::string, config::ReliableTopicConfig> reliableTopicConfigMap;
+
+            std::map<std::string, config::NearCacheConfig> nearCacheConfigMap;
+
+            const config::NearCacheConfig *
+            lookupByPattern(const std::map<std::string, config::NearCacheConfig> &nearCacheConfigMap,
+                            const std::string &name) const;
         };
 
     }

--- a/hazelcast/include/hazelcast/client/IMap.h
+++ b/hazelcast/include/hazelcast/client/IMap.h
@@ -865,8 +865,7 @@ namespace hazelcast {
                 mapImpl->destroy();
             }
         private:
-            IMap(const std::string &instanceName, spi::ClientContext *context) : mapImpl(
-                    new map::ClientMapProxy<K, V>(instanceName, context)) {
+            IMap(std::auto_ptr<map::ClientMapProxy<K, V> > proxy) : mapImpl(proxy) {
             }
 
             boost::shared_ptr<map::ClientMapProxy<K, V> > mapImpl;

--- a/hazelcast/include/hazelcast/client/config/NearCacheConfig.h
+++ b/hazelcast/include/hazelcast/client/config/NearCacheConfig.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZELCAST_CLIENT_CONFIG_NEARCACHECONFIG_H_
+#define HAZELCAST_CLIENT_CONFIG_NEARCACHECONFIG_H_
+
+#include "hazelcast/util/HazelcastDll.h"
+#include <string>
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export	
+#endif 
+
+namespace hazelcast {
+    namespace client {
+        namespace config {
+            class HAZELCAST_API NearCacheConfig {
+            public:
+                NearCacheConfig();
+
+                NearCacheConfig(const char *name);
+            };
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif 
+
+#endif /* HAZELCAST_CLIENT_CONFIG_NEARCACHECONFIG_H_ */

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZELCAST_CLIENT_MAP_NEARCACHEDCLIENTMAPPROXY_H_
+#define HAZELCAST_CLIENT_MAP_NEARCACHEDCLIENTMAPPROXY_H_
+
+#include <stdexcept>
+#include <climits>
+#include <hazelcast/client/config/NearCacheConfig.h>
+#include "hazelcast/client/map/ClientMapProxy.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
+namespace hazelcast {
+    namespace client {
+        namespace map {
+            /**
+             * A Client-side {@code IMap} implementation which is fronted by a near-cache.
+             *
+             * @param <K> the key type for this {@code IMap} proxy.
+             * @param <V> the value type for this {@code IMap} proxy.
+             */
+            template<typename K, typename V>
+            class NearCachedClientMapProxy : public ClientMapProxy<K, V> {
+            public:
+                NearCachedClientMapProxy(const std::string &instanceName, spi::ClientContext *context,
+                                         const config::NearCacheConfig *nearcacheConfig)
+                        : ClientMapProxy<K, V>(instanceName, context) {
+                    // TODO: implement it
+                }
+            };
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+#endif /* HAZELCAST_CLIENT_MAP_NEARCACHEDCLIENTMAPPROXY_H_ */
+

--- a/hazelcast/src/hazelcast/client/ClientConfig.cpp
+++ b/hazelcast/src/hazelcast/client/ClientConfig.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <hazelcast/client/config/NearCacheConfig.h>
 #include "hazelcast/client/ClientConfig.h"
 #include "hazelcast/client/LifecycleListener.h"
 #include "hazelcast/client/InitialMembershipListener.h"
@@ -198,5 +199,22 @@ namespace hazelcast {
             }
             return &reliableTopicConfigMap[name];
         }
+
+        const config::NearCacheConfig *ClientConfig::getNearCacheConfig(const std::string &name) {
+            const config::NearCacheConfig *nearCacheConfig = lookupByPattern(nearCacheConfigMap, name);
+            if (nearCacheConfig != NULL) {
+                return nearCacheConfig;
+            }
+
+            return &nearCacheConfigMap["default"];
+        }
+
+        const config::NearCacheConfig *ClientConfig::lookupByPattern(
+                const std::map<std::string, config::NearCacheConfig> &nearCacheConfigMap,
+                const std::string &basic_string) const {
+            // TODO: implement the lookup
+            return NULL;
+        }
+
     }
 }

--- a/hazelcast/src/hazelcast/client/config/NearCacheConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/NearCacheConfig.cpp
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 //
-// Created by İhsan Demir on 21/12/15.
-//
-#include <hazelcast/client/HazelcastClient.h>
+// Created by ihsan demir on 22 Nov 2016.
 
-int main() {
-    hazelcast::client::ClientConfig config;
-    hazelcast::client::HazelcastClient hz(config);
+#include "hazelcast/client/config/NearCacheConfig.h"
 
-    hazelcast::client::IQueue<std::string> map = hz.getDistributedObject<hazelcast::client::IQueue<std::string> >(
-            "queue distributed object");
+namespace hazelcast {
+    namespace client {
+        namespace config {
+            NearCacheConfig::NearCacheConfig() {
+            }
 
-    std::cout << "Finished" << std::endl;
-
-    return 0;
+            NearCacheConfig::NearCacheConfig(const char *name) {
+            }
+        }
+    }
 }
-


### PR DESCRIPTION
Added the capability to return NearCachedMapProxy wrapped IMap when the cache is configured for the map. Internal implementation is to be completed.