### PR TITLE
Windows compilation fails - Error: EvictionConfig.h(103): error C2039: 'auto_ptr' : is not a member of 'std'

### DIFF
--- a/hazelcast/include/hazelcast/client/config/EvictionConfig.h
+++ b/hazelcast/include/hazelcast/client/config/EvictionConfig.h
@@ -99,9 +99,6 @@ namespace hazelcast {
 /*
            const EvictionPolicyComparator comparator;
 */
-
-                std::auto_ptr<EvictionConfig> readOnly;
-
             private:
                 /**
                  * Used by the {@link NearCacheConfigAccessor} to initialize the proper default value for on-heap maps.


### PR DESCRIPTION
Eliminates the unused field which caused compilation failures at windows. Example failure:

C:\jenkins\ope-fs-root\workspace\cpp-windows-nightly-release\hazelcast\include\hazelcast/client/config/EvictionConfig.h(103): error C2039: 'auto_ptr' : is not a member of 'std' (C:\jenkins\ope-fs-root\workspace\cpp-windows-nightly-release\hazelcast\src\hazelcast\client\config\EvictionConfig.cpp) [c:\jenkins\ope-fs-root\workspace\cpp-windows-nightly-release\ReleaseShared64\HazelcastClient3.7-SNAPSHOT_64.vcxproj]