### PR TITLE
Client network config getConnectionTimeout/setConnectionTimeout symbols are not included when building without SSL

### DIFF
--- a/hazelcast/src/hazelcast/client/config/ClientNetworkConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/ClientNetworkConfig.cpp
@@ -32,6 +32,7 @@ namespace hazelcast {
                 this->sslConfig = sslConfig;
                 return *this;
             }
+            #endif // HZ_BUILD_WITH_SSL
 
             int64_t ClientNetworkConfig::getConnectionTimeout() const {
                 return connectionTimeout;
@@ -41,7 +42,6 @@ namespace hazelcast {
                 this->connectionTimeout = connectionTimeoutInMillis;
                 return *this;
             }
-            #endif // HZ_BUILD_WITH_SSL
         }
     }
 }


### PR DESCRIPTION
Corrected the network config cpp file so that the getConnectionTimeout and setConnectionTimeout are defined even when no ssl.