### PR TITLE
Release zip file size is too much

### DIFF
--- a/releaseLinux.sh
+++ b/releaseLinux.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e #abort the script at first failure
 
 echo "Cleanup release directories"
@@ -35,7 +36,6 @@ cp -R external/release_include/* cpp/Linux_32/external/include/
 
 echo "Moving 32bit examples to target"
 cp -r examples cpp/Linux_32/examples/src
-find ReleaseStatic32/examples -perm +111 -type f -exec cp {} cpp/Linux_32/examples/ \;
 
 echo "Clearing temporary 32bit libraries"
 rm -rf ./ReleaseShared32
@@ -72,7 +72,6 @@ cp -R external/release_include/* cpp/Linux_64/external/include/
 
 echo "Moving 64bit examples to target"
 cp -r examples cpp/Linux_64/examples/src
-find ReleaseStatic64/examples -perm +111 -type f -exec cp {} cpp/Linux_64/examples/ \;
 
 echo "Clearing temporary 64bit libraries"
 rm -rf ./ReleaseShared64

--- a/releaseOSX.sh
+++ b/releaseOSX.sh
@@ -37,7 +37,6 @@ cp -R external/release_include/ cpp/Mac_64/external/include/
 
 echo "Moving examples to target"
 cp -r examples cpp/Mac_64/examples/src
-find ReleaseStatic/examples -perm +111 -type f -exec cp {} cpp/Mac_64/examples/ \;
 
 #MAC SPECIFIC
 cd cpp/Mac_64/hazelcast/lib/

--- a/releaseWindows.bat
+++ b/releaseWindows.bat
@@ -36,7 +36,6 @@ xcopy /S /Q external\release_include\* cpp\Windows_32\external\include\
 
 echo "Moving 32bit examples to target"
 xcopy /S /Q examples  cpp\Windows_32\examples\src\
-for /R ReleaseStatic32\examples %%G IN (*.exe) DO xcopy "%%G" cpp\Windows_32\examples
 
 echo "Clearing temporary 32bit librares"
 rm -rf .\ReleaseShared32
@@ -76,7 +75,6 @@ xcopy /S /Q external\release_include\* cpp\Windows_64\external\include\
 
 echo "Moving 64bit examples to target"
 xcopy /S /Q examples  cpp\Windows_64\examples\src\
-for /R ReleaseStatic64\examples %%G IN (*.exe) DO xcopy "%%G" cpp\Windows_64\examples
 
 echo "Clearing tempraroy 64bit librares"
 rm -rf ./ReleaseShared64


### PR DESCRIPTION
Release zip for 3.6.3 is 127MB including examples binaries and around 33 MB without the examples binaries. Hence, we decided to not include examples binaries in the release zip. This PR removes examples binaries from released zip.