### PR TITLE
Enum print when compiling 32-bit causes warning at gcc 4.1.2

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyEvaluatorProvider.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyEvaluatorProvider.h
@@ -88,7 +88,7 @@ namespace hazelcast {
                                 return boost::shared_ptr<EvictionPolicyComparator<A, E> >();
                             default:
                                 std::ostringstream out;
-                                out << "Unsupported eviction policy type: " << evictionPolicyType;
+                                out << "Unsupported eviction policy type: " << (int) evictionPolicyType;
                                 throw exception::IllegalArgumentException(out.str());
                         }
                     }

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.h
@@ -88,9 +88,9 @@ namespace hazelcast {
                                                     *ANCRS::records));
                                 }
                                 std::ostringstream out;
-                                out << "Invalid max-size policy " << '(' << maxSizePolicy << ") for " <<
-                                nearCacheConfig.getName() << "! Only " << config::EvictionConfig<K, V>::ENTRY_COUNT <<
-                                " is supported.";
+                                out << "Invalid max-size policy " << '(' << (int) maxSizePolicy << ") for " <<
+                                nearCacheConfig.getName() << "! Only " <<
+                                        (int) config::EvictionConfig<K, V>::ENTRY_COUNT << " is supported.";
                                 throw exception::IllegalArgumentException(out.str());
                             }
 


### PR DESCRIPTION
Cast enum explicitly to avoid warning when compiling 32-bit at gcc 4.1.2