### PR TITLE
SSL reconnect fail at Linux environments

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/SSLSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SSLSocket.h
@@ -126,11 +126,9 @@ namespace hazelcast {
                      */
                     int handleError(const std::string &source, size_t numBytes, const asio::error_code &error) const;
 
-                    void startTimer();
+                    void checkDeadline(const asio::error_code &ec);
 
                     client::Address remoteEndpoint;
-
-                    util::AtomicBoolean isOpen;
 
                     asio::io_service &ioService;
                     asio::ssl::context &sslContext;

--- a/hazelcast/src/hazelcast/client/connection/Connection.cpp
+++ b/hazelcast/src/hazelcast/client/connection/Connection.cpp
@@ -51,7 +51,6 @@ namespace hazelcast {
             : live(true)
             , clientContext(clientContext)
             , invocationService(clientContext.getInvocationService())
-            , socket(new internal::socket::TcpSocket(address))
             , readHandler(*this, iListener, 16 << 10, clientContext)
             , writeHandler(*this, oListener, 16 << 10)
             , _isOwnerConnection(isOwner)

--- a/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
@@ -189,7 +189,7 @@ namespace hazelcast {
                         if (ptr.get() == NULL) {
                             partitionResponse = getPartitionsFrom();
                         } else {
-                            partitionResponse = getPartitionsFrom(*ptr.get());
+                            partitionResponse = getPartitionsFrom(*ptr);
                         }
                         if (partitionResponse.get() != NULL) {
                             processPartitionResponse(*partitionResponse);

--- a/hazelcast/test/src/ClientTestSupportBase.cpp
+++ b/hazelcast/test/src/ClientTestSupportBase.cpp
@@ -13,30 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//
-// Created by İhsan Demir on 26/05/15.
-//
 
-#include "ClientTestSupport.h"
+#include "ClientTestSupportBase.h"
 
 #include "hazelcast/client/ClientConfig.h"
 #include "hazelcast/client/HazelcastClient.h"
-#include "HazelcastServerFactory.h"
 
 namespace hazelcast {
     namespace client {
         namespace test {
-            std::string ClientTestSupport::getCAFilePath() {
+            std::string ClientTestSupportBase::getCAFilePath() {
                 return "hazelcast/test/resources/cpp_client.crt";
             }
 
-            std::auto_ptr<hazelcast::client::ClientConfig> ClientTestSupport::getConfig() {
+            std::auto_ptr<hazelcast::client::ClientConfig> ClientTestSupportBase::getConfig() {
                 std::auto_ptr<hazelcast::client::ClientConfig> clientConfig(new ClientConfig());
-                clientConfig->addAddress(Address(g_srvFactory->getServerAddress(), 5701));
                 return clientConfig;
             }
 
-            std::auto_ptr<HazelcastClient> ClientTestSupport::getNewClient() {
+            std::auto_ptr<HazelcastClient> ClientTestSupportBase::getNewClient() {
                 std::auto_ptr<HazelcastClient> result(new HazelcastClient(*getConfig()));
                 return result;
             }

--- a/hazelcast/test/src/ClientTestSupportBase.h
+++ b/hazelcast/test/src/ClientTestSupportBase.h
@@ -21,6 +21,7 @@
 #define HAZELCAST_CLIENT_TEST_CLIENTTESTSUPPORTBASE_H
 
 #include <memory>
+#include <string>
 
 namespace hazelcast {
     namespace client {

--- a/hazelcast/test/src/ClientTestSupportBase.h
+++ b/hazelcast/test/src/ClientTestSupportBase.h
@@ -17,13 +17,10 @@
 // Created by İhsan Demir on 26/05/15.
 //
 
-#ifndef HAZELCASTCLIENT_CLIENTTESTSUPPORT_H
-#define HAZELCASTCLIENT_CLIENTTESTSUPPORT_H
+#ifndef HAZELCAST_CLIENT_TEST_CLIENTTESTSUPPORTBASE_H
+#define HAZELCAST_CLIENT_TEST_CLIENTTESTSUPPORTBASE_H
 
 #include <memory>
-#include <gtest/gtest.h>
-
-#include "ClientTestSupportBase.h"
 
 namespace hazelcast {
     namespace client {
@@ -36,10 +33,17 @@ namespace hazelcast {
 
             extern HazelcastServerFactory *g_srvFactory;
 
-            class ClientTestSupport : public ClientTestSupportBase, public ::testing::Test {
+            class ClientTestSupportBase {
+            public:
+                static std::string getCAFilePath();
+            protected:
+
+                static std::auto_ptr<hazelcast::client::ClientConfig> getConfig();
+
+                static std::auto_ptr<HazelcastClient> getNewClient();
             };
         }
     }
 }
 
-#endif //HAZELCASTCLIENT_CLIENTTESTSUPPORT_H
+#endif //HAZELCAST_CLIENT_TEST_CLIENTTESTSUPPORTBASE_H


### PR DESCRIPTION
Fix SSLSocket so that it cancels the timer appropriately. The bug was to fail the cancellation of the timer if connect failed which caused the timer method to try access an invalid memory location of an already destroyed error_code object. 

Also, changed the cluster test so that it runs with both TcpSocket and SSLSocket.