### PR TITLE
Test and release builds do not show compile flags 

### DIFF
--- a/releaseLinux.sh
+++ b/releaseLinux.sh
@@ -9,14 +9,14 @@ echo "Compiling Static 32bit library"
 mkdir ReleaseStatic32;
 cd ./ReleaseStatic32;
 cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j 4;
+make -j 4 VERBOSE=1;
 cd ..;
 
 echo "Compiling Shared 32bit library"
 mkdir ReleaseShared32;
 cd ./ReleaseShared32;
 cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j 4;
+make -j 4 VERBOSE=1;
 cd ..;
 
 
@@ -45,14 +45,14 @@ echo "Compiling Static 64bit library"
 mkdir ReleaseStatic64;
 cd ./ReleaseStatic64;
 cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j 4;
+make -j 4 VERBOSE=1;
 cd ..;
 
 echo "Compiling Shared 64bit library"
 mkdir ReleaseShared64;
 cd ./ReleaseShared64;
 cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j 4;
+make -j 4 VERBOSE=1;
 cd ..;
 
 

--- a/releaseOSX.sh
+++ b/releaseOSX.sh
@@ -9,14 +9,14 @@ echo "Compiling Static Library"
 mkdir ReleaseStatic
 cd ReleaseStatic
 cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j 4
+make -j 4 VERBOSE=1
 cd ..
 
 echo "Compiling Shared Library"
 mkdir ReleaseShared
 cd ReleaseShared
 cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
-make -j 4
+make -j 4 VERBOSE=1
 cd ..
 
 #STANDART PART

--- a/testLinuxSingleCase.sh
+++ b/testLinuxSingleCase.sh
@@ -49,7 +49,7 @@ echo "Running cmake to compose Makefiles for compilation."
 cmake .. -DHZ_LIB_TYPE=${HZ_LIB_TYPE} -DHZ_BIT=${HZ_BIT_VERSION} -DCMAKE_BUILD_TYPE=${HZ_BUILD_TYPE} ${HZ_COVERAGE_STRING} -DHZ_BUILD_TESTS=ON -DHZ_BUILD_EXAMPLES=ON
 
 echo "Running make. Building the project."
-make -j 8 -l 4  # run 8 jobs in parallel and a maximum load of 4
+make -j 8 -l 4 VERBOSE=1  # run 8 jobs in parallel and a maximum load of 4
 if [ $? -ne 0 ]
 then
     echo "Client compilation failed!!!"


### PR DESCRIPTION
Added verbose flag to make command so that we can see the compile and link flags during compilation.