### PR TITLE
testListenersWhenClusterDown test causes invalid owner member uuid error

### DIFF
--- a/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
@@ -198,6 +198,9 @@ namespace hazelcast {
                             std::ostringstream errorStream;
                             errorStream << "IO error  during initial connection to " << (*it) << " for owner connection =>" << e.what();
                             util::ILogger::getLogger().warning(errorStream.str());
+                            if (!clientContext.getLifecycleService().isRunning()) {
+                                throw;
+                            }
                         }
                     }
 

--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -198,7 +198,7 @@ namespace hazelcast {
                 HazelcastServer instance(*g_srvFactory);
 
                 std::auto_ptr<ClientConfig> clientConfig(getConfig());
-                clientConfig->setAttemptPeriod(1000 * 10).setConnectionAttemptLimit(100).setLogLevel(FINEST);
+                clientConfig->setAttemptPeriod(1000).setConnectionAttemptLimit(100).setLogLevel(FINEST);
                 // set the heartbeat interval to 1 seconds so that the heartbeater ClientPingCodec related code is
                 // executed for code coverage.
                 clientConfig->getProperties()[ClientProperties::PROP_HEARTBEAT_INTERVAL] = "1";
@@ -218,7 +218,7 @@ namespace hazelcast {
                 HazelcastServer instance2(*g_srvFactory);
                 ASSERT_TRUE(lifecycleLatch.await(120));
                 // Let enough time for the client to re-register the failed listeners
-                util::sleep(1);
+                util::sleep(5);
                 m.put("sample", "entry");
                 ASSERT_TRUE(countDownLatch.await(60));
                 ASSERT_TRUE(hazelcastClient.removeLifecycleListener(&lifecycleListener));


### PR DESCRIPTION
Java server rejects the non-owner authentication request with: Member having uuid 294fcb20-33ed-42ec-93bf-c45cd3440889 is not part of the cluster. Client Authentication rejected.

Added ensureOwnerConnectionAvailable functionality to connection manager.