### PR TITLE
The nightly tests release builds are not working as release build - cmake string comparison failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,12 @@ project (HazelcastClient)
 INCLUDE(TestBigEndian)
 
 SET(HZ_VERSION 3.7.1-SNAPSHOT)
-if (${CMAKE_BUILD_TYPE})
-	message(STATUS "Build type is  ${CMAKE_BUILD_TYPE}")
-else()
-	message(STATUS "Build needs CMAKE_BUILD_TYPE. Setting default as -DCMAKE_BUILD_TYPE=Debug (other option -DCMAKE_BUILD_TYPE=Release)")	
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
+	message(STATUS "Build needs CMAKE_BUILD_TYPE. Setting default as -DCMAKE_BUILD_TYPE=Debug (other option -DCMAKE_BUILD_TYPE=Release)")
 	SET(CMAKE_BUILD_TYPE Debug)
-endif (${CMAKE_BUILD_TYPE})
+else()
+	message(STATUS "Build type is  ${CMAKE_BUILD_TYPE}")
+endif ()
 
 add_definitions(-DHAZELCAST_VERSION="${HZ_VERSION}")
 


### PR DESCRIPTION
The build type variable value detection is not working as expected after the last commit which tries to provide a default value for the build type. It does not use the provided -DCMAKE_BUILD_TYPE=Release as expected (it writes Build needs CMAKE_BUILD_TYPE. Setting default as -DCMAKE_BUILD_TYPE=Debug (other option -DCMAKE_BUILD_TYPE=Release)  but this is already provided!)

The fix handles both cases where variable is not defined and defined (can be "" empty string). See http://public.kitware.com/pipermail/cmake/2011-October/046939.html  