### PR TITLE
centos7 gcc 4.8.5 build failure due to missing header

### DIFF
--- a/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 #include "hazelcast/util/HazelcastDll.h"
 


### PR DESCRIPTION
Fixes the warning at centos7 gcc 4.8.5 about missing header for std::auto_ptr.