### PR TITLE
Do not loose original exception type when re-throwing an exception

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/AbstractNearCacheRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/AbstractNearCacheRecordStore.h
@@ -125,7 +125,7 @@ namespace hazelcast {
                                     }
                                 } catch (exception::IException &error) {
                                     onGetError(key, value, record, error);
-                                    throw error;
+                                    throw;
                                 }
                             }
 
@@ -157,7 +157,7 @@ namespace hazelcast {
                                     return record.get() != NULL;
                                 } catch (exception::IException &error) {
                                     onRemoveError(key, record, removed, error);
-                                    throw error;
+                                    throw;
                                 }
                             }
 
@@ -484,7 +484,7 @@ namespace hazelcast {
                                     onPut(key, value, record, oldRecord);
                                 } catch (exception::IException &error) {
                                     onPutError(key, value, record, oldRecord, error);
-                                    throw error;
+                                    throw;
                                 }
                             }
 

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -118,7 +118,7 @@ namespace hazelcast {
                         return value;
                     } catch (exception::IException &e) {
                         resetToUnmarkedState(key);
-                        throw e;
+                        throw;
                     }
                 }
 
@@ -264,7 +264,7 @@ namespace hazelcast {
                         return responses;
                     } catch (exception::IException &e) {
                         unmarkRemainingMarkedKeys(markers);
-                        throw e;
+                        throw;
                     }
                 }
 
@@ -392,7 +392,7 @@ namespace hazelcast {
                         resetToUnmarkedState(keyData);
                     } catch (exception::IException &e) {
                         resetToUnmarkedState(keyData);
-                        throw e;
+                        throw;
                     }
                 }
 

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -147,7 +147,7 @@ namespace hazelcast {
                     }
                 } catch (exception::IException &e) {
                     if (tryCount <= 0) {
-                        throw e;
+                        throw;
                     }
                 }
 
@@ -161,7 +161,7 @@ namespace hazelcast {
                     } catch (exception::IException &e) {
                         ++count;
                         if (count >= tryCount) {
-                            throw e;
+                            throw;
                         }
                     }
                 }

--- a/hazelcast/src/hazelcast/client/connection/IOSelector.cpp
+++ b/hazelcast/src/hazelcast/client/connection/IOSelector.cpp
@@ -57,7 +57,7 @@ namespace hazelcast {
                     wakeUpSocket->send(&wakeUpSignal, sizeof(int));
                 } catch(exception::IOException &e) {
                     util::ILogger::getLogger().warning(std::string("Exception at IOSelector::wakeUp ") + e.what());
-                    throw e;
+                    throw;
                 }
             }
 

--- a/hazelcast/src/hazelcast/client/spi/impl/ProxyManager.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/ProxyManager.cpp
@@ -42,7 +42,7 @@ namespace hazelcast {
                     initializeWithRetry(clientProxy);
                 } catch (exception::IException &e) {
                     proxies.remove(ns);
-                    throw e;
+                    throw;
                 }
                 return clientProxy;
             }

--- a/hazelcast/src/hazelcast/client/txn/TransactionProxy.cpp
+++ b/hazelcast/src/hazelcast/client/txn/TransactionProxy.cpp
@@ -82,7 +82,7 @@ namespace hazelcast {
                     state = TxnState::ACTIVE;
                 } catch (exception::IException &e) {
                     onTxnEnd();
-                    throw e;
+                    throw;
                 }
 
             }
@@ -132,7 +132,7 @@ namespace hazelcast {
                     state = TxnState::ROLLED_BACK;
                 } catch (exception::IException &e) {
                     onTxnEnd();
-                    throw e;
+                    throw;
                 }
                 onTxnEnd();
 

--- a/hazelcast/test/src/issues/IssueTest.cpp
+++ b/hazelcast/test/src/issues/IssueTest.cpp
@@ -121,6 +121,27 @@ namespace hazelcast {
                 ASSERT_TRUE(server.shutdown());
             }
 
+            TEST_F(IssueTest, testIssue221) {
+                // start a server
+                HazelcastServer server(*g_srvFactory);
+                
+                // start a client
+                std::auto_ptr<ClientConfig> config = getConfig();
+                HazelcastClient client(*config);
+
+                IMap<int, int> map = client.getMap<int, int>("Issue221_test_map");
+
+                server.shutdown();
+
+                try {
+                    map.get(1);
+                } catch (exception::IOException &e) {
+                    // this is the expected exception, test passes, do nothing
+                } catch (exception::IException &e) {
+                    FAIL() << "IException is received while we expect IOException. Received exception:" << e.what();
+                }
+            }
+
             void IssueTest::Issue864MapListener::entryAdded(const EntryEvent<int, int> &event) {
                 int count = latch.get();
                 if (2 == count) {


### PR DESCRIPTION
Fixes issue 221. Rethrowing the exception with variable name causes the exception to be implicitely reconstructed, hence this may cause the rethrown exception to be of base class type rather than the original exception type. More info: http://stackoverflow.com/questions/2360597/c-exceptions-questions-on-rethrow-of-original-exception

fixes #221 