### PR TITLE
windows compilation fails due to missing header file

### DIFF
--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -25,6 +25,7 @@
 #include "hazelcast/client/impl/RoundRobinLB.h"
 #include "hazelcast/util/ILogger.h"
 #include "hazelcast/client/config/ReliableTopicConfig.h"
+#include "hazelcast/client/config/NearCacheConfig.h"
 
 #include <vector>
 #include <set>


### PR DESCRIPTION
Fixes windows compilation failure: C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include\utility(199): error C2079: 'std::pair<const _Kty,_Ty>::second' uses undefined class 'hazelcast::client::config::NearCacheConfig'