### PR TITLE
Nightly linux no SSL test fails for ClusterTest

### DIFF
--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -253,10 +253,15 @@ namespace hazelcast {
                 ASSERT_THROW(HazelcastClient client(clientConfig), exception::IllegalStateException);
             }
 
+            #ifdef HZ_BUILD_WITH_SSL
             INSTANTIATE_TEST_CASE_P(All,
                                     ClusterTest,
                                     ::testing::Values(new ClientConfig(), new SSLClientConfig()));
-
+            #else
+            INSTANTIATE_TEST_CASE_P(All,
+                                    ClusterTest,
+                                    ::testing::Values(new ClientConfig()));
+            #endif
         }
     }
 }


### PR DESCRIPTION
ClusterTest SSLSocket version should only be run if SSL was enabled during the build. Failure to do this causes the nightly cpp-linux-nightly-64-STATIC-Debug-NoSSL to fail.