### PR TITLE
Linux release verification nightly test failed due to missing compilation flag

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -92,7 +92,7 @@ if (NOT("${HAZELCAST_INSTALL_DIR}x" STREQUAL "x"))
 
         message(STATUS "${HZ_BIT} Bit")
 
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall ${HZ_BIT_FLAG}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS ${HZ_BIT_FLAG}")
 
         set(HZ_LIB_PATH "")
         IF (${HZ_LIB_TYPE} MATCHES "STATIC")


### PR DESCRIPTION
Fixes the linux nightly release verification failures due to the missing compilation flag -D__STDC_LIMIT_MACROS while building the examples.

The failure log: https://hazelcast-l337.ci.cloudbees.com/job/cpp-linux-nightly-release/337/console