### PR TITLE
Examples cmake minimum required version can be changed to 2.6.4

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 2.6.4)
 project (HazelcastExamples)
 
 INCLUDE(TestBigEndian)


### PR DESCRIPTION
Change examples minimum required cmake version to 2.6.4 as this is the case for the master CMakeLists.txt.