### PR TITLE
Incorrect Char array type number for portable serialization

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/ClassDefinitionBuilder.h
+++ b/hazelcast/include/hazelcast/client/serialization/ClassDefinitionBuilder.h
@@ -68,6 +68,8 @@ namespace hazelcast {
 
                 ClassDefinitionBuilder& addByteArrayField(const std::string& fieldName);
 
+                ClassDefinitionBuilder& addBooleanArrayField(const std::string& fieldName);
+
                 ClassDefinitionBuilder& addCharArrayField(const std::string& fieldName);
 
                 ClassDefinitionBuilder& addIntArrayField(const std::string& fieldName);

--- a/hazelcast/include/hazelcast/client/serialization/FieldType.h
+++ b/hazelcast/include/hazelcast/client/serialization/FieldType.h
@@ -53,12 +53,14 @@ namespace hazelcast {
                 static const FieldType TYPE_UTF(9);
                 static const FieldType TYPE_PORTABLE_ARRAY(10);
                 static const FieldType TYPE_BYTE_ARRAY(11);
-                static const FieldType TYPE_CHAR_ARRAY(12);
-                static const FieldType TYPE_SHORT_ARRAY(13);
-                static const FieldType TYPE_INT_ARRAY(14);
-                static const FieldType TYPE_LONG_ARRAY(15);
-                static const FieldType TYPE_FLOAT_ARRAY(16);
-                static const FieldType TYPE_DOUBLE_ARRAY(17);
+                static const FieldType TYPE_BOOLEAN_ARRAY(12);
+                static const FieldType TYPE_CHAR_ARRAY(13);
+                static const FieldType TYPE_SHORT_ARRAY(14);
+                static const FieldType TYPE_INT_ARRAY(15);
+                static const FieldType TYPE_LONG_ARRAY(16);
+                static const FieldType TYPE_FLOAT_ARRAY(17);
+                static const FieldType TYPE_DOUBLE_ARRAY(18);
+                static const FieldType TYPE_UTF_ARRAY(19);
             }
         }
     }

--- a/hazelcast/include/hazelcast/client/serialization/PortableReader.h
+++ b/hazelcast/include/hazelcast/client/serialization/PortableReader.h
@@ -134,6 +134,13 @@ namespace hazelcast {
 
                 /**
                 * @param fieldName name of the field
+                * @return the bool array value read
+                * @throws IOException
+                */
+                std::auto_ptr<std::vector<bool> > readBooleanArray(const char *fieldName);
+
+                /**
+                * @param fieldName name of the field
                 * @return the char array value read
                 * @throws IOException
                 */

--- a/hazelcast/include/hazelcast/client/serialization/PortableWriter.h
+++ b/hazelcast/include/hazelcast/client/serialization/PortableWriter.h
@@ -123,6 +123,13 @@ namespace hazelcast {
 
                 /**
                 * @param fieldName name of the field
+                * @param values bool array to be written
+                * @throws IOException
+                */
+                void writeBooleanArray(const char *fieldName, const std::vector<bool> *values);
+
+                /**
+                * @param fieldName name of the field
                 * @param values     char array to be written
                 * @throws IOException
                 */

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/ClassDefinitionWriter.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/ClassDefinitionWriter.h
@@ -74,6 +74,8 @@ namespace hazelcast {
 
                     void writeByteArray(const char *fieldName, const std::vector<byte> *values);
 
+                    void writeBooleanArray(const char *fieldName, const std::vector<bool> *values);
+
                     void writeCharArray(const char *fieldName, const std::vector<char> *data);
 
                     void writeShortArray(const char *fieldName, const std::vector<short> *data);

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/DefaultPortableWriter.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/DefaultPortableWriter.h
@@ -77,6 +77,8 @@ namespace hazelcast {
 
                     void writeByteArray(const char *fieldName, const std::vector<byte> *x);
 
+                    void writeBooleanArray(const char *fieldName, const std::vector<bool> *x);
+
                     void writeCharArray(const char *fieldName, const std::vector<char> *data);
 
                     void writeShortArray(const char *fieldName, const std::vector<short> *data);

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/PortableReaderBase.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/PortableReaderBase.h
@@ -66,6 +66,8 @@ namespace hazelcast {
 
                     virtual std::auto_ptr<std::vector<byte> > readByteArray(const char *fieldName);
 
+                    virtual std::auto_ptr<std::vector<bool> > readBooleanArray(const char *fieldName);
+
                     virtual std::auto_ptr<std::vector<char> > readCharArray(const char *fieldName);
 
                     virtual std::auto_ptr<std::vector<int> > readIntArray(const char *fieldName);

--- a/hazelcast/src/hazelcast/client/serialization/ClassDefinitionBuilder.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/ClassDefinitionBuilder.cpp
@@ -96,6 +96,11 @@ namespace hazelcast {
                 return *this;
             }
 
+            ClassDefinitionBuilder& ClassDefinitionBuilder::addBooleanArrayField(const std::string& fieldName) {
+                addField(fieldName, FieldTypes::TYPE_BOOLEAN_ARRAY);
+                return *this;
+            }
+
             ClassDefinitionBuilder& ClassDefinitionBuilder::addCharArrayField(const std::string& fieldName) {
                 addField(fieldName, FieldTypes::TYPE_CHAR_ARRAY);
                 return *this;

--- a/hazelcast/src/hazelcast/client/serialization/PortableReader.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/PortableReader.cpp
@@ -110,6 +110,13 @@ namespace hazelcast {
                 return morphingPortableReader->readByteArray(fieldName);
             }
 
+
+            std::auto_ptr<std::vector<bool> > PortableReader::readBooleanArray(const char *fieldName) {
+                if (isDefaultReader)
+                    return defaultPortableReader->readBooleanArray(fieldName);
+                return morphingPortableReader->readBooleanArray(fieldName);
+            }
+
             std::auto_ptr<std::vector<char> > PortableReader::readCharArray(const char *fieldName) {
                 if (isDefaultReader)
                     return defaultPortableReader->readCharArray(fieldName);

--- a/hazelcast/src/hazelcast/client/serialization/PortableWriter.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/PortableWriter.cpp
@@ -97,6 +97,12 @@ namespace hazelcast {
                 return classDefinitionWriter->writeByteArray(fieldName, data);
             }
 
+            void PortableWriter::writeBooleanArray(const char *fieldName, const std::vector<bool> *data) {
+                if (isDefaultWriter)
+                    return defaultPortableWriter->writeBooleanArray(fieldName, data);
+                return classDefinitionWriter->writeBooleanArray(fieldName, data);
+            }
+
             void PortableWriter::writeCharArray(const char *fieldName, const std::vector<char > *data) {
                 if (isDefaultWriter)
                     return defaultPortableWriter->writeCharArray(fieldName, data);

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/ClassDefinitionWriter.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/ClassDefinitionWriter.cpp
@@ -80,6 +80,10 @@ namespace hazelcast {
                     builder.addByteArrayField(fieldName);
                 }
 
+                void ClassDefinitionWriter::writeBooleanArray(const char *fieldName, const std::vector<bool> *values) {
+                    builder.addBooleanArrayField(fieldName);
+                }
+
                 void ClassDefinitionWriter::writeCharArray(const char *fieldName, const std::vector<char> *values) {
                     builder.addCharArrayField(fieldName);
                 }

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DefaultPortableWriter.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DefaultPortableWriter.cpp
@@ -100,6 +100,11 @@ namespace hazelcast {
                     dataOutput.writeByteArray(bytes);
                 }
 
+                void DefaultPortableWriter::writeBooleanArray(const char *fieldName, const std::vector<bool> *bytes) {
+                    setPosition(fieldName, FieldTypes::TYPE_BOOLEAN_ARRAY);
+                    dataOutput.writeBooleanArray(bytes);
+                }
+
                 void DefaultPortableWriter::writeCharArray(const char *fieldName, const std::vector<char> *data) {
                     setPosition(fieldName, FieldTypes::TYPE_CHAR_ARRAY);
                     dataOutput.writeCharArray(data);

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/PortableReaderBase.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/PortableReaderBase.cpp
@@ -105,6 +105,11 @@ namespace hazelcast {
                     return dataInput.readByteArray();
                 }
 
+                std::auto_ptr<std::vector<bool> > PortableReaderBase::readBooleanArray(const char *fieldName) {
+                    setPosition(fieldName, FieldTypes::TYPE_BOOLEAN_ARRAY);
+                    return dataInput.readBooleanArray();
+                }
+
                 std::auto_ptr<std::vector<char> > PortableReaderBase::readCharArray(const char *fieldName) {
                     setPosition(fieldName, FieldTypes::TYPE_CHAR_ARRAY);
                     return dataInput.readCharArray();

--- a/hazelcast/test/src/serialization/ClientSerializationTest.cpp
+++ b/hazelcast/test/src/serialization/ClientSerializationTest.cpp
@@ -201,6 +201,8 @@ namespace hazelcast {
                 std::vector<byte> bb(byteArray, byteArray + 3);
                 char charArray[] = {'c', 'h', 'a', 'r'};
                 std::vector<char> cc(charArray, charArray + 4);
+                char boolArray[] = {false, true, true, false};
+                std::vector<bool> ba(boolArray, boolArray + 4);
                 short shortArray[] = {3, 4, 5};
                 std::vector<short> ss(shortArray, shortArray + 3);
                 int integerArray[] = {9, 8, 7, 6};
@@ -218,7 +220,7 @@ namespace hazelcast {
                 }
                 std::vector<TestNamedPortable> nn(portableArray, portableArray + 5);
 
-                TestInnerPortable inner(bb, cc, ss, ii, ll, ff, dd, nn);
+                TestInnerPortable inner(bb, ba, cc, ss, ii, ll, ff, dd, nn);
 
                 data = serializationService.toData<TestInnerPortable>(&inner);
 
@@ -250,6 +252,8 @@ namespace hazelcast {
 
                 byte *byteArray = new byte[LARGE_ARRAY_SIZE];
                 std::vector<byte> bb(byteArray, byteArray + LARGE_ARRAY_SIZE);
+                bool *boolArray = new bool[LARGE_ARRAY_SIZE];
+                std::vector<bool> ba(boolArray, boolArray + LARGE_ARRAY_SIZE);
                 char *charArray;
                 charArray = new char[LARGE_ARRAY_SIZE];
                 std::vector<char> cc(charArray, charArray + LARGE_ARRAY_SIZE);
@@ -277,7 +281,7 @@ namespace hazelcast {
                 }
                 std::vector<TestNamedPortable> nn(portableArray, portableArray + 5);
 
-                TestInnerPortable inner(bb, cc, ss, ii, ll, ff, dd, nn);
+                TestInnerPortable inner(bb, ba, cc, ss, ii, ll, ff, dd, nn);
 
                 data = serializationService.toData<TestInnerPortable>(&inner);
 
@@ -326,6 +330,8 @@ namespace hazelcast {
 
                 byte byteArray[] = {0, 1, 2};
                 std::vector<byte> bb(byteArray, byteArray + 3);
+                bool boolArray[] = {true, true, false};
+                std::vector<bool> ba(boolArray, boolArray + 3);
                 char charArray[] = {'c', 'h', 'a', 'r'};
                 std::vector<char> cc(charArray, charArray + 4);
                 short shortArray[] = {3, 4, 5};
@@ -345,7 +351,7 @@ namespace hazelcast {
                 }
                 std::vector<TestNamedPortable> nn(portableArray, portableArray + 5);
 
-                TestInnerPortable inner(bb, cc, ss, ii, ll, ff, dd, nn);
+                TestInnerPortable inner(bb, ba, cc, ss, ii, ll, ff, dd, nn);
 
                 data = serializationService.toData<TestInnerPortable>(&inner);
 

--- a/hazelcast/test/src/serialization/Employee.cpp
+++ b/hazelcast/test/src/serialization/Employee.cpp
@@ -25,13 +25,38 @@ namespace hazelcast {
     namespace client {
         namespace test {
             Employee::Employee():age(-1), name("") {
-
             }
 
             Employee::Employee(std::string name, int age)
                     :age(age)
                     , name(name) {
+                by = 2;
+                boolean = true;
+                c = 'c';
+                s = 4;
+                i = 2000;
+                l = 321324141;
+                f = 3.14f;
+                d = 3.14334;
+                str = "Hello world";
+                utfStr = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム";
 
+                byte byteArray[] = {50, 100, 150, 200};
+                byteVec = std::vector<byte>(byteArray, byteArray + 4);
+                char charArray[] = {'c', 'h', 'a', 'r'};
+                cc = std::vector<char>(charArray, charArray + 4);
+                bool boolArray[] = {true, false, false, true};
+                ba = std::vector<bool>(boolArray, boolArray + 4);
+                short shortArray[] = {3, 4, 5};
+                ss = std::vector<short>(shortArray, shortArray + 3);
+                int integerArray[] = {9, 8, 7, 6};
+                ii = std::vector<int>(integerArray, integerArray + 4);
+                long longArray[] = {0, 1, 5, 7, 9, 11};
+                ll = std::vector<long>(longArray, longArray + 6);
+                float floatArray[] = {0.6543f, -3.56f, 45.67f};
+                ff = std::vector<float>(floatArray, floatArray + 3);
+                double doubleArray[] = {456.456, 789.789, 321.321};
+                dd = std::vector<double>(doubleArray, doubleArray + 3);
             }
 
             bool Employee::operator==(const Employee &rhs) const {
@@ -53,11 +78,71 @@ namespace hazelcast {
             void Employee::writePortable(serialization::PortableWriter &writer) const {
                 writer.writeUTF("n", &name);
                 writer.writeInt("a", age);
+
+                writer.writeByte("b", by);
+                writer.writeChar("c", c);
+                writer.writeBoolean("bo", boolean);
+                writer.writeShort("s", s);
+                writer.writeInt("i", i);
+                writer.writeLong("l", l);
+                writer.writeFloat("f", f);
+                writer.writeDouble("d", d);
+                writer.writeUTF("str", &str);
+                writer.writeUTF("utfstr", &utfStr);
+
+                writer.writeByteArray("bb", &byteVec);
+                writer.writeCharArray("cc", &cc);
+                writer.writeBooleanArray("ba", &ba);
+                writer.writeShortArray("ss", &ss);
+                writer.writeIntArray("ii", &ii);
+                writer.writeFloatArray("ff", &ff);
+                writer.writeDoubleArray("dd", &dd);
+
+                serialization::ObjectDataOutput &out = writer.getRawDataOutput();
+                out.writeObject<byte>(&by);
+                out.writeObject<char>(&c);
+                out.writeObject<bool>(&boolean);
+                out.writeObject<short>(&s);
+                out.writeObject<int>(&i);
+                out.writeObject<float>(&f);
+                out.writeObject<double>(&d);
+                out.writeObject<std::string>(&str);
+                out.writeObject<std::string>(&utfStr);
             }
 
             void Employee::readPortable(serialization::PortableReader &reader) {
                 name = *reader.readUTF("n");
                 age = reader.readInt("a");
+
+                by = reader.readByte("b");;
+                c = reader.readChar("c");;
+                boolean = reader.readBoolean("bo");;
+                s = reader.readShort("s");;
+                i = reader.readInt("i");;
+                l = reader.readLong("l");;
+                f = reader.readFloat("f");;
+                d = reader.readDouble("d");;
+                str = *reader.readUTF("str");;
+                utfStr = *reader.readUTF("utfstr");;
+
+                byteVec = *reader.readByteArray("bb");;
+                cc = *reader.readCharArray("cc");;
+                ba = *reader.readBooleanArray("ba");;
+                ss = *reader.readShortArray("ss");;
+                ii = *reader.readIntArray("ii");;
+                ff = *reader.readFloatArray("ff");;
+                dd = *reader.readDoubleArray("dd");;
+
+                serialization::ObjectDataInput &in = reader.getRawDataInput();
+                by = *in.readObject<byte>();
+                c = *in.readObject<char>();
+                boolean = *in.readObject<bool>();
+                s = *in.readObject<short>();
+                i = *in.readObject<int>();
+                f = *in.readObject<float>();
+                d = *in.readObject<double>();
+                str = *in.readObject<std::string>();
+                utfStr = *in.readObject<std::string>();
             }
 
             int Employee::getAge() const {

--- a/hazelcast/test/src/serialization/Employee.h
+++ b/hazelcast/test/src/serialization/Employee.h
@@ -57,6 +57,27 @@ namespace hazelcast {
             private:
                 int age;
                 std::string name;
+
+                // add all possible types
+                byte by;
+                bool boolean;
+                char c;
+                short s;
+                int i;
+                long l;
+                float f;
+                double d;
+                std::string str;
+                std::string utfStr;
+
+                std::vector<byte> byteVec;
+                std::vector<char> cc;
+                std::vector<bool> ba;
+                std::vector<short> ss;
+                std::vector<int> ii;
+                std::vector<long> ll;
+                std::vector<float> ff;
+                std::vector<double> dd;
             };
 
             // Compares based on the employee age

--- a/hazelcast/test/src/serialization/TestInnerPortable.cpp
+++ b/hazelcast/test/src/serialization/TestInnerPortable.cpp
@@ -24,25 +24,28 @@ namespace hazelcast {
             TestInnerPortable::TestInnerPortable() {
             }
 
-            TestInnerPortable::TestInnerPortable(const TestInnerPortable& rhs) {
+            TestInnerPortable::TestInnerPortable(const TestInnerPortable &rhs) {
                 *this = rhs;
             }
 
             TestInnerPortable::TestInnerPortable(std::vector<byte> b,
-                    std::vector<char> c,
-                    std::vector<short> s,
-                    std::vector<int> i,
-                    std::vector<long> l,
-                    std::vector<float> f,
-                    std::vector<double> d,
-                    std::vector<TestNamedPortable> n):ii(i), bb(b), cc(c), ss(s), ll(l), ff(f), dd(d), nn(n) {
+                                                 std::vector<bool> ba,
+                                                 std::vector<char> c,
+                                                 std::vector<short> s,
+                                                 std::vector<int> i,
+                                                 std::vector<long> l,
+                                                 std::vector<float> f,
+                                                 std::vector<double> d,
+                                                 std::vector<TestNamedPortable> n) : ii(i), bb(b), ba(ba), cc(c), ss(s),
+                                                                                     ll(l), ff(f), dd(d), nn(n) {
             }
 
             TestInnerPortable::~TestInnerPortable() {
             }
 
-            TestInnerPortable& TestInnerPortable::operator = (const TestInnerPortable& rhs) {
+            TestInnerPortable &TestInnerPortable::operator=(const TestInnerPortable &rhs) {
                 bb = rhs.bb;
+                ba = rhs.ba;
                 cc = rhs.cc;
                 ss = rhs.ss;
                 ii = rhs.ii;
@@ -61,8 +64,9 @@ namespace hazelcast {
                 return TestSerializationConstants::TEST_DATA_FACTORY;
             }
 
-            bool TestInnerPortable::operator ==(const TestInnerPortable& m) const {
+            bool TestInnerPortable::operator==(const TestInnerPortable &m) const {
                 if (bb != m.bb) return false;
+                if (ba != m.ba) return false;
                 if (cc != m.cc) return false;
                 if (ss != m.ss) return false;
                 if (ii != m.ii) return false;
@@ -76,14 +80,13 @@ namespace hazelcast {
                 return true;
             }
 
-
-            bool TestInnerPortable::operator !=(const TestInnerPortable& m) const {
+            bool TestInnerPortable::operator!=(const TestInnerPortable &m) const {
                 return !(*this == m);
             }
 
-
-            void TestInnerPortable::writePortable(serialization::PortableWriter& writer) const {
+            void TestInnerPortable::writePortable(serialization::PortableWriter &writer) const {
                 writer.writeByteArray("b", &bb);
+                writer.writeBooleanArray("ba", &ba);
                 writer.writeCharArray("c", &cc);
                 writer.writeShortArray("s", &ss);
                 writer.writeIntArray("i", &ii);
@@ -93,8 +96,9 @@ namespace hazelcast {
                 writer.writePortableArray("nn", &nn);
             }
 
-            void TestInnerPortable::readPortable(serialization::PortableReader& reader) {
+            void TestInnerPortable::readPortable(serialization::PortableReader &reader) {
                 bb = *reader.readByteArray("b");
+                ba = *reader.readBooleanArray("ba");
                 cc = *reader.readCharArray("c");
                 ss = *reader.readShortArray("s");
                 ii = *reader.readIntArray("i");

--- a/hazelcast/test/src/serialization/TestInnerPortable.h
+++ b/hazelcast/test/src/serialization/TestInnerPortable.h
@@ -36,7 +36,9 @@ namespace hazelcast {
 
                 TestInnerPortable(const TestInnerPortable& rhs);
 
-                TestInnerPortable(std::vector<byte> b, std::vector<char> c, std::vector<short> s, std::vector<int> i, std::vector<long> l, std::vector<float> f, std::vector<double> d, std::vector<TestNamedPortable> n);
+                TestInnerPortable(std::vector<byte> b, std::vector<bool> ba, std::vector<char> c, std::vector<short> s,
+                                  std::vector<int> i, std::vector<long> l, std::vector<float> f, std::vector<double> d,
+                                  std::vector<TestNamedPortable> n);
 
                 TestInnerPortable& operator = (const TestInnerPortable& rhs);
 
@@ -57,6 +59,7 @@ namespace hazelcast {
             private:
                 std::vector<int> ii;
                 std::vector<byte> bb;
+                std::vector<bool> ba;
                 std::vector<char> cc;
                 std::vector<short> ss;
                 std::vector<long> ll;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,6 +8,10 @@
     <artifactId>cpp-hazelcast</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>

--- a/java/src/main/java/CppClientListener.java
+++ b/java/src/main/java/CppClientListener.java
@@ -66,6 +66,27 @@ class Employee implements Portable {
     private String name;
     private int age;
 
+    // add all possible types
+    byte by = 2;
+    boolean bool = true;
+    char c = 'c';
+    short s = 4;
+    int i = 2000;
+    long l = 321324141;
+    float f = 3.14f;
+    double d = 3.14334;
+    String str = "Hello world";
+    String utfStr = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム";
+
+    byte byteArray[] = {50, 100, (byte) 150, (byte) 200};
+    char charArray[] = {'c', 'h', 'a', 'r'};
+    boolean boolArray[] = {true, false, false, true};
+    short shortArray[] = {3, 4, 5};
+    int integerArray[] = {9, 8, 7, 6};
+    long longArray[] = {0, 1, 5, 7, 9, 11};
+    float floatArray[] = {0.6543f, -3.56f, 45.67f};
+    double doubleArray[] = {456.456, 789.789, 321.321};
+
     public Employee() {
     }
 
@@ -85,11 +106,71 @@ class Employee implements Portable {
     public void writePortable(PortableWriter writer) throws IOException {
         writer.writeUTF("n", name);
         writer.writeInt("a", age);
+
+        writer.writeByte("b", by);
+        writer.writeChar("c", c);
+        writer.writeBoolean("bo", bool);
+        writer.writeShort("s", s);
+        writer.writeInt("i", i);
+        writer.writeLong("l", l);
+        writer.writeFloat("f", f);
+        writer.writeDouble("d", d);
+        writer.writeUTF("str", str);
+        writer.writeUTF("utfstr", utfStr);
+
+        writer.writeByteArray("bb", byteArray);
+        writer.writeCharArray("cc", charArray);
+        writer.writeBooleanArray("ba", boolArray);
+        writer.writeShortArray("ss", shortArray);
+        writer.writeIntArray("ii", integerArray);
+        writer.writeFloatArray("ff", floatArray);
+        writer.writeDoubleArray("dd", doubleArray);
+
+        ObjectDataOutput out = writer.getRawDataOutput();
+        out.writeObject(by);
+        out.writeObject(c);
+        out.writeObject(bool);
+        out.writeObject(s);
+        out.writeObject(i);
+        out.writeObject(f);
+        out.writeObject(d);
+        out.writeObject(str);
+        out.writeObject(utfStr);
     }
 
     public void readPortable(PortableReader reader) throws IOException {
         name = reader.readUTF("n");
         age = reader.readInt("a");
+
+        by = reader.readByte("b");;
+        c = reader.readChar("c");;
+        bool = reader.readBoolean("bo");;
+        s = reader.readShort("s");;
+        i = reader.readInt("i");;
+        l = reader.readLong("l");;
+        f = reader.readFloat("f");;
+        d = reader.readDouble("d");;
+        str = reader.readUTF("str");;
+        utfStr = reader.readUTF("utfstr");;
+
+        byteArray = reader.readByteArray("bb");;
+        charArray = reader.readCharArray("cc");;
+        boolArray = reader.readBooleanArray("ba");;
+        shortArray = reader.readShortArray("ss");;
+        integerArray = reader.readIntArray("ii");;
+        floatArray = reader.readFloatArray("ff");;
+        doubleArray = reader.readDoubleArray("dd");;
+
+        ObjectDataInput in = reader.getRawDataInput();
+        by = in.readObject();
+        c = in.readObject();
+        bool = in.readObject();
+        s = in.readObject();
+        i = in.readObject();
+        f = in.readObject();
+        d = in.readObject();
+        str = in.readObject();
+        utfStr = in.readObject();
     }
 
     public int getAge() {


### PR DESCRIPTION
Corrected the Type number at FieldType class to be the same as Java. Added read/writeBooleanArray to portable reader/writer.

Fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/230

Fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/236