### PR TITLE
Type stack_st_SSL_CIPHER does not exist at earlier openssl versions (e.g. 0.9.8e)

### DIFF
--- a/hazelcast/src/hazelcast/client/internal/socket/SSLSocket.cpp
+++ b/hazelcast/src/hazelcast/client/internal/socket/SSLSocket.cpp
@@ -157,7 +157,7 @@ namespace hazelcast {
                 }
 
                 std::vector<SSLSocket::CipherInfo> SSLSocket::getCiphers() const {
-                    stack_st_SSL_CIPHER *ciphers = SSL_get_ciphers(socket->native_handle());
+                    STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(socket->native_handle());
                     std::vector<CipherInfo> supportedCiphers;
                     for (int i = 0; i < sk_SSL_CIPHER_num (ciphers); ++i) {
                         struct SSLSocket::CipherInfo info;


### PR DESCRIPTION
Use a more portable ssl type name when retrieving the ciphers. This is needed when compiling the library on CentOS 5 which comes with openssl 0.9.8.

The STACK_OF(SSL_CIPHER) macro is more portable.