### PR TITLE
Compiler warning causes nightly tests fail at gcc 4.8.5 when compiling the newly added near cache examples

### DIFF
--- a/examples/distributed-map/near-cache/NearCacheSupport.h
+++ b/examples/distributed-map/near-cache/NearCacheSupport.h
@@ -30,20 +30,19 @@ public:
 
     static void printNearCacheStats(hazelcast::client::IMap<int, std::string> &map, const char *message) {
         hazelcast::client::monitor::NearCacheStats *stats = map.getLocalMapStats().getNearCacheStats();
-        printf("%s (%lld entries, %lld hits, %lld misses, %lld evictions, %lld expirations)\n",
-               message, stats->getOwnedEntryCount(), stats->getHits(), stats->getMisses(),
-               stats->getEvictions(), stats->getExpirations());
+        printf("%s (%ld entries, %ld hits, %ld misses, %ld evictions, %ld expirations)\n",
+               message, (long) stats->getOwnedEntryCount(), (long) stats->getHits(), (long) stats->getMisses(),
+               (long) stats->getEvictions(), (long) stats->getExpirations());
     }
 
     static void printNearCacheStats(hazelcast::client::IMap<int, std::string> &map) {
         hazelcast::client::monitor::NearCacheStats *stats = map.getLocalMapStats().getNearCacheStats();
 
-        printf("The Near Cache contains %lld entries.\n", stats->getOwnedEntryCount());
-        printf("The first article instance was retrieved from the remote instance (Near Cache misses: %lld).\n",
-               stats->getMisses());
-        printf(
-                "The second and third article instance were retrieved from the local Near Cache (Near Cache hits: %lld).\n",
-                stats->getHits());
+        printf("The Near Cache contains %ld entries.\n", (long) stats->getOwnedEntryCount());
+        printf("The first article instance was retrieved from the remote instance (Near Cache misses: %ld).\n",
+               (long) stats->getMisses());
+        printf("The second and third article instance were retrieved from the local Near Cache (Near Cache hits: %ld).\n",
+                (long) stats->getHits());
     }
 
     static void waitForInvalidationEvents() {

--- a/hazelcast/test/src/TestHelperFunctions.h
+++ b/hazelcast/test/src/TestHelperFunctions.h
@@ -59,7 +59,7 @@
 #define ASSERT_NOTNULL(value, type) ASSERT_NE((type *) NULL, value)
 #define ASSERT_TRUE_EVENTUALLY(value) ASSERT_EQ_EVENTUALLY(value, true)
 #define ASSERT_FALSE_EVENTUALLY(value) ASSERT_EQ_EVENTUALLY(value, false)
-#define ASSERT_NULL_EVENTUALLY(value, type) ASSERT_EQ_EVENTUALLY(value, (type *) NULL)
+#define ASSERT_NULL_EVENTUALLY(value, type) ASSERT_EQ_EVENTUALLY((type *) NULL, value)
 #define ASSERT_NOTNULL_EVENTUALLY(value) ASSERT_NE_EVENTUALLY(value, NULL)
 
 #endif //HAZELCAST_TestHelperFunctions


### PR DESCRIPTION
Eliminates the compiler warnings for in the newly added near cache examples (happens at 64-bit Debug compilations) by casting the int64_t to long type.

Example error:
03:56:02 In file included from /home/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/examples/distributed-map/near-cache/NearCacheWithInvalidation.cpp:19:
03:56:02 /home/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/examples/distributed-map/near-cache/NearCacheSupport.h: In static member function `static void NearCacheSupport::printNearCacheStats(hazelcast::client::IMap<int, std::string>&, const char*)':
03:56:02 /home/jenkins/jenkins/workspace/cpp-linux-nightly-64-SHARED-Debug/examples/distributed-map/near-cache/NearCacheSupport.h:35: warning: long long int format, int64_t arg (arg 3)

Also fixes the expected and actual value order at ASSERT_NULL_EVENTUALLY macro.
