### PR TITLE
ConnectionManager::shutdown should not throw any exception and ClusterTest.testListenersWhenClusterDown fails

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -123,6 +123,8 @@ namespace hazelcast {
 
                 int connectionId;
             };
+
+            std::ostream HAZELCAST_API &operator << (std::ostream &out, const Connection &connection);
         }
     }
 }

--- a/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
+++ b/hazelcast/include/hazelcast/client/connection/ConnectionManager.h
@@ -131,7 +131,7 @@ namespace hazelcast {
                 void onConnectionClose(const Address &address, int socketId);
 
                 /**
-                * Shutdown clientConnectionManager
+                * Shutdown clientConnectionManager. It does not throw any excpetion.
                 */
                 void shutdown();
 

--- a/hazelcast/include/hazelcast/client/spi/InvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/InvocationService.h
@@ -22,7 +22,6 @@
 #include "hazelcast/util/AtomicInt.h"
 #include "hazelcast/util/SynchronizedMap.h"
 #include "hazelcast/client/protocol/IMessageHandler.h"
-#include "hazelcast/util/AtomicBoolean.h"
 #include "hazelcast/client/protocol/ClientExceptionFactory.h"
 
 #include <boost/shared_ptr.hpp>
@@ -65,6 +64,7 @@ namespace hazelcast {
 
         namespace spi {
             class ClientContext;
+            class LifecycleService;
 
             class HAZELCAST_API InvocationService : public protocol::IMessageHandler {
             public:
@@ -142,7 +142,6 @@ namespace hazelcast {
                 // Is not using the Connection* for the key due to a possible ABA problem.
                 util::SynchronizedMap<int , util::SynchronizedMap<int64_t, connection::CallPromise > > callPromises;
                 util::SynchronizedMap<int, util::SynchronizedMap<int64_t, connection::CallPromise > > eventHandlerPromises;
-                util::AtomicBoolean isOpen;
                 protocol::ClientExceptionFactory exceptionFactory;
 
                 bool isAllowedToSentRequest(connection::Connection& connection, protocol::ClientMessage const&);

--- a/hazelcast/include/hazelcast/client/spi/InvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/InvocationService.h
@@ -110,7 +110,7 @@ namespace hazelcast {
                 * @param callId of event handler registration request
                 * @return true if found and removed, false otherwise
                 */
-                void removeEventHandler(int64_t callId);
+                bool removeEventHandler(int64_t callId);
 
                 /**
                 * Clean all promises (both request and event handlers). Retries requests on available connections if applicable.

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -81,8 +81,10 @@ namespace hazelcast {
                                 previousConnectionAddr = conn->getRemoteEndpoint();
                                 previousConnectionAddrPtr = &previousConnectionAddr;
                             } catch (std::exception &e) {
-                                util::ILogger::getLogger().severe(
-                                        std::string("Error while connecting to cluster! =>") + e.what());
+                                if (clientContext.getLifecycleService().isRunning()) {
+                                    util::ILogger::getLogger().severe(
+                                            std::string("Error while connecting to cluster! =>") + e.what());
+                                }
                                 isStartedSuccessfully = false;
                                 clientContext.getLifecycleService().shutdown();
                                 startLatch.countDown();

--- a/hazelcast/src/hazelcast/client/connection/Connection.cpp
+++ b/hazelcast/src/hazelcast/client/connection/Connection.cpp
@@ -223,6 +223,21 @@ namespace hazelcast {
             bool Connection::isOwnerConnection() const {
                 return _isOwnerConnection;
             }
+
+            std::ostream HAZELCAST_API &operator << (std::ostream &out, const Connection &connection) {
+                Connection &conn = const_cast<Connection &>(connection);
+                time_t lastRead = conn.lastRead;
+                bool live = conn.live;
+                out << "ClientConnection{"
+                << "alive=" << live
+                << ", connectionId=" << connection.getConnectionId()
+                << ", remoteEndpoint=" << connection.getRemoteEndpoint()
+                << ", lastReadTime=" << lastRead
+                << ", isHeartbeating=" << conn.isHeartBeating()
+                << '}';
+
+                return out;
+            }
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ConnectionManager.cpp
@@ -72,7 +72,8 @@ namespace hazelcast {
                 live = false;
                 // close connections
                 BOOST_FOREACH(boost::shared_ptr<Connection> connection ,  connections.values()) {
-                                connection->close("Hazelcast client is shutting down");
+                                // prevent any exceptions
+                                util::IOUtil::closeResource(connection.get(), "Hazelcast client is shutting down");
                             }
                 heartBeater.shutdown();
                 if (heartBeatThread.get() != NULL) {

--- a/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
@@ -70,10 +70,10 @@ namespace hazelcast {
                     return;
                 }
                 fireLifecycleEvent(LifecycleEvent::SHUTTING_DOWN);
+                clientContext.getInvocationService().shutdown();
                 clientContext.getConnectionManager().shutdown();
                 clientContext.getClusterService().shutdown();
                 clientContext.getPartitionService().shutdown();
-                clientContext.getInvocationService().shutdown();
                 clientContext.getNearCacheManager().destroyAllNearCaches();
                 fireLifecycleEvent(LifecycleEvent::SHUTDOWN);
             }

--- a/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
@@ -43,15 +43,16 @@ namespace hazelcast {
                 fireLifecycleEvent(LifecycleEvent::STARTING);
                 active = true;
 
+
+                if (!clientContext.getInvocationService().start()) {
+                    return false;
+                }
+
                 if (!clientContext.getConnectionManager().start()) {
                     return false;
                 }
 
                 if (!clientContext.getClusterService().start()) {
-                    return false;
-                }
-
-                if (!clientContext.getInvocationService().start()) {
                     return false;
                 }
 
@@ -71,9 +72,9 @@ namespace hazelcast {
                 }
                 fireLifecycleEvent(LifecycleEvent::SHUTTING_DOWN);
                 clientContext.getInvocationService().shutdown();
+                clientContext.getPartitionService().shutdown();
                 clientContext.getConnectionManager().shutdown();
                 clientContext.getClusterService().shutdown();
-                clientContext.getPartitionService().shutdown();
                 clientContext.getNearCacheManager().destroyAllNearCaches();
                 fireLifecycleEvent(LifecycleEvent::SHUTDOWN);
             }

--- a/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/PartitionService.cpp
@@ -107,7 +107,9 @@ namespace hazelcast {
                     responseMessage = future.get();
 
                 } catch (exception::IOException& e) {
-                    util::ILogger::getLogger().severe(std::string("Error while fetching cluster partition table => ") + e.what());
+                    if (clientContext.getLifecycleService().isRunning()) {
+                        util::ILogger::getLogger().severe(std::string("Error while fetching cluster partition table => ") + e.what());
+                    }
                 }
                 return responseMessage;
             }
@@ -123,7 +125,9 @@ namespace hazelcast {
                     responseMessage = future.get();
 
                 } catch (exception::IOException& e) {
-                    util::ILogger::getLogger().severe(std::string("Error while fetching cluster partition table => ") + e.what());
+                    if (clientContext.getLifecycleService().isRunning()) {
+                        util::ILogger::getLogger().severe(std::string("Error while fetching cluster partition table => ") + e.what());
+                    }
                 }
                 return responseMessage;
             }
@@ -170,12 +174,14 @@ namespace hazelcast {
                     }
                 }
 
-                if (!result) {
-                    util::ILogger::getLogger().severe("PartitionService::getInitialPartitions Cannot get initial partitions!");
-                } else {
-                    util::ILogger::getLogger().finest("PartitionService::getInitialPartitions Got " +
-                                                              util::IOUtil::to_string<int>(partitionCount) +
-                                                              " initial partitions successfully.");
+                if (clientContext.getLifecycleService().isRunning()) {
+                    if (!result) {
+                        util::ILogger::getLogger().severe("PartitionService::getInitialPartitions Cannot get initial partitions!");
+                    } else {
+                        util::ILogger::getLogger().finest("PartitionService::getInitialPartitions Got " +
+                                                          util::IOUtil::to_string<int>(partitionCount) +
+                                                          " initial partitions successfully.");
+                    }
                 }
                 return result;
             }
@@ -195,9 +201,13 @@ namespace hazelcast {
                             processPartitionResponse(*partitionResponse);
                         }
                     } catch (hazelcast::client::exception::IException& e) {
-                        util::ILogger::getLogger().finest(std::string("Exception in partitionService::refreshPartitions ") + e.what());
+                        if (clientContext.getLifecycleService().isRunning()) {
+                            util::ILogger::getLogger().finest(std::string("Exception in partitionService::refreshPartitions ") + e.what());
+                        }
                     } catch (...) {
-                        util::ILogger::getLogger().finest(std::string("Unkown exception in partitionService::refreshPartitions "));
+                        if (clientContext.getLifecycleService().isRunning()) {
+                            util::ILogger::getLogger().finest(std::string("Unkown exception in partitionService::refreshPartitions "));
+                        }
                         throw;
                     }
                     updating = false;


### PR DESCRIPTION
Prevented ConnectionManager::shutdown to throw any exception.

Reverted the order of InvocationService shutdown and ConnectionManager shutdown in order to eliminate any unnecessary retries happening during client shutdown, and prevent these retries causing any exceptions. Note that InvocationService::shutdown is only setting a boolean flag.

At Java client, there is a CleanResourcesTask which periodically performs the cleanup of invocations. We really need such a task implemented in the future.

fixes #258 