### PR TITLE
Nightly release builds are failing

### DIFF
--- a/hazelcast/test/src/util/HttpsClientTest.cpp
+++ b/hazelcast/test/src/util/HttpsClientTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifdef HZ_BUILD_WITH_SSL
 
 #include <gtest/gtest.h>
 
@@ -44,3 +45,4 @@ namespace hazelcast {
     }
 }
 
+#endif // HZ_BUILD_WITH_SSL


### PR DESCRIPTION
HttpsClientTest should be disabled if tls/ssl is not enabled.