### PR TITLE
Operator less overriding for Data causes compilation error for exception signature

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
@@ -87,7 +87,7 @@ namespace hazelcast {
 namespace boost {
     template<>
     bool HAZELCAST_API operator<(const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &lhs,
-                   const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &rhs);
+                   const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &rhs) BOOST_NOEXCEPT;
 }
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/Data.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/Data.cpp
@@ -125,7 +125,8 @@ namespace boost {
      * Template specialization for the less operator comparing two shared_ptr Data.
      */
     template<>
-    bool operator <(const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &lhs, const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &rhs) {
+    bool operator <(const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &lhs,
+                   const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &rhs) BOOST_NOEXCEPT {
         const hazelcast::client::serialization::pimpl::Data *leftPtr = lhs.get();
         const hazelcast::client::serialization::pimpl::Data *rightPtr = rhs.get();
         if (leftPtr == rightPtr) {


### PR DESCRIPTION
Fixes the problem for overriden less operator for Data. The problem occurs at Centos 7. The error is:

include/hazelcast/client/serialization/pimpl/Data.h:90:95: error: declaration of ‘bool boost::operator<(const boost::shared_ptr<X>&, const boost::shared_ptr<U>&) [with T = hazelcast::client::serialization::pimpl::Data; U = hazelcast::client::serialization::pimpl::Data]’ has a different exception specifier
                    const boost::shared_ptr<hazelcast::client::serialization::pimpl::Data> &rhs);
                                                                                               ^
Added the same exception signature as defined at the boost shared_ptr less operator.