### PR TITLE
No need to wait for test server availability if the test has no dependency on the server

### DIFF
--- a/hazelcast/test/src/HazelcastServerFactory.h
+++ b/hazelcast/test/src/HazelcastServerFactory.h
@@ -26,6 +26,7 @@
 #include "hazelcast/client/Socket.h"
 #include "hazelcast/client/connection/OutputSocketStream.h"
 #include "hazelcast/client/connection/InputSocketStream.h"
+#include "hazelcast/client/internal/socket/TcpSocket.h"
 
 namespace hazelcast {
     namespace util {
@@ -60,11 +61,14 @@ namespace hazelcast {
                 ~HazelcastServerFactory();
 
             private:
+                void checkConnection();
+
                 Address address;
-                std::auto_ptr<Socket> socket;
+                internal::socket::TcpSocket socket;
                 connection::OutputSocketStream outputSocketStream;
                 connection::InputSocketStream inputSocketStream;
                 util::ILogger &logger;
+                bool connected;
 
                 void shutdownInstance(int id);
             };


### PR DESCRIPTION
Removed the requirement that the test server needs to be up when starting a test that does not require server side connection.