### PR TITLE
gcc 4.8.5 unused variable warning causes examples build fail

### DIFF
--- a/examples/distributed-map/query/queryExample.cpp
+++ b/examples/distributed-map/query/queryExample.cpp
@@ -280,8 +280,15 @@ void queryMapUsingDifferentPredicates() {
     size_t numberOfValues = valuesArray->size();
     if (numberOfValues > 0) {
         const int *firstValue = valuesArray->get(0);
-        firstValue = (*valuesArray)[0];
+        const int *firstValueAsArrayIndex = (*valuesArray)[0];
+	if (NULL != firstValue) {
+		std::cout << "First value:" << *firstValue << std::endl;
+		std::cout << "Pointer addresses:" << firstValue << ", as array index:" << firstValueAsArrayIndex << std::endl;
+	}
         std::auto_ptr<int> firstValueWithMemoryOwnership = valuesArray->release(0);
+	if (NULL != firstValueWithMemoryOwnership.get()) {
+		std::cout << "First value:" << *firstValueWithMemoryOwnership << std::endl;
+	}
     }
 
     // value == 8


### PR DESCRIPTION
Fixes the warnings in examples while compiling for gcc 4.8.5.