### PR TITLE
Update test server version since Hazelcast 3.8.1 is released

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,12 +16,12 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-enterprise</artifactId>
-            <version>3.8.1-SNAPSHOT</version>
+            <version>3.8.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.8.1-SNAPSHOT</version>
+            <version>3.8.2-SNAPSHOT</version>
             <type>test-jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Since Hazelcast 3.8.1 is already released, use 3.8.2-SNAPSHOT for tests.