### PR TITLE
Non SSL build tests fail since it uses server with TLS config on

### DIFF
--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -84,8 +84,14 @@ namespace hazelcast {
                     }
 
                     static void SetUpTestCase() {
+                        #ifdef HZ_BUILD_WITH_SSL
                         instance = new HazelcastServer(*g_srvFactory, true);
                         instance2 = new HazelcastServer(*g_srvFactory, true);
+                        #else
+                        instance = new HazelcastServer(*g_srvFactory);
+                        instance2 = new HazelcastServer(*g_srvFactory);
+                        #endif
+
                         clientConfig = getConfig().release();
                         #ifdef HZ_BUILD_WITH_SSL
                         config::SSLConfig sslConfig;

--- a/hazelcast/test/src/list/ClientListTest.cpp
+++ b/hazelcast/test/src/list/ClientListTest.cpp
@@ -35,8 +35,14 @@ namespace hazelcast {
                 }
 
                 static void SetUpTestCase() {
+                    #ifdef HZ_BUILD_WITH_SSL
                     instance = new HazelcastServer(*g_srvFactory, true);
+                    #else
+                    instance = new HazelcastServer(*g_srvFactory);
+                    #endif
+
                     clientConfig = getConfig().release();
+
                     #ifdef HZ_BUILD_WITH_SSL
                     config::ClientNetworkConfig networkConfig;
                     config::SSLConfig sslConfig;
@@ -44,6 +50,7 @@ namespace hazelcast {
                     networkConfig.setSSLConfig(sslConfig);
                     clientConfig->setNetworkConfig(networkConfig);
                     #endif // HZ_BUILD_WITH_SSL
+
                     client = new HazelcastClient(*clientConfig);
                     list = new IList<std::string>(client->getList<std::string>("MyList"));
                 }


### PR DESCRIPTION
Use server instance with no SSL configured during tests when -DHZ_BUILD_WITH_SSL flag is not provided.