### PR TITLE
Integrate AWS discovery and private to public ip translation to the client

### DIFF
--- a/hazelcast/include/hazelcast/client/ClientProperties.h
+++ b/hazelcast/include/hazelcast/client/ClientProperties.h
@@ -80,6 +80,7 @@ namespace hazelcast {
 
             const ClientProperty& getRetryWaitTime() const;
 
+            const ClientProperty& getAwsMemberPort() const;
 
             /**
             * Client will be sending heartbeat messages to members and this is the timeout. If there is no any message
@@ -124,11 +125,20 @@ namespace hazelcast {
             */
             static const std::string PROP_REQUEST_RETRY_WAIT_TIME;
             static const std::string PROP_REQUEST_RETRY_WAIT_TIME_DEFAULT;
+
+            /**
+             * The discovery mechanism will discover only IP addresses. You can define the port on which Hazelcast is expected to be
+             * running here. This port number is not used by the discovery mechanism itself, it is only returned by the discovery
+             * mechanism. The default port is {@link PROP_AWS_MEMBER_PORT_DEFAULT}
+             */
+            static const std::string PROP_AWS_MEMBER_PORT;
+            static const std::string PROP_AWS_MEMBER_PORT_DEFAULT;
         private:
             ClientProperty heartbeatTimeout;
             ClientProperty heartbeatInterval;
             ClientProperty retryCount;
             ClientProperty retryWaitTime;
+            ClientProperty awsMemberPort;
         };
 
     }

--- a/hazelcast/include/hazelcast/client/aws/AWSClient.h
+++ b/hazelcast/include/hazelcast/client/aws/AWSClient.h
@@ -36,13 +36,13 @@ namespace hazelcast {
         namespace aws {
             class HAZELCAST_API AWSClient {
             public:
-                AWSClient(config::ClientAwsConfig &awsConfig);
+                AWSClient(const config::ClientAwsConfig &awsConfig);
 
                 std::map<std::string, std::string> getAddresses();
 
                 const std::string &getEndpoint() const;
             private:
-                config::ClientAwsConfig &awsConfig;
+                const config::ClientAwsConfig &awsConfig;
                 std::string endpoint;
             };
         }

--- a/hazelcast/include/hazelcast/client/aws/AWSClient.h
+++ b/hazelcast/include/hazelcast/client/aws/AWSClient.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_AWS_AWSCLIENT_H_
 #define HAZELCAST_CLIENT_AWS_AWSCLIENT_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 #include <map>
 
@@ -40,7 +38,6 @@ namespace hazelcast {
 
                 std::map<std::string, std::string> getAddresses();
 
-                const std::string &getEndpoint() const;
             private:
                 config::ClientAwsConfig &awsConfig;
                 std::string endpoint;
@@ -52,7 +49,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_AWSCLIENT_H_ */

--- a/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
@@ -53,13 +53,13 @@ namespace hazelcast {
                      *
                      * @throws IOException if the address can not be translated.
                      */
-                    virtual std::auto_ptr<Address> translate(const Address &address);
+                    std::auto_ptr<Address> translate(const Address &address);
 
                 private:
                     /**
                      * Update the internal lookup table from AWS.
                      */
-                    virtual void refresh();
+                    void refresh();
 
                     std::auto_ptr<Address> findFromCache(const Address &address);
 

--- a/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZELCAST_CLIENT_AWS_IMPL_AWSADDRESSTRANSLATOR_H_
+#define HAZELCAST_CLIENT_AWS_IMPL_AWSADDRESSTRANSLATOR_H_
+
+#ifdef HZ_BUILD_WITH_SSL
+
+#include <memory>
+#include <map>
+#include <boost/shared_ptr.hpp>
+
+#include "hazelcast/client/aws/AWSClient.h"
+#include "hazelcast/util/Atomic.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export	
+#endif
+
+namespace hazelcast {
+    namespace client {
+        class Address;
+
+        namespace aws {
+            namespace impl {
+                class HAZELCAST_API AwsAddressTranslator {
+                public:
+                    /**
+                     * AwsAddressTranslator loads EC2 IP addresses with given AWS credentials.
+                     *
+                     * Keeps a lookup table of private to public IP addresses.
+                     */
+                    AwsAddressTranslator(const config::ClientAwsConfig &awsConfig);
+
+                    /**
+                     * Translates an IP address from the private AWS network to the public network.
+                     *
+                     * @param address the private address to translate
+                     * @return public address of network whose private address is given.
+                     *
+                     * @throws IOException if the address can not be translated.
+                     */
+                    virtual std::auto_ptr<Address> translate(const Address &address);
+
+                private:
+                    /**
+                     * Update the internal lookup table from AWS.
+                     */
+                    virtual void refresh();
+
+                    std::auto_ptr<Address> findFromCache(const Address &address);
+
+                    std::auto_ptr<AWSClient> awsClient;
+                    util::Atomic<boost::shared_ptr<std::map<std::string, std::string> > > privateToPublic;
+                };
+            };
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+#endif // HZ_BUILD_WITH_SSL
+
+#endif /* HAZELCAST_CLIENT_AWS_IMPL_AWSADDRESSTRANSLATOR_H_ */

--- a/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
@@ -53,7 +53,7 @@ namespace hazelcast {
                      *
                      * @throws IOException if the address can not be translated.
                      */
-                    std::auto_ptr<Address> translate(const Address &address);
+                    Address translate(const Address &address);
 
                 private:
                     /**
@@ -61,7 +61,7 @@ namespace hazelcast {
                      */
                     void refresh();
 
-                    std::auto_ptr<Address> findFromCache(const Address &address);
+                    bool findFromCache(const Address &address, Address &translatedAddress);
 
                     std::auto_ptr<AWSClient> awsClient;
                     util::Atomic<boost::shared_ptr<std::map<std::string, std::string> > > privateToPublic;

--- a/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_AWS_IMPL_AWSADDRESSTRANSLATOR_H_
 #define HAZELCAST_CLIENT_AWS_IMPL_AWSADDRESSTRANSLATOR_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <memory>
 #include <map>
 #include <boost/shared_ptr.hpp>
@@ -74,7 +72,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_IMPL_AWSADDRESSTRANSLATOR_H_ */

--- a/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
@@ -43,7 +43,7 @@ namespace hazelcast {
                      *
                      * Keeps a lookup table of private to public IP addresses.
                      */
-                    AwsAddressTranslator(const config::ClientAwsConfig &awsConfig);
+                    AwsAddressTranslator(config::ClientAwsConfig &awsConfig);
 
                     /**
                      * Translates an IP address from the private AWS network to the public network.

--- a/hazelcast/include/hazelcast/client/aws/impl/Constants.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/Constants.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_AWS_IMPL_CONSTANTS_H_
 #define HAZELCAST_CLIENT_AWS_IMPL_CONSTANTS_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include "hazelcast/util/HazelcastDll.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -44,7 +42,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_IMPL_CONSTANTS_H_ */

--- a/hazelcast/include/hazelcast/client/aws/impl/Constants.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/Constants.h
@@ -34,6 +34,7 @@ namespace hazelcast {
                     static const char *DOC_VERSION;
                     static const char *SIGNATURE_METHOD_V4;
                     static const char *GET;
+                    static const char *ECS_CREDENTIALS_ENV_VAR_NAME;
                 };
             };
         }

--- a/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
@@ -41,7 +41,7 @@ namespace hazelcast {
             namespace impl {
                 class HAZELCAST_API DescribeInstances {
                 public:
-                    DescribeInstances(config::ClientAwsConfig &awsConfig, const std::string &endpoint);
+                    DescribeInstances(const config::ClientAwsConfig &awsConfig, const std::string &endpoint);
 
                     virtual ~DescribeInstances();
 
@@ -60,7 +60,7 @@ namespace hazelcast {
                     std::istream &callService();
 
                     std::auto_ptr<security::EC2RequestSigner> rs;
-                    config::ClientAwsConfig &awsConfig;
+                    const config::ClientAwsConfig &awsConfig;
                     const std::string &endpoint;
                     std::map<std::string, std::string> attributes;
                     std::auto_ptr<util::SyncHttpsClient> httpsClient;

--- a/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
@@ -16,13 +16,10 @@
 #ifndef HAZELCAST_CLIENT_AWS_IMPL_DESCRIBEINSTANCES_H_
 #define HAZELCAST_CLIENT_AWS_IMPL_DESCRIBEINSTANCES_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 #include <map>
 
 #include "hazelcast/util/HazelcastDll.h"
-#include "hazelcast/util/SyncHttpsClient.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -30,6 +27,9 @@
 #endif
 
 namespace hazelcast {
+    namespace util {
+        class SyncHttpsClient;
+    }
     namespace client {
         namespace config {
             class ClientAwsConfig;
@@ -84,7 +84,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_IMPL_DESCRIBEINSTANCES_H_ */

--- a/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
@@ -41,7 +41,7 @@ namespace hazelcast {
             namespace impl {
                 class HAZELCAST_API DescribeInstances {
                 public:
-                    DescribeInstances(const config::ClientAwsConfig &awsConfig, const std::string &endpoint);
+                    DescribeInstances(config::ClientAwsConfig &awsConfig, const std::string &endpoint);
 
                     virtual ~DescribeInstances();
 
@@ -59,13 +59,22 @@ namespace hazelcast {
 
                     std::istream &callService();
 
+                    void checkKeysFromIamRoles();
+                    void tryGetDefaultIamRole();
+                    void getKeysFromIamTaskRole();
+                    void getKeysFromIamRole();
+                    void parseAndStoreRoleCreds(std::istream &in);
+
                     std::auto_ptr<security::EC2RequestSigner> rs;
-                    const config::ClientAwsConfig &awsConfig;
+                    config::ClientAwsConfig &awsConfig;
                     const std::string &endpoint;
                     std::map<std::string, std::string> attributes;
                     std::auto_ptr<util::SyncHttpsClient> httpsClient;
 
                     static const std::string QUERY_PREFIX;
+                    static const std::string IAM_ROLE_ENDPOINT;
+                    static const std::string IAM_ROLE_QUERY;
+                    static const std::string IAM_TASK_ROLE_ENDPOINT;
                 };
             }
         }

--- a/hazelcast/include/hazelcast/client/aws/security/EC2RequestSigner.h
+++ b/hazelcast/include/hazelcast/client/aws/security/EC2RequestSigner.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_AWS_SECURITY_EC2REQUESTSIGNER_H_
 #define HAZELCAST_CLIENT_AWS_SECURITY_EC2REQUESTSIGNER_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 #include <map>
 #include <vector>
@@ -76,8 +74,6 @@ namespace hazelcast {
 
                     std::string convertToHexString(const unsigned char *buffer, unsigned int len) const;
 
-                    std::string hmacSHA256(const std::string &key, const std::string &msg) const;
-
                     unsigned int hmacSHA256Bytes(const void *key, int keyLen, const std::string &msg,
                                                  unsigned char *hash) const;
 
@@ -108,7 +104,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_SECURITY_EC2REQUESTSIGNER_H_ */

--- a/hazelcast/include/hazelcast/client/aws/utility/AwsURLEncoder.h
+++ b/hazelcast/include/hazelcast/client/aws/utility/AwsURLEncoder.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_AWS_UTILITY_AWSURLENCODER_H_
 #define HAZELCAST_CLIENT_AWS_UTILITY_AWSURLENCODER_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 
 #include "hazelcast/util/HazelcastDll.h"
@@ -46,7 +44,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_UTILITY_AWSURLENCODER_H_ */

--- a/hazelcast/include/hazelcast/client/aws/utility/CloudUtility.h
+++ b/hazelcast/include/hazelcast/client/aws/utility/CloudUtility.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_AWS_UTILITY_CLOUDUTILITY_H_
 #define HAZELCAST_CLIENT_AWS_UTILITY_CLOUDUTILITY_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 #include <map>
 #include <boost/property_tree/ptree.hpp>
@@ -70,7 +68,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_AWS_UTILITY_CLOUDUTILITY_H_ */

--- a/hazelcast/include/hazelcast/client/aws/utility/CloudUtility.h
+++ b/hazelcast/include/hazelcast/client/aws/utility/CloudUtility.h
@@ -53,6 +53,9 @@ namespace hazelcast {
                     static std::map<std::string, std::string> unmarshalTheResponse(std::istream &stream,
                                                                                    const config::ClientAwsConfig &awsConfig);
 
+                    static void unmarshalJsonResponse(std::istream &stream, config::ClientAwsConfig &awsConfig,
+                                                      std::map<std::string, std::string> &attributes);
+
                 private:
                     static bool acceptTag(const config::ClientAwsConfig &awsConfig, pt::ptree &reservationSetItem);
 

--- a/hazelcast/include/hazelcast/client/config/ClientAwsConfig.h
+++ b/hazelcast/include/hazelcast/client/config/ClientAwsConfig.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_CONFIG_CLIENTAWSCONFIG_H_
 #define HAZELCAST_CLIENT_CONFIG_CLIENTAWSCONFIG_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 #include <ostream>
 #include <stdint.h>
@@ -241,7 +239,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_CONFIG_CLIENTAWSCONFIG_H_ */

--- a/hazelcast/include/hazelcast/client/config/ClientNetworkConfig.h
+++ b/hazelcast/include/hazelcast/client/config/ClientNetworkConfig.h
@@ -43,7 +43,6 @@ namespace hazelcast {
                 */
                 ClientNetworkConfig();
 
-                #ifdef HZ_BUILD_WITH_SSL
                 /**
                  * Returns the current {@link SSLConfig}.
                  *
@@ -60,7 +59,6 @@ namespace hazelcast {
                  * @see #getSSLConfig()
                  */
                 ClientNetworkConfig &setSSLConfig(const config::SSLConfig &sslConfig);
-                #endif // HZ_BUILD_WITH_SSL
 
                 /**
                 * @param connectionTimeout Timeout value in millis for nodes to accept client connection requests.
@@ -77,7 +75,6 @@ namespace hazelcast {
                 */
                 int64_t getConnectionTimeout() const;
 
-                #ifdef HZ_BUILD_WITH_SSL
                 /**
                  * Sets configuration to connect nodes in aws environment.
                  *
@@ -92,12 +89,9 @@ namespace hazelcast {
                  * @return ClientAwsConfig
                  */
                 ClientAwsConfig &getAwsConfig();
-                #endif
             private:
-                #ifdef HZ_BUILD_WITH_SSL
                 config::SSLConfig sslConfig;
                 config::ClientAwsConfig clientAwsConfig;
-                #endif
 
                 int64_t connectionTimeout;
             };

--- a/hazelcast/include/hazelcast/client/config/SSLConfig.h
+++ b/hazelcast/include/hazelcast/client/config/SSLConfig.h
@@ -16,8 +16,6 @@
 #ifndef HAZELCAST_CLIENT_CONFIG_SSLCONFIG_H_
 #define HAZELCAST_CLIENT_CONFIG_SSLCONFIG_H_
 
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -137,7 +135,5 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif /* HAZELCAST_CLIENT_CONFIG_SSLCONFIG_H_ */

--- a/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
+++ b/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
@@ -88,9 +88,7 @@ namespace hazelcast {
                 bool isInitialMembersLoaded;
                 bool isRegistrationIdReceived;
 
-                #ifdef HZ_BUILD_WITH_SSL
                 int awsMemberPort;
-                #endif
 
                 void loadInitialMemberList();
 
@@ -102,9 +100,7 @@ namespace hazelcast {
 
                 std::vector<Address> getConfigAddresses() const;
 
-                #ifdef HZ_BUILD_WITH_SSL
                 std::vector<Address> getAwsAddresses() const;
-                #endif // HZ_BUILD_WITH_SSL
 
                 void memberAdded(const Member &member);
 

--- a/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
+++ b/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
@@ -88,6 +88,10 @@ namespace hazelcast {
                 bool isInitialMembersLoaded;
                 bool isRegistrationIdReceived;
 
+                #ifdef HZ_BUILD_WITH_SSL
+                int awsMemberPort;
+                #endif
+
                 void loadInitialMemberList();
 
                 void listenMembershipEvents();

--- a/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
+++ b/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
@@ -98,6 +98,10 @@ namespace hazelcast {
 
                 std::vector<Address> getConfigAddresses() const;
 
+                #ifdef HZ_BUILD_WITH_SSL
+                std::vector<Address> getAwsAddresses() const;
+                #endif // HZ_BUILD_WITH_SSL
+
                 void memberAdded(const Member &member);
 
                 void memberRemoved(const Member &member);

--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -20,11 +20,6 @@
 
 #include <memory>
 
-#ifdef HZ_BUILD_WITH_SSL
-#include <asio.hpp>
-#include <asio/ssl.hpp>
-#endif
-
 #include "hazelcast/client/Socket.h"
 #include "hazelcast/client/connection/ReadHandler.h"
 #include "hazelcast/client/connection/WriteHandler.h"
@@ -49,6 +44,12 @@ namespace hazelcast {
             class InvocationService;
         }
 
+        namespace internal {
+            namespace socket {
+                class SocketFactory;
+            }
+        }
+
         class Address;
 
         namespace connection {
@@ -59,11 +60,7 @@ namespace hazelcast {
             class HAZELCAST_API Connection : public util::Closeable, public protocol::IMessageHandler {
             public:
                 Connection(const Address& address, spi::ClientContext& clientContext, InSelector& iListener,
-                           OutSelector& listener, bool isOwner
-                #ifdef HZ_BUILD_WITH_SSL
-                        , asio::io_service *ioService, asio::ssl::context *sslContext
-                #endif
-                           );
+                           OutSelector& listener, internal::socket::SocketFactory &socketFactory, bool isOwner);
 
                 ~Connection();
 

--- a/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
+++ b/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
@@ -26,18 +26,13 @@
 #include "hazelcast/client/connection/OwnerConnectionFuture.h"
 #include "hazelcast/client/connection/HeartBeater.h"
 #include "hazelcast/client/protocol/Principal.h"
+#include "hazelcast/client/internal/socket/SocketFactory.h"
 #include "hazelcast/util/Atomic.h"
 #include "hazelcast/util/Thread.h"
 
 #include <boost/shared_ptr.hpp>
 #include <stdint.h>
 #include <memory>
-
-#ifdef HZ_BUILD_WITH_SSL
-#include <asio.hpp>
-#include <asio/ssl.hpp>
-#include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
-#endif // HZ_BUILD_WITH_SSL
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -226,11 +221,7 @@ namespace hazelcast {
                 util::Atomic<int64_t> callIdGenerator;
                 util::Atomic<int> connectionIdCounter;
 
-                #ifdef HZ_BUILD_WITH_SSL
-                std::auto_ptr<asio::io_service> ioService;
-                std::auto_ptr<asio::ssl::context> sslContext;
-                aws::impl::AwsAddressTranslator translator;
-                #endif
+                internal::socket::SocketFactory socketFactory;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
+++ b/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
@@ -36,7 +36,8 @@
 #ifdef HZ_BUILD_WITH_SSL
 #include <asio.hpp>
 #include <asio/ssl.hpp>
-#endif
+#include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
+#endif // HZ_BUILD_WITH_SSL
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -151,6 +152,13 @@ namespace hazelcast {
                 std::auto_ptr<Connection> connectTo(const Address &address, bool ownerConnection);
 
                 /**
+                 * Connects to the translated ip address (if translation is needed, such as when aws is used)
+                * @param address
+                * @return Return the newly created connection.
+                */
+                std::auto_ptr<Connection> connectAsOwner(const Address &address);
+
+                /**
                 * @param address
                 * @param ownerConnection
                 */
@@ -194,6 +202,8 @@ namespace hazelcast {
 
                 boost::shared_ptr<Connection> getOwnerConnection();
 
+                inline Address translateAddress(const Address &address);
+
                 std::vector<byte> PROTOCOL;
                 util::SynchronizedMap<Address, Connection, addressComparator> connections;
                 util::SynchronizedMap<int, Connection> socketConnections;
@@ -219,6 +229,7 @@ namespace hazelcast {
                 #ifdef HZ_BUILD_WITH_SSL
                 std::auto_ptr<asio::io_service> ioService;
                 std::auto_ptr<asio::ssl::context> sslContext;
+                aws::impl::AwsAddressTranslator translator;
                 #endif
             };
         }

--- a/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
+++ b/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
@@ -19,6 +19,10 @@
 #ifndef HAZELCAST_CONNECTION_MANAGER
 #define HAZELCAST_CONNECTION_MANAGER
 
+#include <boost/shared_ptr.hpp>
+#include <stdint.h>
+#include <memory>
+
 #include "hazelcast/client/Address.h"
 #include "hazelcast/util/SynchronizedMap.h"
 #include "hazelcast/client/connection/InSelector.h"
@@ -27,12 +31,9 @@
 #include "hazelcast/client/connection/HeartBeater.h"
 #include "hazelcast/client/protocol/Principal.h"
 #include "hazelcast/client/internal/socket/SocketFactory.h"
+#include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
 #include "hazelcast/util/Atomic.h"
 #include "hazelcast/util/Thread.h"
-
-#include <boost/shared_ptr.hpp>
-#include <stdint.h>
-#include <memory>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -222,6 +223,7 @@ namespace hazelcast {
                 util::Atomic<int> connectionIdCounter;
 
                 internal::socket::SocketFactory socketFactory;
+                aws::impl::AwsAddressTranslator translator;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
@@ -23,7 +23,6 @@
 #ifdef HZ_BUILD_WITH_SSL
 #include <asio.hpp>
 #include <asio/ssl.hpp>
-#include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
 #endif // HZ_BUILD_WITH_SSL
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -48,15 +47,12 @@ namespace hazelcast {
                     bool start();
 
                     std::auto_ptr<Socket> create(const Address &address) const;
-
-                    Address translateAddress(const Address &address);
                 private:
                     spi::ClientContext &clientContext;
 
                     #ifdef HZ_BUILD_WITH_SSL
                     std::auto_ptr<asio::io_service> ioService;
                     std::auto_ptr<asio::ssl::context> sslContext;
-                    aws::impl::AwsAddressTranslator translator;
                     #endif
                 };
             }

--- a/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZELCAST_CLIENT_INTERNAL_SOCKET_SOCKETFACTORY_H_
+#define HAZELCAST_CLIENT_INTERNAL_SOCKET_SOCKETFACTORY_H_
+
+#include <memory>
+
+#include "hazelcast/util/HazelcastDll.h"
+
+#ifdef HZ_BUILD_WITH_SSL
+#include <asio.hpp>
+#include <asio/ssl.hpp>
+#include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
+#endif // HZ_BUILD_WITH_SSL
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export	
+#endif
+
+namespace hazelcast {
+    namespace client {
+        class Socket;
+        class Address;
+
+        namespace spi {
+            class ClientContext;
+        }
+        namespace internal {
+            namespace socket {
+                class HAZELCAST_API SocketFactory {
+                public:
+                    SocketFactory(spi::ClientContext &clientContext);
+
+                    bool start();
+
+                    std::auto_ptr<Socket> create(const Address &address) const;
+
+                    Address translateAddress(const Address &address);
+                private:
+                    spi::ClientContext &clientContext;
+
+                    #ifdef HZ_BUILD_WITH_SSL
+                    std::auto_ptr<asio::io_service> ioService;
+                    std::auto_ptr<asio::ssl::context> sslContext;
+                    std::auto_ptr<aws::impl::AwsAddressTranslator> translator;
+                    #endif
+                };
+            }
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+#endif /* HAZELCAST_CLIENT_INTERNAL_SOCKET_SOCKETFACTORY_H_ */

--- a/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
@@ -56,7 +56,7 @@ namespace hazelcast {
                     #ifdef HZ_BUILD_WITH_SSL
                     std::auto_ptr<asio::io_service> ioService;
                     std::auto_ptr<asio::ssl::context> sslContext;
-                    std::auto_ptr<aws::impl::AwsAddressTranslator> translator;
+                    aws::impl::AwsAddressTranslator translator;
                     #endif
                 };
             }

--- a/hazelcast/include/hazelcast/util/Preconditions.h
+++ b/hazelcast/include/hazelcast/util/Preconditions.h
@@ -75,6 +75,12 @@ namespace hazelcast {
              * @throws client::exception::IllegalArgumentException if the string is empty
              */
             static const std::string &checkHasText(const std::string &argument, const std::string &errorMessage);
+
+            /**
+             * @throws client::exception::InvalidConfigurationException if the user does not compile with
+             * HZ_BUILD_WITH_SSL flag but is trying to use a feature (e.g. TLS, AWS Cloud Discovery) that needs this flag.
+             */
+            static void checkSSL(const std::string &sourceMethod) throw (client::exception::InvalidConfigurationException);
         };
     }
 }

--- a/hazelcast/include/hazelcast/util/SyncHttpClient.h
+++ b/hazelcast/include/hazelcast/util/SyncHttpClient.h
@@ -13,39 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef HAZELCAST_CLIENT_AWS_AWSCLIENT_H_
-#define HAZELCAST_CLIENT_AWS_AWSCLIENT_H_
-
-#ifdef HZ_BUILD_WITH_SSL
+#ifndef HAZELCAST_UTIL_SYNCHTTPCLIENT_H_
+#define HAZELCAST_UTIL_SYNCHTTPCLIENT_H_
 
 #include <string>
-#include <map>
+#include <asio.hpp>
 
 #include "hazelcast/util/HazelcastDll.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
-#pragma warning(disable: 4251) //for dll export	
+#pragma warning(disable: 4251) //for dll export
+#pragma warning(disable: 4003) //for  not enough actual parameters for macro 'min' in asio wait_traits
 #endif
 
 namespace hazelcast {
-    namespace client {
-        namespace config {
-            class ClientAwsConfig;
-        }
-        namespace aws {
-            class HAZELCAST_API AWSClient {
-            public:
-                AWSClient(config::ClientAwsConfig &awsConfig);
+    namespace util {
+        class HAZELCAST_API SyncHttpClient {
+        public:
+            SyncHttpClient(const std::string &serverIp, const std::string &uriPath);
 
-                std::map<std::string, std::string> getAddresses();
-
-                const std::string &getEndpoint() const;
-            private:
-                config::ClientAwsConfig &awsConfig;
-                std::string endpoint;
-            };
-        }
+            std::istream &openConnection();
+        private:
+            std::string server;
+            std::string uriPath;
+            asio::io_service ioService;
+            asio::ip::tcp::socket socket;
+            asio::streambuf response;
+            std::istream responseStream;
+        };
     }
 }
 
@@ -53,6 +49,5 @@ namespace hazelcast {
 #pragma warning(pop)
 #endif
 
-#endif // HZ_BUILD_WITH_SSL
+#endif //HAZELCAST_UTIL_SYNCHTTPCLIENT_H_
 
-#endif /* HAZELCAST_CLIENT_AWS_AWSCLIENT_H_ */

--- a/hazelcast/include/hazelcast/util/SyncHttpsClient.h
+++ b/hazelcast/include/hazelcast/util/SyncHttpsClient.h
@@ -16,12 +16,14 @@
 #ifndef HAZELCAST_UTIL_SYNCHTTPSCLIENT_H_
 #define HAZELCAST_UTIL_SYNCHTTPSCLIENT_H_
 
-#ifdef HZ_BUILD_WITH_SSL
 
 #include <string>
 #include <asio.hpp>
+
+#ifdef HZ_BUILD_WITH_SSL
 #include <asio/asio/include/asio/ssl/context.hpp>
 #include <asio/asio/include/asio/ssl/stream.hpp>
+#endif // HZ_BUILD_WITH_SSL
 
 #include "hazelcast/util/HazelcastDll.h"
 
@@ -43,8 +45,12 @@ namespace hazelcast {
             std::string uriPath;
 
             asio::io_service ioService;
+
+            #ifdef HZ_BUILD_WITH_SSL
             asio::ssl::context sslContext;
             std::auto_ptr<asio::ssl::stream<asio::ip::tcp::socket> > socket;
+            #endif // HZ_BUILD_WITH_SSL
+
             asio::streambuf response;
             std::istream responseStream;
         };
@@ -54,8 +60,6 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
-#endif // HZ_BUILD_WITH_SSL
 
 #endif //HAZELCAST_UTIL_SYNCHTTPSCLIENT_H_
 

--- a/hazelcast/src/hazelcast/client/ClientProperties.cpp
+++ b/hazelcast/src/hazelcast/client/ClientProperties.cpp
@@ -38,6 +38,9 @@ namespace hazelcast {
         const std::string ClientProperties::PROP_REQUEST_RETRY_WAIT_TIME = "hazelcast_client_request_retry_wait_time";
         const std::string ClientProperties::PROP_REQUEST_RETRY_WAIT_TIME_DEFAULT = "1";
 
+        const std::string ClientProperties::PROP_AWS_MEMBER_PORT = "hz-port";
+        const std::string ClientProperties::PROP_AWS_MEMBER_PORT_DEFAULT = "5701";
+
         ClientProperty::ClientProperty(ClientConfig& config, const std::string& name, const std::string& defaultValue)
         : name(name) {
             if (config.getProperties().count(name) > 0) {
@@ -82,10 +85,10 @@ namespace hazelcast {
         : heartbeatTimeout(clientConfig, PROP_HEARTBEAT_TIMEOUT, PROP_HEARTBEAT_TIMEOUT_DEFAULT)
         , heartbeatInterval(clientConfig, PROP_HEARTBEAT_INTERVAL, PROP_HEARTBEAT_INTERVAL_DEFAULT)
         , retryCount(clientConfig, PROP_REQUEST_RETRY_COUNT, PROP_REQUEST_RETRY_COUNT_DEFAULT)
-        , retryWaitTime(clientConfig, PROP_REQUEST_RETRY_WAIT_TIME, PROP_REQUEST_RETRY_WAIT_TIME_DEFAULT) {
+        , retryWaitTime(clientConfig, PROP_REQUEST_RETRY_WAIT_TIME, PROP_REQUEST_RETRY_WAIT_TIME_DEFAULT)
+        , awsMemberPort(clientConfig, PROP_AWS_MEMBER_PORT, PROP_AWS_MEMBER_PORT_DEFAULT) {
 
         }
-
 
         const ClientProperty& ClientProperties::getHeartbeatTimeout() const {
             return heartbeatTimeout;
@@ -101,6 +104,10 @@ namespace hazelcast {
 
         const ClientProperty& ClientProperties::getRetryWaitTime() const {
             return retryWaitTime;
+        }
+
+        const ClientProperty& ClientProperties::getAwsMemberPort() const {
+            return awsMemberPort;
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
+++ b/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
@@ -26,14 +26,6 @@ namespace hazelcast {
     namespace client {
         namespace aws {
             AWSClient::AWSClient(config::ClientAwsConfig &awsConfig) : awsConfig(awsConfig) {
-                if (awsConfig.getAccessKey().empty() && awsConfig.getIamRole().empty()) {
-                    throw exception::IllegalArgumentException("AWSClient::AWSClient",
-                                                              "AWS access key or IAM Role is required!");
-                }
-                if (awsConfig.getSecretKey().empty() && awsConfig.getIamRole().empty()) {
-                    throw exception::IllegalArgumentException("AWSClient::AWSClient",
-                                                              "AWS secret key or Iam Role is required!");
-                }
                 this->endpoint = awsConfig.getHostHeader();
                 if (!awsConfig.getRegion().empty() && awsConfig.getRegion().length() > 0) {
                     if (awsConfig.getHostHeader().find("ec2.") != 0) {

--- a/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
+++ b/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <boost/algorithm/string/replace.hpp>
 
 #include "hazelcast/client/aws/AWSClient.h"
@@ -39,12 +37,7 @@ namespace hazelcast {
             std::map<std::string, std::string> AWSClient::getAddresses() {
                 return impl::DescribeInstances(awsConfig, endpoint).execute();
             }
-
-            const std::string &AWSClient::getEndpoint() const {
-                return endpoint;
-            }
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
+++ b/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
@@ -25,7 +25,7 @@
 namespace hazelcast {
     namespace client {
         namespace aws {
-            AWSClient::AWSClient(const config::ClientAwsConfig &awsConfig) : awsConfig(awsConfig) {
+            AWSClient::AWSClient(config::ClientAwsConfig &awsConfig) : awsConfig(awsConfig) {
                 if (awsConfig.getAccessKey().empty() && awsConfig.getIamRole().empty()) {
                     throw exception::IllegalArgumentException("AWSClient::AWSClient",
                                                               "AWS access key or IAM Role is required!");

--- a/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
+++ b/hazelcast/src/hazelcast/client/aws/AWSClient.cpp
@@ -25,7 +25,7 @@
 namespace hazelcast {
     namespace client {
         namespace aws {
-            AWSClient::AWSClient(config::ClientAwsConfig &awsConfig) : awsConfig(awsConfig) {
+            AWSClient::AWSClient(const config::ClientAwsConfig &awsConfig) : awsConfig(awsConfig) {
                 if (awsConfig.getAccessKey().empty() && awsConfig.getIamRole().empty()) {
                     throw exception::IllegalArgumentException("AWSClient::AWSClient",
                                                               "AWS access key or IAM Role is required!");

--- a/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifdef HZ_BUILD_WITH_SSL
+
+#include "hazelcast/client/exception/IOException.h"
+#include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
+#include "hazelcast/client/config/ClientAwsConfig.h"
+#include "hazelcast/client/Address.h"
+#include "hazelcast/client/exception/IException.h"
+#include "hazelcast/util/ILogger.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace aws {
+            namespace impl {
+                AwsAddressTranslator::AwsAddressTranslator(const config::ClientAwsConfig &awsConfig) {
+                    if (awsConfig.isEnabled() && !awsConfig.isInsideAws()) {
+                        awsClient = std::auto_ptr<AWSClient>(new AWSClient(awsConfig));
+                    }
+                }
+
+                std::auto_ptr<Address> AwsAddressTranslator::translate(const Address &address) {
+                    // if no translation is needed just return the address as it is
+                    if (NULL == awsClient.get()) {
+                        return std::auto_ptr<Address>(new Address(address));
+                    }
+
+                    std::auto_ptr<Address> result = findFromCache(address);
+                    if (NULL != result.get()) {
+                        return result;
+                    }
+
+                    refresh();
+
+                    result = findFromCache(address);
+                    if (NULL != result.get()) {
+                        return result;
+                    }
+
+                    std::stringstream out;
+                    out << "No translation is found for private ip:" << address;
+                    throw exception::IOException("AwsAddressTranslator::translate", out.str());
+                }
+
+                void AwsAddressTranslator::refresh() {
+                    try {
+                        privateToPublic = boost::shared_ptr<std::map<std::string, std::string> >(
+                                new std::map<std::string, std::string>(awsClient->getAddresses()));
+                    } catch (exception::IException &e) {
+                        util::ILogger::getLogger().warning(std::string("AWS addresses failed to load: ") + e.what());
+                    }
+                }
+
+                std::auto_ptr<Address> AwsAddressTranslator::findFromCache(const Address &address) {
+                    boost::shared_ptr<std::map<std::string, std::string> > mapping = privateToPublic;
+                    if (mapping.get() == NULL) {
+                        return std::auto_ptr<Address>();
+                    }
+
+                    std::map<std::string, std::string>::const_iterator publicAddressIt = mapping->find(
+                            address.getHost());
+                    if (publicAddressIt != mapping->end()) {
+                        const std::string &publicIp = (*publicAddressIt).second;
+                        if (!publicIp.empty()) {
+                            return std::auto_ptr<Address>(new Address((*publicAddressIt).second, address.getPort()));
+                        }
+                    }
+
+                    return std::auto_ptr<Address>();
+                }
+            }
+        }
+    }
+}
+#endif // HZ_BUILD_WITH_SSL
+

--- a/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
@@ -32,11 +32,12 @@ namespace hazelcast {
                 }
 
                 Address AwsAddressTranslator::translate(const Address &address) {
-                    Address translatedAddress = address;
                     // if no translation is needed just return the address as it is
                     if (NULL == awsClient.get()) {
-                        return translatedAddress;
+                        return address;
                     }
+
+                    Address translatedAddress = address;
 
                     if (findFromCache(address, translatedAddress)) {
                         return translatedAddress;

--- a/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
 
 #include "hazelcast/client/exception/IOException.h"
 #include "hazelcast/client/aws/impl/AwsAddressTranslator.h"
@@ -85,5 +84,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/AwsAddressTranslator.cpp
@@ -26,7 +26,7 @@ namespace hazelcast {
     namespace client {
         namespace aws {
             namespace impl {
-                AwsAddressTranslator::AwsAddressTranslator(const config::ClientAwsConfig &awsConfig) {
+                AwsAddressTranslator::AwsAddressTranslator(config::ClientAwsConfig &awsConfig) {
                     if (awsConfig.isEnabled() && !awsConfig.isInsideAws()) {
                         awsClient = std::auto_ptr<AWSClient>(new AWSClient(awsConfig));
                     }

--- a/hazelcast/src/hazelcast/client/aws/impl/Constants.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/Constants.cpp
@@ -25,6 +25,7 @@ namespace hazelcast {
                 const char *Constants::DOC_VERSION = "2014-06-15";
                 const char *Constants::SIGNATURE_METHOD_V4 = "AWS4-HMAC-SHA256";
                 const char *Constants::GET = "GET";
+                const char *Constants::ECS_CREDENTIALS_ENV_VAR_NAME = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/aws/impl/Constants.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/Constants.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
-
 #include "hazelcast/client/aws/impl/Constants.h"
 
 namespace hazelcast {
@@ -30,5 +28,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
@@ -33,7 +33,7 @@ namespace hazelcast {
             namespace impl {
                 const std::string DescribeInstances::QUERY_PREFIX = "/?";
 
-                DescribeInstances::DescribeInstances(config::ClientAwsConfig &awsConfig,
+                DescribeInstances::DescribeInstances(const config::ClientAwsConfig &awsConfig,
                                                      const std::string &endpoint) : awsConfig(awsConfig),
                                                                                     endpoint(endpoint) {
 /*TODO
@@ -76,7 +76,8 @@ namespace hazelcast {
 
                 std::istream &DescribeInstances::callService() {
                     std::string query = rs->getCanonicalizedQueryString(attributes);
-                    httpsClient = std::auto_ptr<util::SyncHttpsClient>(new util::SyncHttpsClient(endpoint.c_str(), QUERY_PREFIX + query));
+                    httpsClient = std::auto_ptr<util::SyncHttpsClient>(
+                            new util::SyncHttpsClient(endpoint.c_str(), QUERY_PREFIX + query));
                     return httpsClient->openConnection();
                 }
             }

--- a/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
@@ -20,25 +20,28 @@
 
 #include <asio.hpp>
 
-#include "hazelcast/util/SyncHttpsClient.h"
 #include "hazelcast/client/aws/impl/DescribeInstances.h"
 #include "hazelcast/client/aws/impl/Constants.h"
 #include "hazelcast/client/aws/security/EC2RequestSigner.h"
 #include "hazelcast/client/aws/utility/CloudUtility.h"
 #include "hazelcast/client/config/ClientAwsConfig.h"
+#include "hazelcast/util/SyncHttpsClient.h"
+#include "hazelcast/client/exception/IOException.h"
+#include "hazelcast/util/SyncHttpClient.h"
 
 namespace hazelcast {
     namespace client {
         namespace aws {
             namespace impl {
                 const std::string DescribeInstances::QUERY_PREFIX = "/?";
+                const std::string DescribeInstances::IAM_ROLE_ENDPOINT = "169.254.169.254";
+                const std::string DescribeInstances::IAM_ROLE_QUERY = "/latest/meta-data/iam/security-credentials/";
+                const std::string DescribeInstances::IAM_TASK_ROLE_ENDPOINT = "169.254.170.2";
 
-                DescribeInstances::DescribeInstances(const config::ClientAwsConfig &awsConfig,
+                DescribeInstances::DescribeInstances(config::ClientAwsConfig &awsConfig,
                                                      const std::string &endpoint) : awsConfig(awsConfig),
                                                                                     endpoint(endpoint) {
-/*TODO
                     checkKeysFromIamRoles();
-*/
 
                     std::string timeStamp = getFormattedTimestamp();
                     rs = std::auto_ptr<security::EC2RequestSigner>(
@@ -79,6 +82,80 @@ namespace hazelcast {
                     httpsClient = std::auto_ptr<util::SyncHttpsClient>(
                             new util::SyncHttpsClient(endpoint.c_str(), QUERY_PREFIX + query));
                     return httpsClient->openConnection();
+                }
+
+                void DescribeInstances::checkKeysFromIamRoles() {
+                    if (!awsConfig.getAccessKey().empty() && awsConfig.getIamRole().empty()) {
+                        return;
+                    }
+                    // in case no IAM role has been defined, this will attempt to retrieve name of default role.
+                    tryGetDefaultIamRole();
+
+                    // if IAM role is still empty, one last attempt
+                    if (awsConfig.getIamRole().empty()) {
+                        getKeysFromIamTaskRole();
+                    } else {
+                        getKeysFromIamRole();
+                    }
+                }
+
+                void DescribeInstances::tryGetDefaultIamRole() {
+                    // if none of the below are true
+                    if (!(awsConfig.getIamRole().empty() || awsConfig.getIamRole() == "DEFAULT")) {
+                        // stop here. No point looking up the default role.
+                        return;
+                    }
+                    try {
+                        util::SyncHttpClient httpClient(IAM_ROLE_ENDPOINT, IAM_ROLE_QUERY);
+                        std::string roleName;
+                        std::istream &responseStream = httpClient.openConnection();
+                        responseStream >> roleName;
+                        awsConfig.setIamRole(roleName);
+                    } catch (exception::IOException &e) {
+                        throw exception::InvalidConfigurationException("tryGetDefaultIamRole",
+                                                                       std::string("Invalid Aws Configuration") +
+                                                                       e.what());
+                    }
+                }
+
+                void DescribeInstances::getKeysFromIamTaskRole() {
+                    // before giving up, attempt to discover whether we're running in an ECS Container,
+                    // in which case, AWS_CONTAINER_CREDENTIALS_RELATIVE_URI will exist as an env var.
+                    const char *uri = getenv(Constants::ECS_CREDENTIALS_ENV_VAR_NAME);
+                    if (uri) {
+                        throw exception::IllegalArgumentException("getKeysFromIamTaskRole",
+                                                                  "Could not acquire credentials! Did not find declared AWS access key or IAM Role, and could not discover IAM Task Role or default role.");
+                    }
+                    
+                    util::SyncHttpClient httpClient(IAM_TASK_ROLE_ENDPOINT, uri);
+
+                    try {
+                        std::istream &istream = httpClient.openConnection();
+                        parseAndStoreRoleCreds(istream);
+                    } catch (exception::IException &e) {
+                        std::stringstream out;
+                        out << "Unable to retrieve credentials from IAM Task Role. URI: " << uri << ". \n " << e.what();
+                        throw exception::InvalidConfigurationException("getKeysFromIamTaskRole", out.str());
+                    }
+                }
+
+                void DescribeInstances::getKeysFromIamRole() {
+                    std::string query = "/latest/meta-data/iam/security-credentials/" + awsConfig.getIamRole();
+
+                    util::SyncHttpClient httpClient(IAM_TASK_ROLE_ENDPOINT, query);
+
+                    try {
+                        std::istream &istream = httpClient.openConnection();
+                        parseAndStoreRoleCreds(istream);
+                    } catch (exception::IException &e) {
+                        std::stringstream out;
+                        out << "Unable to retrieve credentials from IAM Task Role. URI: " << query << ". \n " << e.what();
+                        throw exception::InvalidConfigurationException("getKeysFromIamRole", out.str());
+                    }
+                }
+
+                void DescribeInstances::parseAndStoreRoleCreds(std::istream &in) {
+                    utility::CloudUtility::unmarshalJsonResponse(in, awsConfig, attributes);
                 }
             }
         }

--- a/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
@@ -142,7 +142,7 @@ namespace hazelcast {
                 void DescribeInstances::getKeysFromIamRole() {
                     std::string query = "/latest/meta-data/iam/security-credentials/" + awsConfig.getIamRole();
 
-                    util::SyncHttpClient httpClient(IAM_TASK_ROLE_ENDPOINT, query);
+                    util::SyncHttpClient httpClient(IAM_ROLE_ENDPOINT, query);
 
                     try {
                         std::istream &istream = httpClient.openConnection();

--- a/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/date_time.hpp>
@@ -161,5 +160,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/aws/utility/AwsURLEncoder.cpp
+++ b/hazelcast/src/hazelcast/client/aws/utility/AwsURLEncoder.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
-
 #include <string>
 #include <cctype>
 #include <sstream>
@@ -60,5 +58,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/aws/utility/CloudUtility.cpp
+++ b/hazelcast/src/hazelcast/client/aws/utility/CloudUtility.cpp
@@ -94,13 +94,16 @@ namespace hazelcast {
 
                     bool emptyExpectedValue = expectedTagValue.empty();
 
-                    BOOST_FOREACH(pt::ptree::value_type & item, reservationSetItem.get_child("tagSet")) {
-                        std::string key = item.second.get_optional<std::string>("key").get_value_or("");
-                        std::string value = item.second.get_optional<std::string>("value").get_value_or(
-                                "");
-                        if (key == expectedTagKey &&
-                            (emptyExpectedValue || value == expectedTagValue)) {
-                            return true;
+                    boost::optional<pt::ptree &> tags = reservationSetItem.get_child_optional("tagSet");
+                    if (tags) {
+                        BOOST_FOREACH(pt::ptree::value_type &item, tags.get()) {
+                                        std::string key = item.second.get_optional<std::string>("key").get_value_or("");
+                                        std::string value = item.second.get_optional<std::string>("value").get_value_or(
+                                                "");
+                                        if (key == expectedTagKey &&
+                                            (emptyExpectedValue || value == expectedTagValue)) {
+                                            return true;
+                                        }
                         }
                     }
                     return false;
@@ -112,13 +115,17 @@ namespace hazelcast {
                         return true;
                     }
 
-                    BOOST_FOREACH(pt::ptree::value_type & item, reservationSetItem.get_child("groupSet")) {
-                        boost::optional<std::string> groupNameOptional = item.second.get_optional<std::string>(
-                                "groupName");
-                        if (groupNameOptional && groupNameOptional.get() == securityGroupName) {
-                            return true;
+                    boost::optional<pt::ptree &> groups = reservationSetItem.get_child_optional("groupSet");
+                    if (groups) {
+                        BOOST_FOREACH(pt::ptree::value_type &item, groups.get()) {
+                                        boost::optional<std::string> groupNameOptional = item.second.get_optional<std::string>(
+                                                "groupName");
+                                        if (groupNameOptional && groupNameOptional.get() == securityGroupName) {
+                                            return true;
+                                        }
                         }
                     }
+
                     return false;
                 }
 

--- a/hazelcast/src/hazelcast/client/aws/utility/CloudUtility.cpp
+++ b/hazelcast/src/hazelcast/client/aws/utility/CloudUtility.cpp
@@ -16,6 +16,7 @@
 #ifdef HZ_BUILD_WITH_SSL
 
 #include <boost/property_tree/xml_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
 #include <boost/foreach.hpp>
 
 #include "hazelcast/client/aws/utility/CloudUtility.h"
@@ -129,6 +130,14 @@ namespace hazelcast {
                     return false;
                 }
 
+                void CloudUtility::unmarshalJsonResponse(std::istream &stream, config::ClientAwsConfig &awsConfig,
+                                                         std::map<std::string, std::string> &attributes) {
+                    pt::ptree json;
+                    pt::read_json(stream, json);
+                    awsConfig.setAccessKey(json.get_optional<std::string>("AccessKeyId").get_value_or(""));
+                    awsConfig.setSecretKey(json.get_optional<std::string>("SecretAccessKey").get_value_or(""));
+                    attributes["X-Amz-Security-Token"] = json.get_optional<std::string>("Token").get_value_or("");
+                }
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/aws/utility/CloudUtility.cpp
+++ b/hazelcast/src/hazelcast/client/aws/utility/CloudUtility.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
 
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -142,5 +141,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/config/ClientAwsConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/ClientAwsConfig.cpp
@@ -60,6 +60,7 @@ namespace hazelcast {
             }
 
             ClientAwsConfig &ClientAwsConfig::setEnabled(bool enabled) {
+                util::Preconditions::checkSSL("getAwsConfig");
                 this->enabled = enabled;
                 return *this;
             }

--- a/hazelcast/src/hazelcast/client/config/ClientAwsConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/ClientAwsConfig.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
-
 #include "hazelcast/client/config/ClientAwsConfig.h"
 #include "hazelcast/util/Preconditions.h"
 
@@ -128,5 +126,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/config/ClientNetworkConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/ClientNetworkConfig.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "hazelcast/client/config/ClientNetworkConfig.h"
-#include "hazelcast/util/Preconditions.h"
 
 namespace hazelcast {
     namespace client {
@@ -25,12 +24,10 @@ namespace hazelcast {
             }
 
             SSLConfig &ClientNetworkConfig::getSSLConfig() {
-                util::Preconditions::checkSSL("getSSLConfig");
                 return sslConfig;
             }
 
             ClientNetworkConfig &ClientNetworkConfig::setSSLConfig(const config::SSLConfig &sslConfig) {
-                util::Preconditions::checkSSL("setSSLConfig");
                 this->sslConfig = sslConfig;
                 return *this;
             }
@@ -45,13 +42,11 @@ namespace hazelcast {
             }
 
             ClientNetworkConfig &ClientNetworkConfig::setAwsConfig(const ClientAwsConfig &clientAwsConfig) {
-                util::Preconditions::checkSSL("setAwsConfig");
                 this->clientAwsConfig = clientAwsConfig;
                 return *this;
             }
 
             ClientAwsConfig &ClientNetworkConfig::getAwsConfig() {
-                util::Preconditions::checkSSL("getAwsConfig");
                 return clientAwsConfig;
             }
         }

--- a/hazelcast/src/hazelcast/client/config/ClientNetworkConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/ClientNetworkConfig.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "hazelcast/client/config/ClientNetworkConfig.h"
+#include "hazelcast/util/Preconditions.h"
 
 namespace hazelcast {
     namespace client {
@@ -23,16 +24,16 @@ namespace hazelcast {
                     : connectionTimeout(5000) {
             }
 
-            #ifdef HZ_BUILD_WITH_SSL
             SSLConfig &ClientNetworkConfig::getSSLConfig() {
+                util::Preconditions::checkSSL("getSSLConfig");
                 return sslConfig;
             }
 
             ClientNetworkConfig &ClientNetworkConfig::setSSLConfig(const config::SSLConfig &sslConfig) {
+                util::Preconditions::checkSSL("setSSLConfig");
                 this->sslConfig = sslConfig;
                 return *this;
             }
-            #endif // HZ_BUILD_WITH_SSL
 
             int64_t ClientNetworkConfig::getConnectionTimeout() const {
                 return connectionTimeout;
@@ -43,16 +44,16 @@ namespace hazelcast {
                 return *this;
             }
 
-            #ifdef HZ_BUILD_WITH_SSL
             ClientNetworkConfig &ClientNetworkConfig::setAwsConfig(const ClientAwsConfig &clientAwsConfig) {
+                util::Preconditions::checkSSL("setAwsConfig");
                 this->clientAwsConfig = clientAwsConfig;
                 return *this;
             }
 
             ClientAwsConfig &ClientNetworkConfig::getAwsConfig() {
+                util::Preconditions::checkSSL("getAwsConfig");
                 return clientAwsConfig;
             }
-            #endif // HZ_BUILD_WITH_SSL
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/config/SSLConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/SSLConfig.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef HZ_BUILD_WITH_SSL
-
 #include "hazelcast/client/config/SSLConfig.h"
 
 namespace hazelcast {
@@ -61,5 +59,4 @@ namespace hazelcast {
         }
     }
 }
-#endif // HZ_BUILD_WITH_SSL
 

--- a/hazelcast/src/hazelcast/client/config/SSLConfig.cpp
+++ b/hazelcast/src/hazelcast/client/config/SSLConfig.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "hazelcast/client/config/SSLConfig.h"
+#include "hazelcast/util/Preconditions.h"
 
 namespace hazelcast {
     namespace client {
@@ -26,6 +27,7 @@ namespace hazelcast {
             }
 
             SSLConfig &SSLConfig::setEnabled(bool enabled) {
+                util::Preconditions::checkSSL("getAwsConfig");
                 this->enabled = enabled;
                 return *this;
             }

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -216,7 +216,7 @@ namespace hazelcast {
             #ifdef HZ_BUILD_WITH_SSL
             std::vector<Address> ClusterListenerThread::getAwsAddresses() const {
                 std::vector<Address> awsAdresses;
-                const config::ClientAwsConfig &awsConfig = clientContext.getClientConfig().getNetworkConfig().getAwsConfig();
+                config::ClientAwsConfig &awsConfig = clientContext.getClientConfig().getNetworkConfig().getAwsConfig();
                 if (awsConfig.isEnabled()) {
                     try {
                         aws::AWSClient awsClient(awsConfig);

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -16,11 +16,9 @@
 //
 // Created by sancar koyunlu on 5/23/13.
 
-#ifdef HZ_BUILD_WITH_SSL
 #include <boost/foreach.hpp>
 #include "hazelcast/client/aws/AWSClient.h"
 #include "hazelcast/client/ClientProperties.h"
-#endif // HZ_BUILD_WITH_SSL
 
 #include "hazelcast/util/Util.h"
 #include "hazelcast/client/exception/IllegalArgumentException.h"
@@ -41,7 +39,6 @@ namespace hazelcast {
         namespace connection {
             ClusterListenerThread::ClusterListenerThread(spi::ClientContext &clientContext)
                     : startLatch(1), clientContext(clientContext), deletingConnection(false) {
-                #ifdef HZ_BUILD_WITH_SSL
                 config::ClientAwsConfig &awsConfig = clientContext.getClientConfig().getNetworkConfig().getAwsConfig();
                 if (awsConfig.isEnabled()) {
                     int port = clientContext.getClientProperties().getAwsMemberPort().getInteger();
@@ -58,7 +55,6 @@ namespace hazelcast {
 
                     awsMemberPort = port;
                 }
-                #endif
             }
 
             void ClusterListenerThread::staticRun(util::ThreadArgs &args) {
@@ -137,10 +133,8 @@ namespace hazelcast {
                 }
                 std::vector<Address> configAddresses = getConfigAddresses();
                 addresses.insert(configAddresses.begin(), configAddresses.end());
-                #ifdef HZ_BUILD_WITH_SSL
                 std::vector<Address> awsAddresses = getAwsAddresses();
                 addresses.insert(awsAddresses.begin(), awsAddresses.end());
-                #endif // HZ_BUILD_WITH_SSL
 
                 if (addresses.empty()) {
                     addresses.insert(Address("127.0.0.1", 5701));
@@ -213,7 +207,6 @@ namespace hazelcast {
                 return socketAddresses;
             }
 
-            #ifdef HZ_BUILD_WITH_SSL
             std::vector<Address> ClusterListenerThread::getAwsAddresses() const {
                 std::vector<Address> awsAdresses;
                 config::ClientAwsConfig &awsConfig = clientContext.getClientConfig().getNetworkConfig().getAwsConfig();
@@ -231,7 +224,6 @@ namespace hazelcast {
 
                 return awsAdresses;
             }
-            #endif // HZ_BUILD_WITH_SSL
 
             void ClusterListenerThread::handleMember(const Member &member, const int32_t &eventType) {
                 switch (eventType) {

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -46,7 +46,8 @@ namespace hazelcast {
                     : clientContext(clientContext), inSelector(*this), outSelector(*this), inSelectorThread(NULL),
                       outSelectorThread(NULL), live(true), heartBeater(clientContext),
                       heartBeatThread(NULL), smartRouting(smartRouting), ownerConnectionFuture(clientContext),
-                      callIdGenerator(0), connectionIdCounter(0), socketFactory(clientContext) {
+                      callIdGenerator(0), connectionIdCounter(0), socketFactory(clientContext),
+                      translator(clientContext.getClientConfig().getNetworkConfig().getAwsConfig()) {
                 const byte protocol_bytes[3] = {'C', 'B', '2'};
                 PROTOCOL.insert(PROTOCOL.begin(), &protocol_bytes[0], &protocol_bytes[3]);
             }
@@ -436,7 +437,7 @@ namespace hazelcast {
             }
 
             Address ConnectionManager::translateAddress(const Address &address) {
-                return socketFactory.translateAddress(address);
+                return translator.translate(address);
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -489,7 +489,7 @@ namespace hazelcast {
             Address ConnectionManager::translateAddress(const Address &address) {
                 #ifdef HZ_BUILD_WITH_SSL
                 // translate ip
-                return *translator.translate(address);
+                return translator.translate(address);
                 #else
                 return address;
                 #endif // HZ_BUILD_WITH_SSL

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -46,11 +46,7 @@ namespace hazelcast {
                     : clientContext(clientContext), inSelector(*this), outSelector(*this), inSelectorThread(NULL),
                       outSelectorThread(NULL), live(true), heartBeater(clientContext),
                       heartBeatThread(NULL), smartRouting(smartRouting), ownerConnectionFuture(clientContext),
-                      callIdGenerator(0), connectionIdCounter(0)
-            #ifdef HZ_BUILD_WITH_SSL
-            , translator(clientContext.getClientConfig().getNetworkConfig().getAwsConfig())
-            #endif // HZ_BUILD_WITH_SSL
-            {
+                      callIdGenerator(0), connectionIdCounter(0), socketFactory(clientContext) {
                 const byte protocol_bytes[3] = {'C', 'B', '2'};
                 PROTOCOL.insert(PROTOCOL.begin(), &protocol_bytes[0], &protocol_bytes[3]);
             }
@@ -66,51 +62,8 @@ namespace hazelcast {
                 inSelectorThread.reset(new util::Thread("hz.inListener", InSelector::staticListen, &inSelector));
                 outSelectorThread.reset(new util::Thread("hz.outListener", OutSelector::staticListen, &outSelector));
                 heartBeatThread.reset(new util::Thread("hz.heartbeater", HeartBeater::staticStart, &heartBeater));
-                #ifdef HZ_BUILD_WITH_SSL
-                const config::SSLConfig &sslConfig = clientContext.getClientConfig().getNetworkConfig().getSSLConfig();
-                if (sslConfig.isEnabled()) {
-                    sslContext = std::auto_ptr<asio::ssl::context>(new asio::ssl::context(
-                            (asio::ssl::context_base::method) sslConfig.getProtocol()));
 
-                    const std::vector<std::string> &verifyFiles = sslConfig.getVerifyFiles();
-                    bool success = true;
-                    for (std::vector<std::string>::const_iterator it = verifyFiles.begin(); it != verifyFiles.end();
-                         ++it) {
-                        asio::error_code ec;
-                        sslContext->load_verify_file(*it, ec);
-                        if (ec) {
-                            util::ILogger::getLogger().warning(
-                                    std::string("ConnectionManager::start: Failed to load CA "
-                                                        "verify file at ") + *it + " "
-                                    + ec.message());
-                            success = false;
-                        }
-                    }
-
-                    if (!success) {
-                        sslContext.reset();
-                        util::ILogger::getLogger().warning("ConnectionManager::start: Failed to load one or more "
-                                                                   "configured CA verify files (PEM files). Please "
-                                                                   "correct the files and retry.");
-                        return false;
-                    }
-
-                    // set cipher list if the list is set
-                    const std::string &cipherList = sslConfig.getCipherList();
-                    if (!cipherList.empty()) {
-                        if (!SSL_CTX_set_cipher_list(sslContext->native_handle(), cipherList.c_str())) {
-                            util::ILogger::getLogger().warning(
-                                    std::string("ConnectionManager::start: Could not load any "
-                                                        "of the ciphers in the config provided "
-                                                        "ciphers:") + cipherList);
-                            return false;
-                        }
-                    }
-
-                    ioService = std::auto_ptr<asio::io_service>(new asio::io_service);
-                }
-                #endif
-                return true;
+                return socketFactory.start();
             }
 
             void ConnectionManager::shutdown() {
@@ -406,11 +359,7 @@ namespace hazelcast {
 
             std::auto_ptr<Connection> ConnectionManager::connectTo(const Address &address, bool ownerConnection) {
                 std::auto_ptr<connection::Connection> conn(
-                        new Connection(address, clientContext, inSelector, outSelector, ownerConnection
-                #ifdef HZ_BUILD_WITH_SSL
-                , ioService.get(), sslContext.get()
-                #endif
-                ));
+                        new Connection(address, clientContext, inSelector, outSelector, socketFactory, ownerConnection));
 
                 checkLive();
                 conn->connect(clientContext.getClientConfig().getConnectionTimeout());
@@ -487,12 +436,7 @@ namespace hazelcast {
             }
 
             Address ConnectionManager::translateAddress(const Address &address) {
-                #ifdef HZ_BUILD_WITH_SSL
-                // translate ip
-                return translator.translate(address);
-                #else
-                return address;
-                #endif // HZ_BUILD_WITH_SSL
+                return socketFactory.translateAddress(address);
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/connection/OwnerConnectionFuture.cpp
+++ b/hazelcast/src/hazelcast/client/connection/OwnerConnectionFuture.cpp
@@ -40,7 +40,7 @@ namespace hazelcast {
             }
 
             boost::shared_ptr<Connection> OwnerConnectionFuture::createNew(const Address& address) {
-                ownerConnectionPtr = clientContext.getConnectionManager().connectTo(address, true);
+                ownerConnectionPtr = clientContext.getConnectionManager().connectAsOwner(address);
                 ownerConnectionPtr->setAsOwnerConnection(true);
                 return ownerConnectionPtr;
             }

--- a/hazelcast/src/hazelcast/client/internal/socket/SocketFactory.cpp
+++ b/hazelcast/src/hazelcast/client/internal/socket/SocketFactory.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hazelcast/client/internal/socket/SocketFactory.h"
+#include "hazelcast/client/config/SSLConfig.h"
+#include "hazelcast/client/ClientConfig.h"
+#include "hazelcast/client/config/ClientNetworkConfig.h"
+#include "hazelcast/util/ILogger.h"
+#include "hazelcast/client/Socket.h"
+#include "hazelcast/client/internal/socket/TcpSocket.h"
+#include "hazelcast/client/spi/ClientContext.h"
+
+#ifdef HZ_BUILD_WITH_SSL
+#include "hazelcast/client/internal/socket/SSLSocket.h"
+#endif // HZ_BUILD_WITH_SSL
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4996) //for strerror	
+#endif
+
+namespace hazelcast {
+    namespace client {
+        namespace internal {
+            namespace socket {
+                SocketFactory::SocketFactory(spi::ClientContext &clientContext) : clientContext(clientContext) {
+                }
+
+                bool SocketFactory::start() {
+                    #ifdef HZ_BUILD_WITH_SSL
+                    const config::SSLConfig &sslConfig = clientContext.getClientConfig().getNetworkConfig().getSSLConfig();
+                    if (sslConfig.isEnabled()) {
+                        sslContext = std::auto_ptr<asio::ssl::context>(new asio::ssl::context(
+                                (asio::ssl::context_base::method) sslConfig.getProtocol()));
+
+                        const std::vector<std::string> &verifyFiles = sslConfig.getVerifyFiles();
+                        bool success = true;
+                        for (std::vector<std::string>::const_iterator it = verifyFiles.begin(); it != verifyFiles.end();
+                             ++it) {
+                            asio::error_code ec;
+                            sslContext->load_verify_file(*it, ec);
+                            if (ec) {
+                                util::ILogger::getLogger().warning(
+                                        std::string("SocketFactory::start: Failed to load CA "
+                                                            "verify file at ") + *it + " "
+                                        + ec.message());
+                                success = false;
+                            }
+                        }
+
+                        if (!success) {
+                            sslContext.reset();
+                            util::ILogger::getLogger().warning("SocketFactory::start: Failed to load one or more "
+                                                                       "configured CA verify files (PEM files). Please "
+                                                                       "correct the files and retry.");
+                            return false;
+                        }
+
+                        // set cipher list if the list is set
+                        const std::string &cipherList = sslConfig.getCipherList();
+                        if (!cipherList.empty()) {
+                            if (!SSL_CTX_set_cipher_list(sslContext->native_handle(), cipherList.c_str())) {
+                                util::ILogger::getLogger().warning(
+                                        std::string("SocketFactory::start: Could not load any "
+                                                            "of the ciphers in the config provided "
+                                                            "ciphers:") + cipherList);
+                                return false;
+                            }
+                        }
+
+                        ioService = std::auto_ptr<asio::io_service>(new asio::io_service);
+                    }
+                    #else
+                    (void) clientContext;
+                    #endif
+                    
+                    return true;
+                }
+
+                std::auto_ptr<Socket> SocketFactory::create(const Address &address) const {
+                    #ifdef HZ_BUILD_WITH_SSL
+                    if (sslContext.get()) {
+                        return std::auto_ptr<Socket>(new internal::socket::SSLSocket(address, *ioService, *sslContext));
+                    }
+                    #endif
+                    return std::auto_ptr<Socket>(new internal::socket::TcpSocket(address));
+                }
+
+                Address SocketFactory::translateAddress(const Address &address) {
+                    #ifdef HZ_BUILD_WITH_SSL
+                    // translate ip
+                    return translator->translate(address);
+                    #else
+                    return address;
+                    #endif // HZ_BUILD_WITH_SSL
+                }
+            }
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif

--- a/hazelcast/src/hazelcast/client/internal/socket/SocketFactory.cpp
+++ b/hazelcast/src/hazelcast/client/internal/socket/SocketFactory.cpp
@@ -35,11 +35,7 @@ namespace hazelcast {
     namespace client {
         namespace internal {
             namespace socket {
-                SocketFactory::SocketFactory(spi::ClientContext &clientContext) : clientContext(clientContext)
-                    #ifdef HZ_BUILD_WITH_SSL
-                        , translator(clientContext.getClientConfig().getNetworkConfig().getAwsConfig())
-                    #endif
-                {
+                SocketFactory::SocketFactory(spi::ClientContext &clientContext) : clientContext(clientContext) {
                 }
 
                 bool SocketFactory::start() {
@@ -100,15 +96,6 @@ namespace hazelcast {
                     }
                     #endif
                     return std::auto_ptr<Socket>(new internal::socket::TcpSocket(address));
-                }
-
-                Address SocketFactory::translateAddress(const Address &address) {
-                    #ifdef HZ_BUILD_WITH_SSL
-                    // translate ip
-                    return translator.translate(address);
-                    #else
-                    return address;
-                    #endif // HZ_BUILD_WITH_SSL
                 }
             }
         }

--- a/hazelcast/src/hazelcast/client/internal/socket/SocketFactory.cpp
+++ b/hazelcast/src/hazelcast/client/internal/socket/SocketFactory.cpp
@@ -35,7 +35,11 @@ namespace hazelcast {
     namespace client {
         namespace internal {
             namespace socket {
-                SocketFactory::SocketFactory(spi::ClientContext &clientContext) : clientContext(clientContext) {
+                SocketFactory::SocketFactory(spi::ClientContext &clientContext) : clientContext(clientContext)
+                    #ifdef HZ_BUILD_WITH_SSL
+                        , translator(clientContext.getClientConfig().getNetworkConfig().getAwsConfig())
+                    #endif
+                {
                 }
 
                 bool SocketFactory::start() {
@@ -101,7 +105,7 @@ namespace hazelcast {
                 Address SocketFactory::translateAddress(const Address &address) {
                     #ifdef HZ_BUILD_WITH_SSL
                     // translate ip
-                    return translator->translate(address);
+                    return translator.translate(address);
                     #else
                     return address;
                     #endif // HZ_BUILD_WITH_SSL

--- a/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
@@ -168,6 +168,9 @@ namespace hazelcast {
                 if ((Address *) NULL != previousConnectionAddr) {
                     addresses.push_back(*previousConnectionAddr);
                 }
+
+                std::random_shuffle(addresses.begin(), addresses.end());
+
                 return addresses;
             }
             //--------- Used by CLUSTER LISTENER THREAD ------------

--- a/hazelcast/src/hazelcast/util/Preconditions.cpp
+++ b/hazelcast/src/hazelcast/util/Preconditions.cpp
@@ -43,6 +43,14 @@ namespace hazelcast {
 
             return argument;
         }
+
+        void Preconditions::checkSSL(const std::string &sourceMethod) throw(client::exception::InvalidConfigurationException) {
+            #ifndef HZ_BUILD_WITH_SSL
+            throw client::exception::InvalidConfigurationException(sourceMethod, "You should compile with "
+                    "HZ_BUILD_WITH_SSL flag. You should also have the openssl installed on your machine and you need "
+                    "to link with the openssl library.");
+            #endif
+        }
     }
 }
 

--- a/hazelcast/src/hazelcast/util/SyncHttpClient.cpp
+++ b/hazelcast/src/hazelcast/util/SyncHttpClient.cpp
@@ -16,42 +16,29 @@
 //
 //  Created by ihsan demir on 12 Jan 2017
 //
-#ifdef HZ_BUILD_WITH_SSL
-
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #include <WinSock2.h>
 #endif
 
-#include <asio/asio/include/asio/ssl/rfc2818_verification.hpp>
-
-#include "hazelcast/util/SyncHttpsClient.h"
+#include "hazelcast/util/SyncHttpClient.h"
 #include "hazelcast/client/exception/IOException.h"
 
 namespace hazelcast {
     namespace util {
-            SyncHttpsClient::SyncHttpsClient(const std::string &serverIp, const std::string &uriPath) : server(serverIp), uriPath(uriPath),
-                                                                         sslContext(asio::ssl::context::sslv23),
-                                                                         responseStream(&response) {
-                sslContext.set_default_verify_paths();
-                sslContext.set_options(asio::ssl::context::default_workarounds | asio::ssl::context::no_sslv2 |
-                                               asio::ssl::context::single_dh_use);
-
-                socket = std::auto_ptr<asio::ssl::stream<asio::ip::tcp::socket> >(
-                        new asio::ssl::stream<asio::ip::tcp::socket>(ioService, sslContext));
+            SyncHttpClient::SyncHttpClient(const std::string &serverIp, const std::string &uriPath)
+                    : server(serverIp), uriPath(uriPath), socket(ioService), responseStream(&response) {
             }
 
-            std::istream &SyncHttpsClient::openConnection() {
+            std::istream &SyncHttpClient::openConnection() {
                 try {
                     // Get a list of endpoints corresponding to the server name.
                     asio::ip::tcp::resolver resolver(ioService);
-                    asio::ip::tcp::resolver::query query(server, "https");
+                    asio::ip::tcp::resolver::query query(server, "http");
                     asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 
-                    asio::connect(socket->lowest_layer(), endpoint_iterator);
+                    asio::connect(socket, endpoint_iterator);
 
-                    socket->lowest_layer().set_option(asio::ip::tcp::no_delay(true));
-                    socket->set_verify_callback(asio::ssl::rfc2818_verification(server));
-                    socket->handshake(asio::ssl::stream_base::client);
+                    socket.lowest_layer().set_option(asio::ip::tcp::no_delay(true));
 
                     // Form the request. We specify the "Connection: close" header so that the
                     // server will close the socket after transmitting the response. This will
@@ -64,12 +51,12 @@ namespace hazelcast {
                     request_stream << "Connection: close\r\n\r\n";
 
                     // Send the request.
-                    asio::write(*socket, request.data());
+                    asio::write(socket, request.data());
 
                     // Read the response status line. The response streambuf will automatically
                     // grow to accommodate the entire line. The growth may be limited by passing
                     // a maximum size to the streambuf constructor.
-                    asio::read_until(*socket, response, "\r\n");
+                    asio::read_until(socket, response, "\r\n");
 
                     // Check that response is OK.
                     std::string httpVersion;
@@ -84,11 +71,11 @@ namespace hazelcast {
                     if (statusCode != 200) {
                         std::stringstream out;
                         out << "Response returned with status: " << statusCode << " Status message:" << statusMessage;
-                        throw client::exception::IOException("SyncHttpsClient::openConnection", out.str());;
+                        throw client::exception::IOException("SyncHttpClient::openConnection", out.str());;
                     }
 
                     // Read the response headers, which are terminated by a blank line.
-                    asio::read_until(*socket, response, "\r\n\r\n");
+                    asio::read_until(socket, response, "\r\n\r\n");
 
                     // Process the response headers.
                     std::string header;
@@ -97,7 +84,7 @@ namespace hazelcast {
                     // Read until EOF
                     asio::error_code error;
                     size_t bytesRead;
-                    while ((bytesRead = asio::read(*socket, response.prepare(1024),
+                    while ((bytesRead = asio::read(socket, response.prepare(1024),
                                       asio::transfer_at_least(1), error))) {
                         response.commit(bytesRead);
                     }
@@ -109,11 +96,9 @@ namespace hazelcast {
                     return responseStream;
                 } catch (asio::system_error &e) {
                     std::ostringstream out;
-                    out << "Could not retrieve response from https://" << server << uriPath << " Error:" << e.what();
-                    throw client::exception::IOException("SyncHttpsClient::openConnection", out.str());
+                    out << "Could not retrieve response from http://" << server << uriPath << " Error:" << e.what();
+                    throw client::exception::IOException("SyncHttpClient::openConnection", out.str());
                 }
             }
     }
 }
-
-#endif // HZ_BUILD_WITH_SSL

--- a/hazelcast/test/src/aws/AwsClientTest.cpp
+++ b/hazelcast/test/src/aws/AwsClientTest.cpp
@@ -45,6 +45,21 @@ namespace hazelcast {
 
                     HazelcastClient hazelcastClient(clientConfig);
                 }
+
+                /**
+                 * Following test can only run from inside the AWS network
+                 */
+                #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+                TEST_F (AwsClientTest, testRetrieveCredentialsFromIamRoleAndConnect) {
+                    ClientConfig clientConfig;
+
+                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).setIamRole("cloudbees").setTagKey(
+                            "aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
+
+                    HazelcastClient hazelcastClient(clientConfig);
+                }
+                #endif
             }
         }
     }

--- a/hazelcast/test/src/aws/AwsClientTest.cpp
+++ b/hazelcast/test/src/aws/AwsClientTest.cpp
@@ -29,18 +29,21 @@ namespace hazelcast {
                 class AwsClientTest : public ::testing::Test {
                 };
 
-                TEST_F (AwsClientTest, testConnectionToAwsCluster) {
-                    ClientConfig config;
-                    // consume the addresses quickly
-                    config.getNetworkConfig().setConnectionTimeout(500);
-                    config::ClientAwsConfig &awsConfig = config.getNetworkConfig().getAwsConfig();
-                    awsConfig.setEnabled(true).setAccessKey(getenv("HZ_TEST_AWS_ACCESS_KEY")).
-                            setSecretKey(getenv("HZ_TEST_AWS_SECRET")).setTagKey("Name").setTagValue("*linux-release");
-                    try {
-                        HazelcastClient hazelcastClient(config);
-                    } catch (exception::IException &e) {
-                        ASSERT_STREQ("HazelcastClient could not be started!", e.getMessage().c_str());
-                    }
+                TEST_F (AwsClientTest, testClientAwsMemberNonDefaultPortConfig) {
+                    ClientConfig clientConfig;
+
+                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
+                            setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(getenv("AWS_SECRET_ACCESS_KEY")).
+                            setTagKey("aws-test-tag").setTagValue("aws-tag-value-1");
+
+                    #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+                    clientConfig.getNetworkConfig().getAwsConfig().setInsideAws(true);
+                    #else
+                    clientConfig.getNetworkConfig().getAwsConfig().setInsideAws(false);
+                    #endif
+
+                    HazelcastClient hazelcastClient(clientConfig);
                 }
             }
         }

--- a/hazelcast/test/src/aws/AwsClientTest.cpp
+++ b/hazelcast/test/src/aws/AwsClientTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HZ_BUILD_WITH_SSL
+
+#include <cmath>
+#include <gtest/gtest.h>
+
+#include <hazelcast/client/HazelcastClient.h>
+#include <hazelcast/client/ClientConfig.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            namespace aws {
+                class AwsClientTest : public ::testing::Test {
+                };
+
+                TEST_F (AwsClientTest, testConnectionToAwsCluster) {
+                    ClientConfig config;
+                    // consume the addresses quickly
+                    config.getNetworkConfig().setConnectionTimeout(500);
+                    config::ClientAwsConfig &awsConfig = config.getNetworkConfig().getAwsConfig();
+                    awsConfig.setEnabled(true).setAccessKey(getenv("HZ_TEST_AWS_ACCESS_KEY")).
+                            setSecretKey(getenv("HZ_TEST_AWS_SECRET")).setTagKey("Name").setTagValue("*linux-release");
+                    try {
+                        HazelcastClient hazelcastClient(config);
+                    } catch (exception::IException &e) {
+                        ASSERT_STREQ("HazelcastClient could not be started!", e.getMessage().c_str());
+                    }
+                }
+            }
+        }
+    }
+}
+#endif // HZ_BUILD_WITH_SSL

--- a/hazelcast/test/src/aws/AwsClientTest.cpp
+++ b/hazelcast/test/src/aws/AwsClientTest.cpp
@@ -44,6 +44,12 @@ namespace hazelcast {
                     #endif
 
                     HazelcastClient hazelcastClient(clientConfig);
+
+                    IMap<int, int> map = hazelcastClient.getMap<int, int>("myMap");
+                    map.put(5, 20);
+                    boost::shared_ptr<int> val = map.get(5);
+                    ASSERT_NE((int *) NULL, val.get());
+                    ASSERT_EQ(20, *val);
                 }
 
                 /**

--- a/hazelcast/test/src/aws/AwsClientTest.cpp
+++ b/hazelcast/test/src/aws/AwsClientTest.cpp
@@ -54,7 +54,17 @@ namespace hazelcast {
                     ClientConfig clientConfig;
 
                     clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
-                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).setIamRole("cloudbees").setTagKey(
+                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).setIamRole("cloudbees-role").setTagKey(
+                            "aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
+
+                    HazelcastClient hazelcastClient(clientConfig);
+                }
+
+                TEST_F (AwsClientTest, testRetrieveCredentialsFromInstanceProfileDefaultIamRoleAndConnect) {
+                    ClientConfig clientConfig;
+
+                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).setTagKey(
                             "aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
 
                     HazelcastClient hazelcastClient(clientConfig);

--- a/hazelcast/test/src/aws/AwsConfigTest.cpp
+++ b/hazelcast/test/src/aws/AwsConfigTest.cpp
@@ -19,7 +19,9 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
-#include <hazelcast/client/ClientConfig.h>
+#include "hazelcast/client/ClientConfig.h"
+#include "hazelcast/client/ClientProperties.h"
+#include "hazelcast/client/HazelcastClient.h"
 
 namespace hazelcast {
     namespace client {
@@ -89,6 +91,21 @@ namespace hazelcast {
                     clientConfig.getNetworkConfig().setAwsConfig(newConfig);
                     // default constructor sets enabled to false
                     ASSERT_FALSE(clientConfig.getNetworkConfig().getAwsConfig().isEnabled());
+                }
+
+                TEST_F (AwsConfigTest, testInvalidAwsMemberPortConfig) {
+                    ClientConfig clientConfig;
+
+                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "65536";
+                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
+                            setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(getenv("AWS_SECRET_ACCESS_KEY")).
+                            setTagKey("aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
+
+                    ASSERT_THROW(HazelcastClient hazelcastClient(clientConfig), exception::InvalidConfigurationException);
+
+                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "-1";
+
+                    ASSERT_THROW(HazelcastClient hazelcastClient(clientConfig), exception::InvalidConfigurationException);
                 }
             }
         }

--- a/hazelcast/test/src/aws/DescribeInstancesTest.cpp
+++ b/hazelcast/test/src/aws/DescribeInstancesTest.cpp
@@ -34,12 +34,12 @@ namespace hazelcast {
                  */
                 TEST_F (DescribeInstancesTest, testDescribeInstances) {
                     client::config::ClientAwsConfig awsConfig;
-                    awsConfig.setEnabled(true);
-
-                    awsConfig.setAccessKey(getenv("HZ_TEST_AWS_ACCESS_KEY")).setSecretKey(getenv("HZ_TEST_AWS_SECRET"));
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("aws-test-tag").setTagValue("aws-tag-value-1");
                     client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
                     std::map<std::string, std::string> results = desc.execute();
-                    ASSERT_GT(results.size(), 0U);
+                    ASSERT_EQ(results.size(), 1U);
+                    ASSERT_NE(results.end(), results.find(getenv("HZ_TEST_AWS_INSTANCE_PRIVATE_IP")));
                 }
             }
         }

--- a/hazelcast/test/src/aws/DescribeInstancesTest.cpp
+++ b/hazelcast/test/src/aws/DescribeInstancesTest.cpp
@@ -36,8 +36,7 @@ namespace hazelcast {
                     client::config::ClientAwsConfig awsConfig;
                     awsConfig.setEnabled(true);
 
-                    awsConfig.setAccessKey(getenv("HZ_TEST_AWS_ACCESS_KEY"));
-                    awsConfig.setSecretKey(getenv("HZ_TEST_AWS_SECRET"));
+                    awsConfig.setAccessKey(getenv("HZ_TEST_AWS_ACCESS_KEY")).setSecretKey(getenv("HZ_TEST_AWS_SECRET"));
                     client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
                     std::map<std::string, std::string> results = desc.execute();
                     ASSERT_GT(results.size(), 0U);

--- a/java/src/main/java/CppClientListener.java
+++ b/java/src/main/java/CppClientListener.java
@@ -532,9 +532,7 @@ public class CppClientListener {
     public static void main(String args[]) throws IOException {
         final Map<Integer, HazelcastInstance> map = new HashMap<Integer, HazelcastInstance>();
         final Config config = prepareConfig();
-        if (args.length >= 1) {
-            System.setProperty("hazelcast.enterprise.license.key", args[0]);
-        }
+        System.setProperty("hazelcast.enterprise.license.key", System.getenv("HAZELCAST_ENTERPRISE_KEY"));
         final AtomicInteger atomicInteger = new AtomicInteger(0);
         final ServerSocket welcomeSocket = new ServerSocket(6543);
         System.out.println(welcomeSocket.getLocalSocketAddress());

--- a/testLinuxSingleCase.sh
+++ b/testLinuxSingleCase.sh
@@ -74,7 +74,7 @@ then
 fi
 
 echo "Starting the java test server"
-mvn exec:java -Dexec.mainClass="CppClientListener"  -Dexec.args="${HAZELCAST_ENTERPRISE_KEY}" &
+mvn exec:java -Dexec.mainClass="CppClientListener" &
 serverPid=$!
 
 echo "Spawned server with pid ${serverPid}"

--- a/testWindowsSingleCase.bat
+++ b/testWindowsSingleCase.bat
@@ -55,7 +55,7 @@ call mvn -U clean install
 call taskkill /F /FI "WINDOWTITLE eq cpp-java"
 
 echo "Starting the java test server"
-start "cpp-java" mvn package exec:java -Dexec.mainClass="CppClientListener" -Dexec.args="%HAZELCAST_ENTERPRISE_KEY%"
+start "cpp-java" mvn package exec:java -Dexec.mainClass="CppClientListener"
 
 SET DEFAULT_TIMEOUT=30
 SET SERVER_PORT=6543


### PR DESCRIPTION
Added aws address translator to be used for private to public ip conversion.

Integrated the cloud discovery using AWSClient to client.

Made the tagSet and groupSet reads from AWS response to be optional since for some instances they may not exist.

Minor fix to CppClientListener to obtain the license key from environment rather than as a command line parameter.