### PR TITLE
32-bit compilation using gcc 4.1.2 causes non-virtual destructor and ‘int’ over ‘long int’ usage warnings

### DIFF
--- a/hazelcast/include/hazelcast/client/impl/ExecutionCallback.h
+++ b/hazelcast/include/hazelcast/client/impl/ExecutionCallback.h
@@ -42,6 +42,8 @@ namespace hazelcast {
             template <typename V>
             class HAZELCAST_API ExecutionCallback {
             public:
+                virtual ~ExecutionCallback() { }
+
                 /**
                  * Called when an execution is completed successfully.
                  *

--- a/hazelcast/include/hazelcast/client/internal/eviction/Evictable.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/Evictable.h
@@ -34,6 +34,8 @@ namespace hazelcast {
                 template <typename V>
                 class Evictable {
                 public:
+                    virtual ~Evictable() { }
+
                     /**
                      * Gets the creation time of this {@link Evictable} in milliseconds.
                      *

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictableEntryView.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictableEntryView.h
@@ -39,6 +39,8 @@ namespace hazelcast {
                 template <typename K, typename V>
                 class EvictableEntryView {
                 public:
+                    virtual ~EvictableEntryView() { }
+
                     /**
                      * Gets the creation time of this {@link EvictableEntryView} in milliseconds.
                      *

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionChecker.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionChecker.h
@@ -34,6 +34,8 @@ namespace hazelcast {
                  */
                 class HAZELCAST_API EvictionChecker {
                 public:
+                    virtual ~EvictionChecker() { }
+
                     /**
                      * Empty {@link} EvictionChecker to allow eviction always.
                      */

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionConfiguration.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionConfiguration.h
@@ -37,6 +37,8 @@ namespace hazelcast {
                 template <typename K, typename V>
                 class EvictionConfiguration {
                 public:
+                    virtual ~EvictionConfiguration() { }
+
                     /**
                      * Gets the type of eviction strategy.
                      *

--- a/hazelcast/include/hazelcast/client/internal/eviction/MaxSizeChecker.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/MaxSizeChecker.h
@@ -32,6 +32,8 @@ namespace hazelcast {
                  */
                 class HAZELCAST_API MaxSizeChecker {
                 public:
+                    virtual ~MaxSizeChecker() { }
+
                     /**
                      * Checks the state to see if it has reached its maximum configured size
                      * {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy}

--- a/hazelcast/include/hazelcast/client/internal/nearcache/NearCacheRecord.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/NearCacheRecord.h
@@ -49,6 +49,8 @@ namespace hazelcast {
                 public:
                     static const int64_t TIME_NOT_SET = -1;
 
+                    virtual ~NearCacheRecord() { }
+
                     /**
                      * Sets the value of this {@link NearCacheRecord}.
                      *

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
@@ -151,7 +151,7 @@ namespace hazelcast {
                                                                                             serializationService));
                                 default:
                                     std::ostringstream out;
-                                    out << "Invalid in memory format: " << inMemoryFormat;
+                                    out << "Invalid in memory format: " << (int) inMemoryFormat;
                                     throw exception::IllegalArgumentException(out.str());
                             }
                         }

--- a/hazelcast/include/hazelcast/client/map/impl/nearcache/KeyStateMarker.h
+++ b/hazelcast/include/hazelcast/client/map/impl/nearcache/KeyStateMarker.h
@@ -45,6 +45,8 @@ namespace hazelcast {
                      */
                     class HAZELCAST_API KeyStateMarker {
                     public:
+                        virtual ~KeyStateMarker() {}
+
                         virtual bool tryMark(const serialization::pimpl::Data &key) = 0;
 
                         virtual bool tryUnmark(const serialization::pimpl::Data &key) = 0;

--- a/hazelcast/include/hazelcast/client/protocol/IMessageHandler.h
+++ b/hazelcast/include/hazelcast/client/protocol/IMessageHandler.h
@@ -40,6 +40,8 @@ namespace hazelcast {
 
             class HAZELCAST_API IMessageHandler {
             public:
+                virtual ~IMessageHandler() { }
+
                 virtual void handleMessage(connection::Connection &connection, std::auto_ptr<ClientMessage> message) = 0;
             };
         }

--- a/hazelcast/include/hazelcast/client/protocol/codec/IAddListenerCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/IAddListenerCodec.h
@@ -33,6 +33,8 @@ namespace hazelcast {
             namespace codec {
                 class IAddListenerCodec {
                 public:
+                    virtual ~IAddListenerCodec() { }
+
                     virtual std::auto_ptr<ClientMessage> encodeRequest() const = 0;
 
                     virtual std::string decodeResponse(ClientMessage &responseMessage) const = 0;

--- a/hazelcast/include/hazelcast/client/protocol/codec/IRemoveListenerCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/IRemoveListenerCodec.h
@@ -33,6 +33,8 @@ namespace hazelcast {
             namespace codec {
                 class IRemoveListenerCodec {
                 public:
+                    virtual ~IRemoveListenerCodec() { }
+
                     virtual std::auto_ptr<ClientMessage> encodeRequest() const = 0;
 
                     virtual bool decodeResponse(ClientMessage &clientMessage) const = 0;

--- a/hazelcast/include/hazelcast/client/serialization/IdentifiedDataSerializable.h
+++ b/hazelcast/include/hazelcast/client/serialization/IdentifiedDataSerializable.h
@@ -45,7 +45,6 @@ namespace hazelcast {
                  * Destructor
                  */
                 virtual ~IdentifiedDataSerializable(){
-
                 }
 
                 /**

--- a/hazelcast/include/hazelcast/client/spi/ClientProxyFactory.h
+++ b/hazelcast/include/hazelcast/client/spi/ClientProxyFactory.h
@@ -41,6 +41,8 @@ namespace hazelcast {
              */
             class HAZELCAST_API ClientProxyFactory {
             public:
+                virtual ~ClientProxyFactory() { }
+
                 /**
                  * Creates a new client proxy with the given id.
                  *

--- a/hazelcast/include/hazelcast/client/spi/InitializingObject.h
+++ b/hazelcast/include/hazelcast/client/spi/InitializingObject.h
@@ -34,6 +34,8 @@ namespace hazelcast {
              */
             class HAZELCAST_API InitializingObject {
             public:
+                virtual ~InitializingObject() { }
+
                 virtual void initialize() = 0;
             };
         }

--- a/hazelcast/include/hazelcast/client/spi/ObjectNamespace.h
+++ b/hazelcast/include/hazelcast/client/spi/ObjectNamespace.h
@@ -34,6 +34,8 @@ namespace hazelcast {
              */
             class HAZELCAST_API ObjectNamespace {
             public:
+                virtual ~ObjectNamespace() { }
+
                 /**
                  * Gets the service name.
                  *

--- a/hazelcast/include/hazelcast/client/topic/MessageListener.h
+++ b/hazelcast/include/hazelcast/client/topic/MessageListener.h
@@ -41,6 +41,8 @@ namespace hazelcast {
             template <typename E>
             class MessageListener {
             public:
+                virtual ~MessageListener() { }
+
                 /**
                 * Invoked when a message is received for the added topic. Note that topic guarantees message ordering.
                 * Therefore there is only one thread invoking onMessage. The user should not keep the thread busy, but preferably

--- a/hazelcast/include/hazelcast/util/Comparator.h
+++ b/hazelcast/include/hazelcast/util/Comparator.h
@@ -24,6 +24,8 @@ namespace hazelcast {
         template <typename T>
         class Comparator {
         public:
+            virtual ~Comparator() { }
+
             /**
              * @lhs First value to compare
              * @rhs Second value to compare


### PR DESCRIPTION
Added the missing virtual destructors. Changed exception string formatting in DefaultNearCache so that there is no warning at 32-bit compiler.

When compiled using gcc 4.8.1 the compilation produces the following warnings:
KeyStateMarker.h:46: warning: ‘class hazelcast::client::map::impl::nearcache::KeyStateMarker’ has virtual functions but non-virtual destructor

DefaultNearCache.h:154: warning: passing ‘hazelcast::client::config::InMemoryFormat’ chooses ‘int’ over ‘long int’