### PR TITLE
Removed the incorrectly used default credentials in the client config.

### DIFF
--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -427,8 +427,6 @@ namespace hazelcast {
 
             Credentials *credentials;
 
-            std::auto_ptr<Credentials> defaultCredentials;
-
             std::map<std::string, config::ReliableTopicConfig> reliableTopicConfigMap;
 
             util::SynchronizedMap<std::string, config::NearCacheConfigBase> nearCacheConfigMap;

--- a/hazelcast/src/hazelcast/client/ClientConfig.cpp
+++ b/hazelcast/src/hazelcast/client/ClientConfig.cpp
@@ -30,8 +30,7 @@ namespace hazelcast {
         , connectionAttemptLimit(2)
         , attemptPeriod(3000)
         , socketInterceptor(NULL)
-        , credentials(NULL)
-        , defaultCredentials(NULL){
+        , credentials(NULL) {
         }
 
         ClientConfig& ClientConfig::addAddress(const Address& address) {
@@ -146,7 +145,7 @@ namespace hazelcast {
         }
 
         const Credentials *ClientConfig::getCredentials() {
-            return defaultCredentials.get();
+            return credentials;
         }
 
         ClientConfig& ClientConfig::setSocketInterceptor(SocketInterceptor *socketInterceptor) {


### PR DESCRIPTION
There is no default credentials for custom credential usage.