### PR TITLE
ConnectionManager principal member object is not thread safe

### DIFF
--- a/hazelcast/include/hazelcast/client/Member.h
+++ b/hazelcast/include/hazelcast/client/Member.h
@@ -118,7 +118,7 @@ namespace hazelcast {
             std::map<std::string, std::string> attributes;
         };
 
-        std::ostream HAZELCAST_API &operator<<(std::ostream &stream, const Member &member);
+        std::ostream HAZELCAST_API &operator<<(std::ostream &out, const Member &member);
     }
 }
 

--- a/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
+++ b/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
@@ -198,7 +198,7 @@ namespace hazelcast {
                 std::auto_ptr<util::Thread> outSelectorThread;
                 util::AtomicBoolean live;
                 util::Mutex lockMutex;
-                std::auto_ptr<protocol::Principal> principal;
+                boost::shared_ptr<protocol::Principal> principal;
 
                 connection::HeartBeater heartBeater;
                 std::auto_ptr<util::Thread> heartBeatThread;

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -384,14 +384,34 @@ namespace hazelcast {
                 connection->setConnectionId(++connectionIdCounter);
 
                 std::stringstream message;
-                (message << "Connected and authenticated by " << *addr << ". Connection id:" << connection->getConnectionId()
-                 << " , socket id:" << connection->getSocket().getSocketId() << (connection->isOwnerConnection() ? " as owner connection." : "."));
-                util::ILogger::getLogger().info(message.str());
+                message << "Connected and authenticated by " << *addr << ". Connection id:"
+                        << connection->getConnectionId() << " , socket id:" << connection->getSocket().getSocketId();
+
                 if (connection->isOwnerConnection()) {
                     principal = std::auto_ptr<protocol::Principal>(new protocol::Principal(uuid, ownerUuid));
+                    message << " as owner connection";
                 } else {
                     connection->getSocket().setBlocking(false);
                 }
+                
+                if ((protocol::Principal *) NULL != principal.get()) {
+                    const std::string *clientUuid = principal->getUuid();
+                    if (NULL != clientUuid) {
+                        message << ". Client uuid: " << *clientUuid;
+                    } else {
+                        message << ". Client uuid is NULL";
+                    }
+                    const std::string *ownerMemberUuid = principal->getOwnerUuid();
+                    if (NULL != ownerMemberUuid) {
+                        message << ". Owner member uuid: " << *ownerMemberUuid;
+                    } else {
+                        message << ". Owner member uuid is NULL";
+                    }
+                } else {
+                    message << ". No principal exist!!!";
+                }
+
+                util::ILogger::getLogger().info(message.str());
             }
 
 

--- a/hazelcast/src/hazelcast/client/connection/Member.cpp
+++ b/hazelcast/src/hazelcast/client/connection/Member.cpp
@@ -52,8 +52,15 @@ namespace hazelcast {
             return attributes;
         }
 
-        std::ostream &operator<<(std::ostream &stream, const Member &member) {
-            return stream << "Member[" << member.getAddress() << "]";
+        std::ostream &operator<<(std::ostream &out, const Member &member) {
+            const Address &address = member.getAddress();
+            out << "Member[";
+            out << address.getHost();
+            out << "]";
+            out << ":";
+            out << address.getPort();
+            out << " - " << member.getUuid();
+            return out;
         }
 
         const std::string *Member::getAttribute(const std::string &key) const {


### PR DESCRIPTION
Makes the principal object thread safe in the ConnectionManager. This object is accessed via owner and non-owner connection authentications which can be done through different threads.

Also enhanced the logging statements. Made the members list logging the same as the java client.

Hoping that this fixes the failure reported at issue: https://github.com/hazelcast/hazelcast-cpp-client/issues/190