### PR TITLE
Do not include AwsConfigTest to the build if SSL is enabled

### DIFF
--- a/hazelcast/test/src/config/AwsConfigTest.cpp
+++ b/hazelcast/test/src/config/AwsConfigTest.cpp
@@ -17,6 +17,8 @@
 // Created by İhsan Demir on 17/05/15.
 //
 
+#ifdef HZ_BUILD_WITH_SSL
+
 #include <cmath>
 #include <gtest/gtest.h>
 
@@ -98,3 +100,4 @@ namespace hazelcast {
         }
     }
 }
+#endif // HZ_BUILD_WITH_SSL


### PR DESCRIPTION
Include the AwsConfigTest only if SSL is enabled. Lack of this cause nightly release script to fail.