### PR TITLE
Data hash calculation causes perf decrease when using near-cache

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
@@ -66,6 +66,12 @@ namespace hazelcast {
 
                     int getPartitionHash() const;
 
+                    /**
+                     * Returns the calculated hash of the data bytes.
+                     * Caches the calculated value.
+                     */
+                    int hash() const;
+
                     bool hasPartitionHash() const;
 
                     std::vector<byte> &toByteArray() const;
@@ -74,10 +80,9 @@ namespace hazelcast {
 
                 private:
                     mutable std::auto_ptr<std::vector<byte> > data;
-                    mutable util::AtomicInt calculatedHash;
-                    mutable util::AtomicBoolean calculatedHashExist;
+                    mutable int cachedHashValue;
 
-                    int hashCode() const;
+                    inline int calculateHash() const;
                 };
             }
         }

--- a/hazelcast/src/hazelcast/util/MurmurHash3.cpp
+++ b/hazelcast/src/hazelcast/util/MurmurHash3.cpp
@@ -31,6 +31,8 @@
 
 #if defined(_MSC_VER)
 
+#define FORCE_INLINE	__forceinline
+
 #include <stdlib.h>
 
 #define ROTL32(x,y)	_rotl(x,y)
@@ -42,11 +44,13 @@
 
 #else	// defined(_MSC_VER)
 
-inline uint32_t rotl32(uint32_t x, int8_t r) {
+#define	FORCE_INLINE inline __attribute__((always_inline))
+
+FORCE_INLINE  uint32_t rotl32(uint32_t x, int8_t r) {
     return (x << r) | (x >> (32 - r));
 }
 
-inline uint64_t rotl64(uint64_t x, int8_t r) {
+FORCE_INLINE  uint64_t rotl64(uint64_t x, int8_t r) {
     return (x << r) | (x >> (64 - r));
 }
 
@@ -63,19 +67,18 @@ inline uint64_t rotl64(uint64_t x, int8_t r) {
 
 namespace hazelcast {
     namespace util {
-
-        uint32_t getblock32(const uint32_t *p, int i) {
+        FORCE_INLINE uint32_t getblock32(const uint32_t *p, int i) {
             return *(p + i);
         }
 
-        uint64_t getblock64(const uint64_t *p, int i) {
+        FORCE_INLINE uint64_t getblock64(const uint64_t *p, int i) {
             return *(p + i);
         }
 
 //-----------------------------------------------------------------------------
 // Finalization mix - force all bits of a hash block to avalanche
 
-        uint32_t fmix32(uint32_t h) {
+        FORCE_INLINE uint32_t fmix32(uint32_t h) {
             h ^= h >> 16;
             h *= 0x85ebca6b;
             h ^= h >> 13;
@@ -87,7 +90,7 @@ namespace hazelcast {
 
 //----------
 
-        uint64_t fmix64(uint64_t k) {
+        FORCE_INLINE uint64_t fmix64(uint64_t k) {
             k ^= k >> 33;
             k *= BIG_CONSTANT(0xff51afd7ed558ccd);
             k ^= k >> 33;


### PR DESCRIPTION
Based on valgrind callgrind analysis, it is found that there was a slow down on data hash calculation and caching. They are being fixed.

Changed Data hash code caching in a more efficient way. Also a minor update to murmur hash inlining.

The fix can increase the near cache 100 % hit case performance 5-6 times.