### PR TITLE
Build fails at CentOs 7 gcc 4.8.5

### DIFF
--- a/hazelcast/include/hazelcast/client/config/EvictionConfig.h
+++ b/hazelcast/include/hazelcast/client/config/EvictionConfig.h
@@ -154,6 +154,7 @@ namespace hazelcast {
                     } else {
                         assert(0);
                     }
+		    return internal::eviction::NONE;
                 }
 
                 std::ostream &operator<<(std::ostream &out) {

--- a/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <map>
 #include <stdint.h>
+#include <string>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)

--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -2157,10 +2157,10 @@ namespace hazelcast {
                     ASSERT_EQ("value1", *(imap->replace("key1", "value2")));
                     ASSERT_EQ("value2", *(imap->get("key1")));
 
-                    ASSERT_EQ(false, imap->replace("key1", "value1", "value3"));
+                    ASSERT_FALSE(imap->replace("key1", "value1", "value3"));
                     ASSERT_EQ("value2", *(imap->get("key1")));
 
-                    ASSERT_EQ(true, imap->replace("key1", "value2", "value3"));
+                    ASSERT_TRUE(imap->replace("key1", "value2", "value3"));
                     ASSERT_EQ("value3", *(imap->get("key1")));
                 }
 

--- a/hazelcast/test/src/common/containers/LitlleEndianBufferTest.cpp
+++ b/hazelcast/test/src/common/containers/LitlleEndianBufferTest.cpp
@@ -212,13 +212,13 @@ namespace hazelcast {
 
                             {
                                 bool result = getBoolean();
-                                ASSERT_EQ(true, result);
+                                ASSERT_TRUE(result);
 
                                 result = getBoolean();
-                                ASSERT_EQ(true, result);
+                                ASSERT_TRUE(result);
 
                                 result = getBoolean();
-                                ASSERT_EQ(false, result);
+                                ASSERT_FALSE(result);
                             }
 
                         }

--- a/hazelcast/test/src/issues/IssueTest.cpp
+++ b/hazelcast/test/src/issues/IssueTest.cpp
@@ -99,26 +99,26 @@ namespace hazelcast {
                 // Put a key, value to the map
                 ASSERT_EQ((int *)NULL, map.put(1, 10).get());
 
-                ASSERT_EQ(true, latch.await(20, 1)); // timeout of 20 seconds
+                ASSERT_TRUE(latch.await(20, 1)); // timeout of 20 seconds
 
                 // 5. Verify that the listener got the entry added event
                 ASSERT_EQ(1, latch.get());
 
                 // 6. Restart the server
-                ASSERT_EQ(true, server.shutdown());
-                ASSERT_EQ(true, server.start());
+                ASSERT_TRUE(server.shutdown());
+                ASSERT_TRUE(server.start());
 
                 std::string putThreadName("Map Put Thread");
                 util::Thread t(putThreadName, putMapMessage, &map, &latch);
 
                 // 8. Verify that the 2nd entry is received by the listener
-                ASSERT_EQ(true, latch.await(20, 0)); // timeout of 20 seconds
+                ASSERT_TRUE(latch.await(20, 0)); // timeout of 20 seconds
 
                 t.cancel();
                 t.join();
 
                 // 9. Shut down the server
-                ASSERT_EQ(true, server.shutdown());
+                ASSERT_TRUE(server.shutdown());
             }
 
             void IssueTest::Issue864MapListener::entryAdded(const EntryEvent<int, int> &event) {

--- a/hazelcast/test/src/map/ClientMapTest.cpp
+++ b/hazelcast/test/src/map/ClientMapTest.cpp
@@ -1983,10 +1983,10 @@ namespace hazelcast {
                 ASSERT_EQ("value1", *(ClientMapTest<TypeParam>::imap->replace("key1", "value2")));
                 ASSERT_EQ("value2", *(ClientMapTest<TypeParam>::imap->get("key1")));
 
-                ASSERT_EQ(false, ClientMapTest<TypeParam>::imap->replace("key1", "value1", "value3"));
+                ASSERT_FALSE(ClientMapTest<TypeParam>::imap->replace("key1", "value1", "value3"));
                 ASSERT_EQ("value2", *(ClientMapTest<TypeParam>::imap->get("key1")));
 
-                ASSERT_EQ(true, ClientMapTest<TypeParam>::imap->replace("key1", "value2", "value3"));
+                ASSERT_TRUE(ClientMapTest<TypeParam>::imap->replace("key1", "value2", "value3"));
                 ASSERT_EQ("value3", *(ClientMapTest<TypeParam>::imap->get("key1")));
             }
 
@@ -2621,9 +2621,9 @@ namespace hazelcast {
                         processor);
 
                 ASSERT_EQ(3, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(5)));
                 ASSERT_EQ(3 * processor.getMultiplier(), *result[3]);
                 ASSERT_EQ(4 * processor.getMultiplier(), *result[4]);
                 ASSERT_EQ(5 * processor.getMultiplier(), *result[5]);
@@ -2644,9 +2644,9 @@ namespace hazelcast {
                         processor, query::TruePredicate());
 
                 ASSERT_EQ(3, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(5)));
                 ASSERT_EQ(3 * processor.getMultiplier(), *result[3]);
                 ASSERT_EQ(4 * processor.getMultiplier(), *result[4]);
                 ASSERT_EQ(5 * processor.getMultiplier(), *result[5]);
@@ -2692,7 +2692,7 @@ namespace hazelcast {
                         processor, andPredicate);
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(5)));
                 ASSERT_EQ(5 * processor.getMultiplier(), *result[5]);
             }
 
@@ -2717,8 +2717,8 @@ namespace hazelcast {
                         processor, orPredicate);
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
                 ASSERT_EQ(3 * processor.getMultiplier(), *result[3]);
                 ASSERT_EQ(4 * processor.getMultiplier(), *result[4]);
             }
@@ -2738,8 +2738,8 @@ namespace hazelcast {
                         processor, query::BetweenPredicate<int>("a", 25, 35));
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(5)));
                 ASSERT_EQ(3 * processor.getMultiplier(), *result[3]);
                 ASSERT_EQ(5 * processor.getMultiplier(), *result[5]);
             }
@@ -2759,7 +2759,7 @@ namespace hazelcast {
                         processor, query::EqualPredicate<int>("a", 25));
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(5)));
 
                 result = ClientMapTest<TypeParam>::employees->template executeOnEntries<int, typename ClientMapTest<TypeParam>::EntryMultiplier>(
                         processor, query::EqualPredicate<int>("a", 10));
@@ -2782,8 +2782,8 @@ namespace hazelcast {
                         processor, query::NotEqualPredicate<int>("a", 25));
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithGreaterLessPredicate) {
@@ -2801,27 +2801,27 @@ namespace hazelcast {
                         processor, query::GreaterLessPredicate<int>("a", 25, false, true)); // <25 matching
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(4)));
 
                 result = ClientMapTest<TypeParam>::employees->template executeOnEntries<int, typename ClientMapTest<TypeParam>::EntryMultiplier>(
                         processor, query::GreaterLessPredicate<int>("a", 25, true, true)); // <=25 matching
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(4)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(5)));
 
                 result = ClientMapTest<TypeParam>::employees->template executeOnEntries<int, typename ClientMapTest<TypeParam>::EntryMultiplier>(
                         processor, query::GreaterLessPredicate<int>("a", 25, false, false)); // >25 matching
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(3)));
 
                 result = ClientMapTest<TypeParam>::employees->template executeOnEntries<int, typename ClientMapTest<TypeParam>::EntryMultiplier>(
                         processor, query::GreaterLessPredicate<int>("a", 25, true, false)); // >=25 matching
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(5)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithLikePredicate) {
@@ -2839,7 +2839,7 @@ namespace hazelcast {
                         processor, query::LikePredicate("n", "deniz"));
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(5)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithILikePredicate) {
@@ -2857,7 +2857,7 @@ namespace hazelcast {
                         processor, query::ILikePredicate("n", "deniz"));
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(5)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithInPredicate) {
@@ -2879,8 +2879,8 @@ namespace hazelcast {
                         processor, predicate);
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithInstanceOfPredicate) {
@@ -2897,9 +2897,9 @@ namespace hazelcast {
                         processor, query::InstanceOfPredicate("Employee"));
 
                 ASSERT_EQ(3, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(5)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithNotPredicate) {
@@ -2918,17 +2918,17 @@ namespace hazelcast {
                         processor, notPredicate);
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
 
                 query::NotPredicate notFalsePredicate(std::auto_ptr<query::Predicate>(new query::FalsePredicate()));
                 result = ClientMapTest<TypeParam>::employees->template executeOnEntries<int, typename ClientMapTest<TypeParam>::EntryMultiplier>(
                         processor, notFalsePredicate);
 
                 ASSERT_EQ(3, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
-                ASSERT_EQ(true, (result.end() != result.find(5)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(5)));
 
                 query::NotPredicate notBetweenPredicate(
                         std::auto_ptr<query::Predicate>(new query::BetweenPredicate<int>("a", 25, 35)));
@@ -2936,7 +2936,7 @@ namespace hazelcast {
                         processor, notBetweenPredicate);
 
                 ASSERT_EQ(1, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(4)));
             }
 
             TYPED_TEST(ClientMapTest, testExecuteOnEntriesWithRegexPredicate) {
@@ -2954,8 +2954,8 @@ namespace hazelcast {
                         processor, query::RegexPredicate("n", ".*met"));
 
                 ASSERT_EQ(2, (int) result.size());
-                ASSERT_EQ(true, (result.end() != result.find(3)));
-                ASSERT_EQ(true, (result.end() != result.find(4)));
+                ASSERT_TRUE((result.end() != result.find(3)));
+                ASSERT_TRUE((result.end() != result.find(4)));
             }
 
             TYPED_TEST(ClientMapTest, testAddInterceptor) {

--- a/hazelcast/test/src/protocol/ClientMessageTest.cpp
+++ b/hazelcast/test/src/protocol/ClientMessageTest.cpp
@@ -30,9 +30,9 @@ namespace hazelcast {
                             hazelcast::client::protocol::ClientMessage::createForEncode(22);
                     ASSERT_EQ(0, msg->getDataSize());
 
-                    ASSERT_EQ(false, msg->isRetryable());
+                    ASSERT_FALSE(msg->isRetryable());
 
-                    ASSERT_EQ(false, msg->isBindToSingleConnection());
+                    ASSERT_FALSE(msg->isBindToSingleConnection());
 
                     ASSERT_EQ(22, msg->getFrameLength());
 
@@ -45,12 +45,12 @@ namespace hazelcast {
                     msg->setVersion(4);
                     msg->updateFrameLength();
 
-                    ASSERT_EQ(true, msg->isBindToSingleConnection());
-                    ASSERT_EQ(true, msg->isRetryable());
+                    ASSERT_TRUE(msg->isBindToSingleConnection());
+                    ASSERT_TRUE(msg->isRetryable());
                     ASSERT_EQ(0xABCDEF12, msg->getCorrelationId());
-                    ASSERT_EQ(false, msg->isFlagSet(2));
-                    ASSERT_EQ(true, msg->isFlagSet(4));
-                    ASSERT_EQ(true, msg->isFlagSet(0x05));
+                    ASSERT_FALSE(msg->isFlagSet(2));
+                    ASSERT_TRUE(msg->isFlagSet(4));
+                    ASSERT_TRUE(msg->isFlagSet(0x05));
                     ASSERT_EQ(0xABCD, msg->getMessageType());
                     ASSERT_EQ((int32_t)0x8ABCDEF1, msg->getPartitionId());
                     ASSERT_EQ(4, msg->getVersion());

--- a/hazelcast/test/src/txn/ClientTxnMapTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnMapTest.cpp
@@ -217,8 +217,8 @@ namespace hazelcast {
                 boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
-                ASSERT_EQ(false, map.replace("key1", "valueNonExistent", "myNewValue"));
-                ASSERT_EQ(true, map.replace("key1", "value1", "myNewValue"));
+                ASSERT_FALSE(map.replace("key1", "valueNonExistent", "myNewValue"));
+                ASSERT_FALSE(map.replace("key1", "value1", "myNewValue"));
 
                 context.commitTransaction();
 

--- a/hazelcast/test/src/txn/ClientTxnMapTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnMapTest.cpp
@@ -218,7 +218,7 @@ namespace hazelcast {
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_FALSE(map.replace("key1", "valueNonExistent", "myNewValue"));
-                ASSERT_FALSE(map.replace("key1", "value1", "myNewValue"));
+                ASSERT_TRUE(map.replace("key1", "value1", "myNewValue"));
 
                 context.commitTransaction();
 

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -131,7 +131,7 @@ namespace hazelcast {
                 } catch (exception::IException&) {
                     gotException = true;
                 }
-                ASSERT_EQ(true, gotException);
+                ASSERT_TRUE(gotException);
             }
 
             void dummyThread(util::ThreadArgs& args) {


### PR DESCRIPTION
It is reported that the current master code fails to compile at Build fails at CentOs 7 gcc 4.8.5 with error:

ClientExceptionFactory.cpp:23:0:
/root/hazelcast-cpp-client/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h:42:84: error: ‘string’ in namespace ‘std’ does not name a type
                virtual std::auto_ptr<exception::IException> createException(const std::string &message....

Solution: Added the missing header and added a return option for EvictionConfig.h  so that CentOS 7 gcc 4.8.5 compiles successfully.

Replaced ASSERT_EQ(true, ...) with ASSERT_TRUE and ASSERT_EQ(false, .…) with ASSERT_FALSE in the tests to eliminate warnings.