### PR TITLE
Filter at AWS server - No client side filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,27 @@ If no IAM role or access key is provided, the client will retrieve the IAM role 
 
 The details of IAM role usage for applications are described at http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html. The IAM role access key retrieval requires that the instance has a valid instance profile association for the IAM role and the IAM role should have the AWS DescribeInstances permission.
  
+### Policy for IAM User
+
+If you are using IAM role configuration (`iam-role`) for EC2 discovery, you need to give the following policy to your IAM user at the least:
+
+`"ec2:DescribeInstances"`
+```
+{
+  "Version": "XXXXXXXX",
+  "Statement": [
+    {
+      "Sid": "XXXXXXXX",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+```
+ 
 # Code Examples
 
 You can try the following C++ client code examples. You need to have a Hazelcast client member running for the code examples to work. 

--- a/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/DescribeInstances.h
@@ -40,6 +40,10 @@ namespace hazelcast {
                 class EC2RequestSigner;
             }
             namespace impl {
+                /**
+                 * See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+                 * for AWS API details.
+                 */
                 class HAZELCAST_API DescribeInstances {
                 public:
                     DescribeInstances(config::ClientAwsConfig &awsConfig, const std::string &endpoint);
@@ -65,6 +69,11 @@ namespace hazelcast {
                     void getKeysFromIamTaskRole();
                     void getKeysFromIamRole();
                     void parseAndStoreRoleCreds(std::istream &in);
+
+                    /**
+                     * Add available filters to narrow down the scope of the query
+                     */
+                    void addFilters();
 
                     std::auto_ptr<security::EC2RequestSigner> rs;
                     config::ClientAwsConfig &awsConfig;

--- a/hazelcast/include/hazelcast/client/aws/impl/Filter.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/Filter.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZELCAST_CLIENT_AWS_IMPL_FILTER_H_
+#define HAZELCAST_CLIENT_AWS_IMPL_FILTER_H_
+
+#include <map>
+#include <string>
+
+#include "hazelcast/util/HazelcastDll.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export	
+#endif
+
+namespace hazelcast {
+    namespace client {
+        namespace aws {
+            namespace impl {
+                /**
+                 * Query filter to narrow down the scope of the queried EC2 instance set.
+                 */
+                class HAZELCAST_API Filter {
+                public:
+                    Filter();
+
+                    /**
+                     *
+                     * Add a new filter with the given name and value to the query.
+                     *
+                     * @param name Filter name
+                     * @param value Filter value
+                     *
+                     */
+                    void addFilter(const std::string &name, const std::string &value);
+
+                    const std::map<std::string, std::string> &getFilters();
+
+                private:
+                    std::map<std::string, std::string> filters;
+                };
+            };
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+#endif /* HAZELCAST_CLIENT_AWS_IMPL_FILTER_H_ */

--- a/hazelcast/include/hazelcast/client/aws/utility/CloudUtility.h
+++ b/hazelcast/include/hazelcast/client/aws/utility/CloudUtility.h
@@ -40,25 +40,16 @@ namespace hazelcast {
                 public:
                     /**
                      * Unmarshal the response from {@link DescribeInstances} and return the discovered node map.
-                     * The map contains mappings from private to public IP and all contained nodes match the filtering rules defined by
-                     * the {@code awsConfig}.
-                     * If there is an exception while unmarshaling the response, returns an empty map.
+                     * The map contains mappings from private to public IP.
+                     * If there is an exception while unmarshalling the response, returns an empty map.
                      *
                      * @param stream    the response XML stream
-                     * @param awsConfig the AWS configuration for filtering the returned addresses
                      * @return map from private to public IP or empty map in case of exceptions
                      */
-                    static std::map<std::string, std::string> unmarshalTheResponse(std::istream &stream,
-                                                                                   const config::ClientAwsConfig &awsConfig);
+                    static std::map<std::string, std::string> unmarshalTheResponse(std::istream &stream);
 
                     static void unmarshalJsonResponse(std::istream &stream, config::ClientAwsConfig &awsConfig,
                                                       std::map<std::string, std::string> &attributes);
-
-                private:
-                    static bool acceptTag(const config::ClientAwsConfig &awsConfig, pt::ptree &reservationSetItem);
-
-                    static bool acceptGroupName(const config::ClientAwsConfig &awsConfig,
-                                                pt::ptree &reservationSetItem);
                 };
             }
         }

--- a/hazelcast/src/hazelcast/client/aws/impl/Constants.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/Constants.cpp
@@ -20,7 +20,7 @@ namespace hazelcast {
         namespace aws {
             namespace impl {
                 const char *Constants::DATE_FORMAT = "%Y%m%dT%H%M%SZ";
-                const char *Constants::DOC_VERSION = "2014-06-15";
+                const char *Constants::DOC_VERSION = "2016-11-15";
                 const char *Constants::SIGNATURE_METHOD_V4 = "AWS4-HMAC-SHA256";
                 const char *Constants::GET = "GET";
                 const char *Constants::ECS_CREDENTIALS_ENV_VAR_NAME = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";

--- a/hazelcast/src/hazelcast/client/aws/impl/Filter.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/Filter.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sstream>
+#include "hazelcast/client/aws/impl/Filter.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace aws {
+            namespace impl {
+                Filter::Filter() {
+                }
+
+                /**
+                 *
+                 * Add a new filter with the given name and value to the query.
+                 *
+                 * @param name Filter name
+                 * @param value Filter value
+                 *
+                 */
+                void Filter::addFilter(const std::string &name, const std::string &value) {
+                    std::stringstream out;
+                    unsigned long index = filters.size() + 1;
+                    out << "Filter." << index << ".Name";
+                    filters[out.str()] = name;
+                    out.str("");
+                    out.clear();
+                    out << "Filter." << index << ".Value.1";
+                    filters[out.str()] = value;
+                }
+
+                const std::map<std::string, std::string> &Filter::getFilters() {
+                    return filters;
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/test/src/aws/AwsClientTest.cpp
+++ b/hazelcast/test/src/aws/AwsClientTest.cpp
@@ -52,6 +52,30 @@ namespace hazelcast {
                     ASSERT_EQ(20, *val);
                 }
 
+                TEST_F (AwsClientTest, testClientAwsMemberWithSecurityGroupDefaultIamRole) {
+                    ClientConfig clientConfig;
+
+                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
+                            setSecurityGroupName("launch-wizard-147");
+
+                    #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+                    // The access key and secret will be retrieved from default IAM role at windows machine
+                    clientConfig.getNetworkConfig().getAwsConfig().setInsideAws(true);
+                    #else
+                    clientConfig.getNetworkConfig().getAwsConfig().setAccessKey(getenv("AWS_ACCESS_KEY_ID")).
+                            setSecretKey(getenv("AWS_SECRET_ACCESS_KEY"));
+                    #endif
+
+                    HazelcastClient hazelcastClient(clientConfig);
+
+                    IMap<int, int> map = hazelcastClient.getMap<int, int>("myMap");
+                    map.put(5, 20);
+                    boost::shared_ptr<int> val = map.get(5);
+                    ASSERT_NE((int *) NULL, val.get());
+                    ASSERT_EQ(20, *val);
+                }
+
                 /**
                  * Following test can only run from inside the AWS network
                  */

--- a/hazelcast/test/src/aws/CloudUtilityTest.cpp
+++ b/hazelcast/test/src/aws/CloudUtilityTest.cpp
@@ -38,7 +38,7 @@ namespace hazelcast {
                     std::istream responseStream(&fb);
 
                     config::ClientAwsConfig awsConfig;
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream, awsConfig);
+                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
                     ASSERT_EQ(4U, results.size());
                     ASSERT_NE(results.end(), results.find("10.0.16.13"));
                     ASSERT_EQ("", results["10.0.16.13"]);
@@ -57,7 +57,7 @@ namespace hazelcast {
 
                     config::ClientAwsConfig awsConfig;
                     awsConfig.setTagKey("mytagkey");
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream, awsConfig);
+                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
                     ASSERT_EQ(2U, results.size());
                     ASSERT_EQ(results.end(), results.find("10.0.16.13"));
                     ASSERT_EQ(results.end(), results.find("10.0.16.17"));
@@ -75,7 +75,7 @@ namespace hazelcast {
                     config::ClientAwsConfig awsConfig;
                     awsConfig.setTagKey("mytagkey");
                     awsConfig.setTagValue("mytagvalue");
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream, awsConfig);
+                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
                     ASSERT_EQ(2U, results.size());
                     ASSERT_EQ(results.end(), results.find("10.0.16.13"));
                     ASSERT_EQ(results.end(), results.find("10.0.16.17"));
@@ -92,7 +92,7 @@ namespace hazelcast {
 
                     config::ClientAwsConfig awsConfig;
                     awsConfig.setSecurityGroupName("mygroup");
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream, awsConfig);
+                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
                     ASSERT_EQ(2U, results.size());
                     ASSERT_EQ(results.end(), results.find("10.0.16.13"));
                     ASSERT_EQ(results.end(), results.find("10.0.16.25"));

--- a/hazelcast/test/src/aws/CloudUtilityTest.cpp
+++ b/hazelcast/test/src/aws/CloudUtilityTest.cpp
@@ -32,7 +32,7 @@ namespace hazelcast {
                 class CloudUtilityTest : public ::testing::Test {
                 };
 
-                TEST_F (CloudUtilityTest, testUnmarshallResponseXmlNoFilter) {
+                TEST_F (CloudUtilityTest, testUnmarshallResponseXml) {
                     std::filebuf fb;
                     ASSERT_TRUE(fb.open("hazelcast/test/resources/sample_aws_response.xml", std::ios::in));
                     std::istream responseStream(&fb);
@@ -45,59 +45,6 @@ namespace hazelcast {
                     ASSERT_NE(results.end(), results.find("10.0.16.17"));
                     ASSERT_EQ("54.85.192.215", results["10.0.16.17"]);
                     ASSERT_NE(results.end(), results.find("10.0.16.25"));
-                    ASSERT_EQ("", results["10.0.16.25"]);
-                    ASSERT_NE(results.end(), results.find("172.30.4.118"));
-                    ASSERT_EQ("54.85.192.213", results["172.30.4.118"]);
-                }
-
-                TEST_F (CloudUtilityTest, testUnmarshallResponseXmlFilterByTagKeyAndNoTagValue) {
-                    std::filebuf fb;
-                    ASSERT_TRUE(fb.open("hazelcast/test/resources/sample_aws_response.xml", std::ios::in));
-                    std::istream responseStream(&fb);
-
-                    config::ClientAwsConfig awsConfig;
-                    awsConfig.setTagKey("mytagkey");
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
-                    ASSERT_EQ(2U, results.size());
-                    ASSERT_EQ(results.end(), results.find("10.0.16.13"));
-                    ASSERT_EQ(results.end(), results.find("10.0.16.17"));
-                    ASSERT_NE(results.end(), results.find("10.0.16.25"));
-                    ASSERT_EQ("", results["10.0.16.25"]);
-                    ASSERT_NE(results.end(), results.find("172.30.4.118"));
-                    ASSERT_EQ("54.85.192.213", results["172.30.4.118"]);
-                }
-
-                TEST_F (CloudUtilityTest, testUnmarshallResponseXmlFilterByTagKeyAndTagValue) {
-                    std::filebuf fb;
-                    ASSERT_TRUE(fb.open("hazelcast/test/resources/sample_aws_response.xml", std::ios::in));
-                    std::istream responseStream(&fb);
-
-                    config::ClientAwsConfig awsConfig;
-                    awsConfig.setTagKey("mytagkey");
-                    awsConfig.setTagValue("mytagvalue");
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
-                    ASSERT_EQ(2U, results.size());
-                    ASSERT_EQ(results.end(), results.find("10.0.16.13"));
-                    ASSERT_EQ(results.end(), results.find("10.0.16.17"));
-                    ASSERT_NE(results.end(), results.find("10.0.16.25"));
-                    ASSERT_EQ("", results["10.0.16.25"]);
-                    ASSERT_NE(results.end(), results.find("172.30.4.118"));
-                    ASSERT_EQ("54.85.192.213", results["172.30.4.118"]);
-                }
-
-                TEST_F (CloudUtilityTest, testUnmarshallResponseXmlFilterBySecurityGroup) {
-                    std::filebuf fb;
-                    ASSERT_TRUE(fb.open("hazelcast/test/resources/sample_aws_response.xml", std::ios::in));
-                    std::istream responseStream(&fb);
-
-                    config::ClientAwsConfig awsConfig;
-                    awsConfig.setSecurityGroupName("mygroup");
-                    std::map<std::string, std::string> results = awsutil::CloudUtility::unmarshalTheResponse(responseStream);
-                    ASSERT_EQ(2U, results.size());
-                    ASSERT_EQ(results.end(), results.find("10.0.16.13"));
-                    ASSERT_EQ(results.end(), results.find("10.0.16.25"));
-                    ASSERT_NE(results.end(), results.find("10.0.16.17"));
-                    ASSERT_EQ("54.85.192.215", results["10.0.16.17"]);
                     ASSERT_EQ("", results["10.0.16.25"]);
                     ASSERT_NE(results.end(), results.find("172.30.4.118"));
                     ASSERT_EQ("54.85.192.213", results["172.30.4.118"]);

--- a/hazelcast/test/src/aws/DescribeInstancesTest.cpp
+++ b/hazelcast/test/src/aws/DescribeInstancesTest.cpp
@@ -29,10 +29,7 @@ namespace hazelcast {
                 class DescribeInstancesTest : public ::testing::Test {
                 };
 
-                /**
-                 * This test will be enabled when the credentials are provided from environment
-                 */
-                TEST_F (DescribeInstancesTest, testDescribeInstances) {
+                TEST_F (DescribeInstancesTest, testDescribeInstancesTagAndValueSet) {
                     client::config::ClientAwsConfig awsConfig;
                     awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
                             getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("aws-test-tag").setTagValue("aws-tag-value-1");
@@ -40,6 +37,72 @@ namespace hazelcast {
                     std::map<std::string, std::string> results = desc.execute();
                     ASSERT_EQ(results.size(), 1U);
                     ASSERT_NE(results.end(), results.find(getenv("HZ_TEST_AWS_INSTANCE_PRIVATE_IP")));
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesTagAndNonExistentValueSet) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("aws-test-tag").setTagValue("non-existent-value");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_TRUE(results.empty());
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesOnlyTagIsSet) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("aws-test-tag");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_EQ(results.size(), 1U);
+                    ASSERT_NE(results.end(), results.find(getenv("HZ_TEST_AWS_INSTANCE_PRIVATE_IP")));
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesOnlyTagIsSetToNonExistentTag) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setTagKey("non-existent-tag");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_TRUE(results.empty());
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesOnlyValueIsSet) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setTagValue("aws-tag-value-1");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_EQ(results.size(), 1U);
+                    ASSERT_NE(results.end(), results.find(getenv("HZ_TEST_AWS_INSTANCE_PRIVATE_IP")));
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesOnlyValueIsSetToNonExistentValue) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setTagValue("non-existent-value");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_TRUE(results.empty());
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesSecurityGroup) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setSecurityGroupName("launch-wizard-147");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_EQ(results.size(), 1U);
+                    ASSERT_NE(results.end(), results.find(getenv("HZ_TEST_AWS_INSTANCE_PRIVATE_IP")));
+                }
+
+                TEST_F (DescribeInstancesTest, testDescribeInstancesNonExistentSecurityGroup) {
+                    client::config::ClientAwsConfig awsConfig;
+                    awsConfig.setEnabled(true).setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(
+                            getenv("AWS_SECRET_ACCESS_KEY")).setSecurityGroupName("non-existent-group");
+                    client::aws::impl::DescribeInstances desc(awsConfig, awsConfig.getHostHeader());
+                    std::map<std::string, std::string> results = desc.execute();
+                    ASSERT_TRUE(results.empty());
                 }
             }
         }


### PR DESCRIPTION
Moved filtering from client side to AWS request so that we can better handle environments with large number of instances. Corresponding PRs at Java aws client: https://github.com/hazelcast/hazelcast-aws/pull/23 and  https://github.com/hazelcast/hazelcast-aws/pull/26