### PR TITLE
Disable randomly failing test LoadTest

### DIFF
--- a/hazelcast/test/src/faulttolerance/LoadTest.cpp
+++ b/hazelcast/test/src/faulttolerance/LoadTest.cpp
@@ -137,14 +137,14 @@ namespace hazelcast {
                             "[LoadTest::loadIntMapTestWithConfig] Finished the test successfully :)");
                 }
 
-                TEST_F(LoadTest, testIntMapSmartClientServerRestart) {
+                TEST_F(LoadTest, DISABLED_testIntMapSmartClientServerRestart) {
                     std::auto_ptr<ClientConfig> config = getLoadTestConfig();
                     config->setSmart(true);
 
                     loadIntMapTestWithConfig(*config, *this);
                 }
 
-                TEST_F(LoadTest, testIntMapDummyClientServerRestart) {
+                TEST_F(LoadTest, DISABLED_testIntMapDummyClientServerRestart) {
                     std::auto_ptr<ClientConfig> config = getLoadTestConfig();
                     config->setSmart(false);
 


### PR DESCRIPTION
Disables the Load tests until issue https://github.com/hazelcast/hazelcast-cpp-client/issues/227 is fixed.