### PR TITLE
testListenersWhenClusterDown fails with segmentation fault

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/impl/listener/EventRegistration.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/listener/EventRegistration.h
@@ -29,10 +29,10 @@
 #include <memory>
 
 #include "hazelcast/util/HazelcastDll.h"
+#include "hazelcast/client/Address.h"
 
 namespace hazelcast {
     namespace client {
-        class Address;
         namespace protocol {
             class ClientMessage;
             namespace codec {
@@ -59,7 +59,7 @@ namespace hazelcast {
 
                     private:
                         int64_t correlationId;
-                        const Address &memberAddress;
+                        Address memberAddress;
                         std::auto_ptr<protocol::codec::IAddListenerCodec> addCodec;
                     };
                 }

--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -290,7 +290,7 @@ namespace hazelcast {
                 DummyListenerClusterTest listener(countDownLatch);
                 IMap<std::string, std::string> m = hazelcastClient.getMap<std::string, std::string>(
                         "testListenersWhenClusterDown");
-                m.addEntryListener(listener, true);
+                std::string entryListenerRegistrationId = m.addEntryListener(listener, true);
                 instance->shutdown();
 
                 util::CountDownLatch lifecycleLatch(1);
@@ -304,6 +304,7 @@ namespace hazelcast {
                 m.put("sample", "entry");
                 ASSERT_TRUE(countDownLatch.await(60));
                 ASSERT_TRUE(hazelcastClient.removeLifecycleListener(&lifecycleListener));
+                ASSERT_TRUE(m.removeEntryListener(entryListenerRegistrationId));
             }
 
             TEST_P(ClusterTest, testBehaviourWhenClusterNotFound) {


### PR DESCRIPTION
The fix removes the entry listener when the test finishes in order to avoid illegal memory access to the destructed entry listener object during client destructor. Since client is instantiated before the listener, and the destruction order is in reverse order, the listener will be destructed first.

The failing test log is:
```
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Initializing cluster partition table arrangement...
Jun 08, 2017 10:23:48 PM CppClientListener
INFO: SHUTDOWN command received
Jun 08, 2017 10:23:48 PM CppClientListener
INFO: SHUTDOWN command for instance 116
Jun 08, 2017 10:23:48 PM com.hazelcast.core.LifecycleService
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] [127.0.0.1]:5701 is SHUTTING_DOWN
Jun 08, 2017 10:23:48 PM com.hazelcast.internal.partition.impl.MigrationManager
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Shutdown request of [127.0.0.1]:5701 is handled
Jun 08, 2017 10:23:48 PM com.hazelcast.instance.Node
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Shutting down connection manager...
Jun 08, 2017 10:23:48 PM com.hazelcast.nio.tcp.TcpIpConnection
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Connection[id=2, /127.0.0.1:5701->/127.0.0.1:38890, endpoint=[127.0.0.1]:38890, alive=false, type=CPP_CLIENT] closed. Reason: TcpIpConnectionManager is stopping
Jun 08, 2017 10:23:48 PM com.hazelcast.nio.tcp.TcpIpConnection
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Connection[id=1, /127.0.0.1:5701->/127.0.0.1:38888, endpoint=[127.0.0.1]:38888, alive=false, type=CPP_CLIENT] closed. Reason: TcpIpConnectionManager is stopping
Jun 08, 2017 10:23:48 PM WARNING: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-190842000] [IOHandler::handleSocketException] Closing socket to endpoint 127.0.0.1:5701, Cause:ExceptionMessage {End of file} at SSLSocket::receive

Jun 08, 2017 10:23:48 PM WARNING: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-190842000] Closing connection (id:4) to Address[127.0.0.1:5701] with socket id 12. 
Jun 08, 2017 10:23:48 PM FINEST: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-190842000] Closing owner connection to Address[127.0.0.1:5701]
Jun 08, 2017 10:23:48 PM WARNING: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-190842000] Closing connection (id:3) to Address[127.0.0.1:5701] with socket id 11 as the owner connection.Closing owner connection to Address[127.0.0.1:5701]
Jun 08, 2017 10:23:48 PM INFO: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-190842000] [cleanResources] There are 0 waiting promises on connection with id:4 (Address[127.0.0.1:5701]) 
Jun 08, 2017 10:23:48 PM INFO: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-190842000] [InvocationService::cleanEventHandlers] There are 1 event handler promises on connection with id:4 to be retried
Jun 08, 2017 10:23:48 PM WARNING: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-281019536] Error while listening cluster events! -> ExceptionMessage {End of file} at SSLSocket::receive
Jun 08, 2017 10:23:48 PM INFO: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [-281019536] LifecycleService::LifecycleEvent CLIENT_DISCONNECTED
Jun 08, 2017 10:23:48 PM com.hazelcast.instance.Node
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Shutting down node engine...
Jun 08, 2017 10:23:48 PM com.hazelcast.instance.NodeExtension
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Destroying node NodeExtension.
Jun 08, 2017 10:23:48 PM com.hazelcast.instance.Node
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] Hazelcast Shutdown is completed in 206 ms.
Jun 08, 2017 10:23:48 PM com.hazelcast.core.LifecycleService
INFO: [127.0.0.1]:5701 [dev] [3.8.2-SNAPSHOT] [127.0.0.1]:5701 is SHUTDOWN
Jun 08, 2017 10:23:48 PM CppClientListener
INFO: SHUTDOWN for instance 116 is completed.
testLinuxSingleCase.sh: line 117:  3470 Segmentation fault      (core dumped) ${BUILD_DIR}/hazelcast/test/src/${EXECUTABLE_NAME} --gtest_output="xml:CPP_Client_Test_Report.xml"
Test FAILED. Result:139
Found core file for the test process: core.3470
[WARNING] 
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:294)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:196)
	at java.net.SocketInputStream.read(SocketInputStream.java:122)
	at java.net.SocketInputStream.read(SocketInputStream.java:210)
	at java.io.DataInputStream.readInt(DataInputStream.java:387)
	at CppClientListener.main(CppClientListener.java:545)
	... 6 more
[?1034h
warning: core file may not match specified executable file.
[New Thread 28185]
[New Thread 28186]
[New Thread 28188]
[New Thread 3470]
[New Thread 28192]
[New Thread 28187]
Missing separate debuginfo for 
Try: yum --enablerepo='*-debug*' install /usr/lib/debug/.build-id/99/8b2d4ed54b40306c26d823100bd8d5cdfe2654
[Thread debugging using libthread_db enabled]
Core was generated by `buildSHARED32Release/hazelcast/test/src/clientTest_SHARED_32 --gtest_output=xml'.
Program terminated with signal 11, Segmentation fault.
#0  0xf73fe7ee in hazelcast::client::internal::socket::SSLSocket::connect(int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so

Thread 6 (Thread 0xf5dafb70 (LWP 28187)):
#0  0xf77d2430 in __kernel_vsyscall ()
No symbol table info available.
#1  0xf77b9824 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib/libpthread.so.0
No symbol table info available.
#2  0xf748037e in hazelcast::util::ConditionVariable::waitFor(hazelcast::util::Mutex&, long long) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#3  0xf7495513 in hazelcast::util::Thread::interruptibleSleep(int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#4  0xf7348af1 in hazelcast::client::connection::HeartBeater::run(hazelcast::util::Thread*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#5  0xf7348cc6 in hazelcast::client::connection::HeartBeater::staticStart(hazelcast::util::ThreadArgs&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#6  0xf7495ee9 in hazelcast::util::Thread::controlledThread(void*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#7  0xf77b5bc9 in start_thread () from /lib/libpthread.so.0
No symbol table info available.
#8  0xf7066dee in clone () from /lib/libc.so.6
No symbol table info available.

Thread 5 (Thread 0xf3fffb70 (LWP 28192)):
#0  0xf77d2430 in __kernel_vsyscall ()
No symbol table info available.
#1  0xf77b9824 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib/libpthread.so.0
No symbol table info available.
#2  0xf748037e in hazelcast::util::ConditionVariable::waitFor(hazelcast::util::Mutex&, long long) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#3  0xf7495513 in hazelcast::util::Thread::interruptibleSleep(int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#4  0xf73d924a in hazelcast::client::spi::PartitionService::runListener(hazelcast::util::Thread*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#5  0xf73d94a6 in hazelcast::client::spi::PartitionService::staticRunListener(hazelcast::util::ThreadArgs&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#6  0xf7495ee9 in hazelcast::util::Thread::controlledThread(void*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#7  0xf77b5bc9 in start_thread () from /lib/libpthread.so.0
No symbol table info available.
#8  0xf7066dee in clone () from /lib/libc.so.6
No symbol table info available.

Thread 4 (Thread 0xf6dcf750 (LWP 3470)):
#0  0xf77d2430 in __kernel_vsyscall ()
No symbol table info available.
#1  0xf77bc998 in recv () from /lib/libpthread.so.0
No symbol table info available.
#2  0xf73ed083 in hazelcast::client::internal::socket::TcpSocket::receive(void*, int, int) const () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#3  0xf7349a8c in hazelcast::client::connection::InputSocketStream::readInt() () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#4  0x087369aa in hazelcast::client::test::HazelcastServerFactory::shutdownInstance(int) ()
No symbol table info available.
#5  0x08736127 in hazelcast::client::test::HazelcastServer::~HazelcastServer() ()
No symbol table info available.
#6  0x0845caae in std::auto_ptr<hazelcast::client::test::HazelcastServer>::~auto_ptr() ()
No symbol table info available.
#7  0x0845ae39 in hazelcast::client::test::ClusterTest_testListenersWhenClusterDown_Test::TestBody() ()
No symbol table info available.
#8  0x087874d7 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
No symbol table info available.
#9  0x08774e84 in testing::Test::Run() ()
No symbol table info available.
#10 0x0877515d in testing::TestInfo::Run() ()
No symbol table info available.
#11 0x08775259 in testing::TestCase::Run() ()
No symbol table info available.
#12 0x08777b89 in testing::internal::UnitTestImpl::RunAllTests() ()
No symbol table info available.
#13 0x0877f20c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
No symbol table info available.
#14 0x08786f97 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
No symbol table info available.
#15 0x08773b1b in testing::UnitTest::Run() ()
No symbol table info available.
#16 0x08714cf8 in main ()
No symbol table info available.

Thread 3 (Thread 0xef3ffb70 (LWP 28188)):
#0  0xf77d2430 in __kernel_vsyscall ()
No symbol table info available.
#1  0xf77b9824 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib/libpthread.so.0
No symbol table info available.
#2  0xf748037e in hazelcast::util::ConditionVariable::waitFor(hazelcast::util::Mutex&, long long) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#3  0xf7495513 in hazelcast::util::Thread::interruptibleSleep(int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#4  0xf7336b68 in hazelcast::client::connection::ClusterListenerThread::run(hazelcast::util::Thread*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#5  0xf73372e6 in hazelcast::client::connection::ClusterListenerThread::staticRun(hazelcast::util::ThreadArgs&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#6  0xf7495ee9 in hazelcast::util::Thread::controlledThread(void*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#7  0xf77b5bc9 in start_thread () from /lib/libpthread.so.0
No symbol table info available.
#8  0xf7066dee in clone () from /lib/libc.so.6
No symbol table info available.

Thread 2 (Thread 0xf55aeb70 (LWP 28186)):
#0  0xf77d2430 in __kernel_vsyscall ()
No symbol table info available.
#1  0xf705f141 in select () from /lib/libc.so.6
No symbol table info available.
#2  0xf734d968 in hazelcast::client::connection::OutSelector::listenInternal() () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#3  0xf7344b6c in hazelcast::client::connection::IOSelector::listen() () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#4  0xf7344d9f in hazelcast::client::connection::IOSelector::staticListen(hazelcast::util::ThreadArgs&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#5  0xf7495ee9 in hazelcast::util::Thread::controlledThread(void*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#6  0xf77b5bc9 in start_thread () from /lib/libpthread.so.0
No symbol table info available.
#7  0xf7066dee in clone () from /lib/libc.so.6
No symbol table info available.

Thread 1 (Thread 0xf49ffb70 (LWP 28185)):
#0  0xf73fe7ee in hazelcast::client::internal::socket::SSLSocket::connect(int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#1  0xf7351049 in hazelcast::client::connection::Connection::connect(int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#2  0xf7356c3e in hazelcast::client::connection::ConnectionManager::connectTo(hazelcast::client::Address const&, bool) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#3  0xf7357b42 in hazelcast::client::connection::ConnectionManager::getOrConnectResolved(hazelcast::client::Address const&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#4  0xf73588c4 in hazelcast::client::connection::ConnectionManager::getOrConnect(hazelcast::client::Address const&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#5  0xf7358c61 in hazelcast::client::connection::ConnectionManager::getOrConnect(hazelcast::client::Address const&, int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#6  0xf735941d in hazelcast::client::connection::ConnectionManager::getRandomConnection(int, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#7  0xf73ca33f in hazelcast::client::spi::InvocationService::resend(boost::shared_ptr<hazelcast::client::connection::CallPromise>, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#8  0xf73d409e in hazelcast::client::spi::ServerListenerService::retryFailedListener(boost::shared_ptr<hazelcast::client::connection::CallPromise>) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#9  0xf73c6e3c in hazelcast::client::spi::InvocationService::cleanEventHandlers(hazelcast::client::connection::Connection&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#10 0xf73cb67f in hazelcast::client::spi::InvocationService::cleanResources(hazelcast::client::connection::Connection&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#11 0xf7350c0e in hazelcast::client::connection::Connection::close(char const*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#12 0xf7349938 in hazelcast::client::connection::IOHandler::handleSocketException(std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#13 0xf734b91b in hazelcast::client::connection::ReadHandler::handle() () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#14 0xf7332296 in hazelcast::client::connection::InSelector::listenInternal() () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#15 0xf7344b6c in hazelcast::client::connection::IOSelector::listen() () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#16 0xf7344d9f in hazelcast::client::connection::IOSelector::staticListen(hazelcast::util::ThreadArgs&) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#17 0xf7495ee9 in hazelcast::util::Thread::controlledThread(void*) () from /home/jenkins/jenkins/workspace/cpp-linux-nightly-32-SHARED-Release/buildSHARED32Release/libHazelcastClient3.8.2-SNAPSHOT_32.so
No symbol table info available.
#18 0xf77b5bc9 in start_thread () from /lib/libpthread.so.0
No symbol table info available.
#19 0xf7066dee in clone () from /lib/libc.so.6
```