### PR TITLE
Warning at Windows builds - Warning 4251, 4003 and missing dllexports

### DIFF
--- a/examples/distributed-map/near-cache/NearCacheSupport.h
+++ b/examples/distributed-map/near-cache/NearCacheSupport.h
@@ -21,6 +21,7 @@
 #define HAZELCASTCLIENT_NEARCACHESUPPORT_H
 
 #include <stdio.h>
+#include <stdint.h>
 
 #include <hazelcast/client/HazelcastAll.h>
 
@@ -50,7 +51,7 @@ public:
     }
 
     static void waitForNearCacheEvictionCount(hazelcast::client::IMap<int, std::string> &map, int64_t expectedEvictionCount) {
-        long evictionCount;
+        int64_t evictionCount;
         do {
             hazelcast::client::monitor::NearCacheStats *stats = map.getLocalMapStats().getNearCacheStats();
             evictionCount = stats->getEvictions();

--- a/hazelcast/include/hazelcast/client/IdGenerator.h
+++ b/hazelcast/include/hazelcast/client/IdGenerator.h
@@ -67,9 +67,9 @@ namespace hazelcast {
         private:
 
             IAtomicLong atomicLong;
-            boost::shared_ptr< util::AtomicInt > local;
-            boost::shared_ptr< util::AtomicInt > residue;
-            boost::shared_ptr< util::Mutex > localLock;
+            boost::shared_ptr<util::Atomic<int64_t> > local;
+            boost::shared_ptr<util::AtomicInt> residue;
+            boost::shared_ptr<util::Mutex> localLock;
             IdGenerator(const std::string &instanceName, spi::ClientContext *context);
 
             void onDestroy();

--- a/hazelcast/include/hazelcast/client/connection/CallFuture.h
+++ b/hazelcast/include/hazelcast/client/connection/CallFuture.h
@@ -24,6 +24,11 @@
 #include <boost/shared_ptr.hpp>
 #include <stdint.h>
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace protocol {
@@ -69,9 +74,12 @@ namespace hazelcast {
                 spi::InvocationService* invocationService;
                 int heartBeatTimeout;
             };
-
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_CallFuture

--- a/hazelcast/include/hazelcast/client/connection/CallPromise.h
+++ b/hazelcast/include/hazelcast/client/connection/CallPromise.h
@@ -25,6 +25,11 @@
 
 #include <memory>
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace protocol {
@@ -34,7 +39,7 @@ namespace hazelcast {
             class BaseEventHandler;
         };
         namespace connection {
-            class CallPromise {
+            class HAZELCAST_API CallPromise {
             public:
                 CallPromise();
 
@@ -65,8 +70,11 @@ namespace hazelcast {
             };
         }
     }
-
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_ClientCallPromise
 

--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -35,6 +35,12 @@
 #include "hazelcast/client/protocol/IMessageHandler.h"
 #include "hazelcast/client/protocol/ClientMessage.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#pragma warning(disable: 4003) //for  not enough actual parameters for macro 'min' in asio wait_traits
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace spi {
@@ -120,10 +126,13 @@ namespace hazelcast {
 
                 int connectionId;
             };
-
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_CONNECTION
 

--- a/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
+++ b/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
@@ -41,6 +41,7 @@
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
 #pragma warning(disable: 4251) //for dll export
+#pragma warning(disable: 4003) //for  not enough actual parameters for macro 'min' in asio wait_traits
 #endif
 
 namespace hazelcast {

--- a/hazelcast/include/hazelcast/client/connection/IOHandler.h
+++ b/hazelcast/include/hazelcast/client/connection/IOHandler.h
@@ -21,6 +21,8 @@
 #define HAZELCAST_IOHandler
 
 #include "hazelcast/client/connection/ListenerTask.h"
+#include "hazelcast/util/HazelcastDll.h"
+
 #include <string>
 
 namespace hazelcast {
@@ -30,7 +32,7 @@ namespace hazelcast {
 
             class Connection;
 
-            class IOHandler : public ListenerTask {
+            class HAZELCAST_API IOHandler : public ListenerTask {
             public:
 
                 IOHandler(Connection &connection, IOSelector & ioSelector);

--- a/hazelcast/include/hazelcast/client/connection/ReadHandler.h
+++ b/hazelcast/include/hazelcast/client/connection/ReadHandler.h
@@ -20,6 +20,7 @@
 #ifndef HAZELCAST_ReadHandler
 #define HAZELCAST_ReadHandler
 
+#include "hazelcast/util/HazelcastDll.h"
 #include "hazelcast/util/ByteBuffer.h"
 #include "hazelcast/client/connection/IOHandler.h"
 #include "hazelcast/client/protocol/ClientMessageBuilder.h"
@@ -37,7 +38,7 @@ namespace hazelcast {
 
             class InSelector;
 
-            class ReadHandler : public IOHandler {
+            class HAZELCAST_API ReadHandler : public IOHandler {
             public:
                 ReadHandler(Connection &connection, InSelector &iListener, size_t bufferSize, spi::ClientContext& clientContext);
 

--- a/hazelcast/include/hazelcast/client/connection/WriteHandler.h
+++ b/hazelcast/include/hazelcast/client/connection/WriteHandler.h
@@ -27,6 +27,7 @@
 #include "hazelcast/util/ConcurrentQueue.h"
 #include "hazelcast/client/connection/IOHandler.h"
 #include "hazelcast/util/AtomicBoolean.h"
+#include "hazelcast/util/HazelcastDll.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -47,7 +48,7 @@ namespace hazelcast {
 
             class OutSelector;
 
-            class WriteHandler : public IOHandler {
+            class HAZELCAST_API WriteHandler : public IOHandler {
             public:
                 WriteHandler(Connection &connection, OutSelector &oListener, size_t bufferSize);
 

--- a/hazelcast/include/hazelcast/client/internal/socket/SSLSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SSLSocket.h
@@ -18,11 +18,6 @@
 
 #ifdef HZ_BUILD_WITH_SSL
 
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(push)
-#pragma warning(disable: 4251) //for dll export
-#endif
-
 #include <asio.hpp>
 #include <asio/ssl.hpp>
 
@@ -32,6 +27,12 @@
 
 #if !defined(MSG_NOSIGNAL)
 #  define MSG_NOSIGNAL 0
+#endif
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#pragma warning(disable: 4003) //for  not enough actual parameters for macro 'min' in asio wait_traits
 #endif
 
 namespace hazelcast {

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -263,7 +263,7 @@ namespace hazelcast {
                         unmarkRemainingMarkedKeys(markers);
 
                         return responses;
-                    } catch (exception::IException &e) {
+                    } catch (exception::IException &) {
                         unmarkRemainingMarkedKeys(markers);
                         throw;
                     }
@@ -391,7 +391,7 @@ namespace hazelcast {
                     try {
                         nearCache->put(keyData, response);
                         resetToUnmarkedState(keyData);
-                    } catch (exception::IException &e) {
+                    } catch (exception::IException &) {
                         resetToUnmarkedState(keyData);
                         throw;
                     }

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessageBuilder.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessageBuilder.h
@@ -32,6 +32,11 @@
 #include <stdint.h>
 #include <memory>
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
 namespace hazelcast {
     namespace util {
         class ByteBuffer;
@@ -44,7 +49,7 @@ namespace hazelcast {
         namespace protocol {
             class IMessageHandler;
 
-            class ClientMessageBuilder {
+            class HAZELCAST_API ClientMessageBuilder {
 
             public:
                 ClientMessageBuilder(IMessageHandler &service, connection::Connection &connection);
@@ -86,5 +91,10 @@ namespace hazelcast {
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
 #endif //HAZELCAST_CLIENT_MESSAGE_BUILDER
 

--- a/hazelcast/include/hazelcast/client/protocol/codec/IAddListenerCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/IAddListenerCodec.h
@@ -25,13 +25,15 @@
 #include <memory>
 #include <string>
 
+#include "hazelcast/util/HazelcastDll.h"
+
 namespace hazelcast {
     namespace client {
         namespace protocol {
             class ClientMessage;
 
             namespace codec {
-                class IAddListenerCodec {
+                class HAZELCAST_API IAddListenerCodec {
                 public:
                     virtual ~IAddListenerCodec() { }
 

--- a/hazelcast/include/hazelcast/client/protocol/codec/IRemoveListenerCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/IRemoveListenerCodec.h
@@ -25,13 +25,15 @@
 #include <memory>
 #include <string>
 
+#include "hazelcast/util/HazelcastDll.h"
+
 namespace hazelcast {
     namespace client {
         namespace protocol {
             class ClientMessage;
 
             namespace codec {
-                class IRemoveListenerCodec {
+                class HAZELCAST_API IRemoveListenerCodec {
                 public:
                     virtual ~IRemoveListenerCodec() { }
 

--- a/hazelcast/src/hazelcast/client/IdGenerator.cpp
+++ b/hazelcast/src/hazelcast/client/IdGenerator.cpp
@@ -21,7 +21,7 @@ namespace hazelcast {
         IdGenerator::IdGenerator(const std::string& instanceName, spi::ClientContext *context)
         : proxy::ProxyImpl("idGeneratorService", instanceName, context)
         , atomicLong("hz:atomic:idGenerator:" + instanceName, context)
-        , local(new util::AtomicInt(-1))
+        , local(new util::Atomic<int64_t>(-1))
         , residue(new util::AtomicInt(BLOCK_SIZE))
         , localLock(new util::Mutex) {
 
@@ -32,7 +32,7 @@ namespace hazelcast {
             if (id <= 0) {
                 return false;
             }
-            long step = (id / BLOCK_SIZE);
+            int64_t step = (id / BLOCK_SIZE);
 
             util::LockGuard lg(*localLock);
             bool init = atomicLong.compareAndSet(0, step + 1);

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -187,7 +187,7 @@ namespace hazelcast {
                             return connection;
                         }
                     }
-                } catch (exception::IException &e) {
+                } catch (exception::IException &) {
                     checkLive();
 
                     if (tryCount <= 0) {
@@ -202,7 +202,7 @@ namespace hazelcast {
                         if (conn.get() != (Connection *) NULL && conn->live) {
                             return conn;
                         }
-                    } catch (exception::IException &e) {
+                    } catch (exception::IException &) {
                         checkLive();
 
                         ++count;

--- a/hazelcast/src/hazelcast/client/spi/impl/ProxyManager.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/ProxyManager.cpp
@@ -40,7 +40,7 @@ namespace hazelcast {
                 }
                 try {
                     initializeWithRetry(clientProxy);
-                } catch (exception::IException &e) {
+                } catch (exception::IException &) {
                     proxies.remove(ns);
                     throw;
                 }

--- a/hazelcast/src/hazelcast/client/txn/TransactionProxy.cpp
+++ b/hazelcast/src/hazelcast/client/txn/TransactionProxy.cpp
@@ -80,7 +80,7 @@ namespace hazelcast {
 
                     txnId = result.response;
                     state = TxnState::ACTIVE;
-                } catch (exception::IException &e) {
+                } catch (exception::IException &) {
                     onTxnEnd();
                     throw;
                 }
@@ -130,7 +130,7 @@ namespace hazelcast {
                     } catch (std::exception &) {
                     }
                     state = TxnState::ROLLED_BACK;
-                } catch (exception::IException &e) {
+                } catch (exception::IException &) {
                     onTxnEnd();
                     throw;
                 }

--- a/hazelcast/test/src/issues/IssueTest.cpp
+++ b/hazelcast/test/src/issues/IssueTest.cpp
@@ -135,7 +135,7 @@ namespace hazelcast {
 
                 try {
                     map.get(1);
-                } catch (exception::IOException &e) {
+                } catch (exception::IOException &) {
                     // this is the expected exception, test passes, do nothing
                 } catch (exception::IException &e) {
                     FAIL() << "IException is received while we expect IOException. Received exception:" << e.what();

--- a/hazelcast/test/src/serialization/ClientSerializationTest.cpp
+++ b/hazelcast/test/src/serialization/ClientSerializationTest.cpp
@@ -203,7 +203,7 @@ namespace hazelcast {
                 std::vector<byte> bb(byteArray, byteArray + 3);
                 char charArray[] = {'c', 'h', 'a', 'r'};
                 std::vector<char> cc(charArray, charArray + 4);
-                char boolArray[] = {false, true, true, false};
+                bool boolArray[] = {false, true, true, false};
                 std::vector<bool> ba(boolArray, boolArray + 4);
                 int16_t shortArray[] = {3, 4, 5};
                 std::vector<int16_t> ss(shortArray, shortArray + 3);

--- a/hazelcast/test/src/serialization/TestInvalidReadPortable.h
+++ b/hazelcast/test/src/serialization/TestInvalidReadPortable.h
@@ -21,6 +21,7 @@
 
 #include "hazelcast/client/serialization/Portable.h"
 #include <string>
+#include <stdint.h>
 
 namespace hazelcast {
     namespace client {
@@ -40,8 +41,8 @@ namespace hazelcast {
 
                 void readPortable(serialization::PortableReader& reader);
             private:
-                long l;
-                int i;
+                int64_t l;
+                int32_t i;
                 std::string s;
             };
         }

--- a/hazelcast/test/src/serialization/TestInvalidWritePortable.h
+++ b/hazelcast/test/src/serialization/TestInvalidWritePortable.h
@@ -21,6 +21,7 @@
 
 #include "hazelcast/client/serialization/Portable.h"
 #include <string>
+#include <stdint.h>
 
 namespace hazelcast {
     namespace client {
@@ -39,8 +40,8 @@ namespace hazelcast {
 
                 void readPortable(serialization::PortableReader& reader);
 
-                long l;
-                int i;
+                int64_t l;
+                int32_t i;
                 std::string s;
             };
         }

--- a/hazelcast/test/src/serialization/TestMainPortable.cpp
+++ b/hazelcast/test/src/serialization/TestMainPortable.cpp
@@ -25,7 +25,7 @@ namespace hazelcast {
             :null(true) {
             }
 
-            TestMainPortable::TestMainPortable(byte b, bool boolean, char c, short s, int i, long l, float f, double d, std::string str, TestInnerPortable p) {
+            TestMainPortable::TestMainPortable(byte b, bool boolean, char c, short s, int i, int64_t l, float f, double d, std::string str, TestInnerPortable p) {
                 null = false;
                 this->b = b;
                 this->boolean = boolean;

--- a/hazelcast/test/src/serialization/TestMainPortable.h
+++ b/hazelcast/test/src/serialization/TestMainPortable.h
@@ -26,6 +26,7 @@
 
 #include "TestInnerPortable.h"
 #include <string>
+#include <stdint.h>
 
 namespace hazelcast {
     namespace client {
@@ -35,7 +36,7 @@ namespace hazelcast {
 
                 TestMainPortable();
 
-                TestMainPortable(byte b, bool boolean, char c, short s, int i, long l, float f, double d, std::string str, TestInnerPortable p);
+                TestMainPortable(byte b, bool boolean, char c, short s, int i, int64_t l, float f, double d, std::string str, TestInnerPortable p);
 
                 bool operator ==(const TestMainPortable &m) const;
 
@@ -57,7 +58,7 @@ namespace hazelcast {
                 bool boolean;
                 char c;
                 short s;
-                long l;
+                int64_t l;
                 float f;
                 double d;
                 std::string str;

--- a/hazelcast/test/src/serialization/TestRawDataPortable.cpp
+++ b/hazelcast/test/src/serialization/TestRawDataPortable.cpp
@@ -57,7 +57,7 @@ namespace hazelcast {
                 ds.readData(in);
             }
 
-            TestRawDataPortable::TestRawDataPortable(long l, std::vector<char> c, TestNamedPortable p, int k, std::string s, TestDataSerializable ds) {
+            TestRawDataPortable::TestRawDataPortable(int64_t l, std::vector<char> c, TestNamedPortable p, int32_t k, std::string s, TestDataSerializable ds) {
                 this->l = l;
                 this->c = c;
                 this->p = p;

--- a/hazelcast/test/src/serialization/TestRawDataPortable.h
+++ b/hazelcast/test/src/serialization/TestRawDataPortable.h
@@ -22,6 +22,7 @@
 #include "TestNamedPortable.h"
 #include "TestDataSerializable.h"
 #include <vector>
+#include <stdint.h>
 
 namespace hazelcast {
     namespace client {
@@ -39,16 +40,16 @@ namespace hazelcast {
 
                 void readPortable(serialization::PortableReader &reader);
 
-                TestRawDataPortable(long l, std::vector<char> c, TestNamedPortable p, int k, std::string s, TestDataSerializable ds);
+                TestRawDataPortable(int64_t l, std::vector<char> c, TestNamedPortable p, int32_t k, std::string s, TestDataSerializable ds);
 
                 bool operator ==(const TestRawDataPortable &m) const;
 
                 bool operator !=(const TestRawDataPortable &m) const;
 
-                long l;
+                int64_t l;
                 std::vector<char> c;
                 TestNamedPortable p;
-                int k;
+                int32_t k;
                 std::string s;
                 TestDataSerializable ds;
             };

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -138,7 +138,7 @@ namespace hazelcast {
                 try {
                     future.get();
                     FAIL();
-                } catch (exception::IException &e) {
+                } catch (exception::IException &) {
                     // expect exception here
                 }
             }


### PR DESCRIPTION
Fixes for windows warnings. Suppresses missing warning 4251 (dll export) and 40003 (not enough actual parameters for macro 'min' in asio wait_traits) Added some missing HAZELCAST_API dllexport statements.