### PR TITLE
CppClientListener does not work with Hazelcast 3.7 jar

### DIFF
--- a/java/src/main/java/CppClientListener.java
+++ b/java/src/main/java/CppClientListener.java
@@ -36,7 +36,6 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.ssl.TestKeyStoreUtil;
-import com.hazelcast.spi.properties.GroupProperty;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -533,7 +532,9 @@ public class CppClientListener {
     public static void main(String args[]) throws IOException {
         final Map<Integer, HazelcastInstance> map = new HashMap<Integer, HazelcastInstance>();
         final Config config = prepareConfig();
-        GroupProperty.ENTERPRISE_LICENSE_KEY.setSystemProperty(args[0]);
+        if (args.length >= 1) {
+            System.setProperty("hazelcast.enterprise.license.key", args[0]);
+        }
         final AtomicInteger atomicInteger = new AtomicInteger(0);
         final ServerSocket welcomeSocket = new ServerSocket(6543);
         System.out.println(welcomeSocket.getLocalSocketAddress());


### PR DESCRIPTION
Removed the dependency from GroupProperty whose package changed from Hazelcast 3.7 to 3.8. Also made setting the license only if the command line argument is provided.

The change is needed when running the compatibility tests.