### PR TITLE
ConditionVariable::waitFor pthread_cond_timedwait may fail with EINVAL 

### DIFF
--- a/hazelcast/src/hazelcast/util/ConditionVariable.cpp
+++ b/hazelcast/src/hazelcast/util/ConditionVariable.cpp
@@ -100,7 +100,7 @@ namespace hazelcast {
             } else {
                 ts.tv_sec += (time_t) (timeInMilliseconds / MILLIS_IN_A_SECOND);
                 long nsec = tv.tv_usec * NANOS_IN_A_USECOND + (timeInMilliseconds % 1000) * NANOS_IN_A_MILLISECOND;
-                if (nsec > NANOS_IN_A_SECOND) {
+                if (nsec >= NANOS_IN_A_SECOND) {
                     nsec -= NANOS_IN_A_SECOND;
                     ++ts.tv_sec;
                 }

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -76,6 +76,18 @@ namespace hazelcast {
 
             }
 
+            TEST_F(ClientUtilTest, testConditionVariableForEINVAL) {
+                util::Mutex mutex;
+                util::ConditionVariable conditionVariable;
+                int wakeUpTime = 1;
+                util::Thread thread(wakeTheConditionUp, &mutex, &conditionVariable, &wakeUpTime);
+                {
+                    util::LockGuard lockGuard(mutex);
+                    // the following call should not fail with assertion for EINVAL
+                    conditionVariable.waitFor(mutex, 19999);
+                }
+            }
+
             TEST_F (ClientUtilTest, testFutureWaitTimeout) {
                 util::Future<int> future;
                 int waitSeconds = 3;


### PR DESCRIPTION
ConditionVariable::waitFor pthread_cond_timedwait fails with EINVAL when timeInMilliseconds=19999.

Variable values when error condition occured:
 tv = {tv_sec = 1490404653, tv_usec = 1000}
ts = {tv_sec = 1490404672, tv_nsec = 1000000000}
         seconds = 19
         error = 22

This was sometimes observed during nightly debug test builds.