### PR TITLE
ClusterTest.testListenersWhenClusterDown fails at linux when using 32-bit Release type library

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -243,8 +243,9 @@ namespace hazelcast {
 
 
             boost::shared_ptr<Connection> ConnectionManager::getOrConnectResolved(const Address &address) {
+                // TODO: Commented out until issue https://github.com/hazelcast/hazelcast-cpp-client/issues/258 is resolved
                 // ensureOwnerConnectionAvailable
-                ownerConnectionFuture.getOrWaitForCreation();
+                // ownerConnectionFuture.getOrWaitForCreation();
 
                 boost::shared_ptr<Connection> conn = connections.get(address);
                 if (conn.get() == NULL) {


### PR DESCRIPTION
The fix is related to issue https://github.com/hazelcast/hazelcast-cpp-client/issues/258 It may not fix the issue completely but it will behave more closely with the Java client on invocation logic during cluster disconnects.

Changed the responsibility of owner connection ensure from connection manager to invocation service as it is done for Java client. Also, do not wait for owner connection if it does not exist but just throw an exception as performed in java and rely on invocation retry mechanism.