### PR TITLE
Windows nightly release fails on examples build - 

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
@@ -84,6 +84,12 @@ namespace hazelcast {
     }
 }
 
+namespace boost {
+    template<>
+    bool HAZELCAST_API operator<(const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &lhs,
+                   const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &rhs);
+}
+
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif

--- a/hazelcast/include/hazelcast/util/Atomic.h
+++ b/hazelcast/include/hazelcast/util/Atomic.h
@@ -93,7 +93,7 @@ namespace hazelcast {
                 return i != v;
             }
 
-            bool compareAndSet(bool compareValue, bool setValue) {
+            bool compareAndSet(const T &compareValue, const T &setValue) {
                 LockGuard lockGuard(mutex);
                 if(compareValue == v){
                     v = setValue;


### PR DESCRIPTION
Two fixes here:
1. Corrected the parameter type at the Atomic template.

2. Puts the declaration of specialized less operator for boost::shared_ptr<serialization::pimpl::Data> so that the windows builds do not fail with the following errors:
(https://hazelcast-l337.ci.cloudbees.com/job/cpp-windows-nightly-release/237/console)
HazelcastClient3.7-SNAPSHOT_32.lib(Data.obj) : error LNK2005: "bool __cdecl boost::operator<<class hazelcast::client::serialization::pimpl::Data,class hazelcast::client::serialization::pimpl::Data>(class boost::shared_ptr<class hazelcast::client::serialization::pimpl::Data> const &,class boost::shared_ptr<class hazelcast::client::serialization::pimpl::Data> const &)" (??$?MVData@pimpl@serialization@client@hazelcast@@V01234@@boost@@YA_NABV?$shared_ptr@VData@pimpl@serialization@client@hazelcast@@@0@0@Z) already defined in AbaProtectedOptimisticUpdate.obj [<https://hazelcast-l337.ci.cloudbees.com/job/cpp-windows-nightly-release/ws/examples\build\distributed-map\locking\AbaProtectedOptimisticUpdate.vcxproj]>