### PR TITLE
Visual Studio compiler warnings - getenv and exception specification ignored

### DIFF
--- a/examples/aws/AwsClientWithKey.cpp
+++ b/examples/aws/AwsClientWithKey.cpp
@@ -21,6 +21,11 @@
  */
 #include <hazelcast/client/HazelcastClient.h>
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4996) //for dll export
+#endif
+
 int main() {
     hazelcast::client::ClientConfig clientConfig;
 
@@ -51,3 +56,7 @@ int main() {
 
     return 0;
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif

--- a/hazelcast/include/hazelcast/util/Preconditions.h
+++ b/hazelcast/include/hazelcast/util/Preconditions.h
@@ -80,7 +80,7 @@ namespace hazelcast {
              * @throws client::exception::InvalidConfigurationException if the user does not compile with
              * HZ_BUILD_WITH_SSL flag but is trying to use a feature (e.g. TLS, AWS Cloud Discovery) that needs this flag.
              */
-            static void checkSSL(const std::string &sourceMethod) throw (client::exception::InvalidConfigurationException);
+            static void checkSSL(const std::string &sourceMethod);
         };
     }
 }

--- a/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
+++ b/hazelcast/src/hazelcast/client/aws/impl/DescribeInstances.cpp
@@ -29,6 +29,11 @@
 #include "hazelcast/client/exception/IOException.h"
 #include "hazelcast/util/SyncHttpClient.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4996) //for dll export
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace aws {
@@ -186,4 +191,8 @@ namespace hazelcast {
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 

--- a/hazelcast/src/hazelcast/util/Preconditions.cpp
+++ b/hazelcast/src/hazelcast/util/Preconditions.cpp
@@ -44,7 +44,7 @@ namespace hazelcast {
             return argument;
         }
 
-        void Preconditions::checkSSL(const std::string &sourceMethod) throw(client::exception::InvalidConfigurationException) {
+        void Preconditions::checkSSL(const std::string &sourceMethod) {
             #ifndef HZ_BUILD_WITH_SSL
             throw client::exception::InvalidConfigurationException(sourceMethod, "You should compile with "
                     "HZ_BUILD_WITH_SSL flag. You should also have the openssl installed on your machine and you need "

--- a/hazelcast/test/src/aws/DescribeInstancesTest.cpp
+++ b/hazelcast/test/src/aws/DescribeInstancesTest.cpp
@@ -22,6 +22,11 @@
 #include <hazelcast/client/config/ClientAwsConfig.h>
 #include <hazelcast/client/aws/impl/DescribeInstances.h>
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4996) //for dll export
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace test {
@@ -108,5 +113,9 @@ namespace hazelcast {
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HZ_BUILD_WITH_SSL


### PR DESCRIPTION
Fixes the following warnings:

- Preconditions.h(83): warning C4290: C++ exception specification ignored except to indicate a function is not __declspec(nothrow)

- DescribeInstancesTest.cpp(58): warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead.

Visual studio C++ compiler does not want an exception definition in method signature. Also, suppressed the insecure warning (4996) for the getenv usage.