### PR TITLE
ClusterService shutdown may not work correctly if it was called when client was disconnected

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
+++ b/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
@@ -56,8 +56,6 @@ namespace hazelcast {
 
                 void setThread(util::Thread *);
 
-                const util::Thread *getThread() const;
-
                 static void staticRun(util::ThreadArgs &args);
 
                 void run(util::Thread *currentThread);
@@ -74,18 +72,20 @@ namespace hazelcast {
 
                 std::set<Address, addressComparator> getSocketAddresses() const;
 
-                util::CountDownLatch startLatch;
 
-                bool isStartedSuccessfully;
+                void awaitStart();
+
             private:
+                util::CountDownLatch startLatch;
                 spi::ClientContext &clientContext;
                 boost::shared_ptr<Connection> conn;
                 util::AtomicBoolean deletingConnection;
+
                 std::vector<Member> members;
 
                 std::auto_ptr<util::Thread> clusterListenerThread;
-
                 bool isInitialMembersLoaded;
+
                 bool isRegistrationIdReceived;
 
                 int awsMemberPort;

--- a/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
+++ b/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
@@ -73,7 +73,10 @@ namespace hazelcast {
                 std::set<Address, addressComparator> getSocketAddresses() const;
 
 
-                void awaitStart();
+                /**
+                 * @return true if started and initialized successfully, false otherwise
+                 */
+                bool awaitStart();
 
             private:
                 util::CountDownLatch startLatch;

--- a/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
+++ b/hazelcast/include/hazelcast/client/connection/ClusterListenerThread.h
@@ -114,7 +114,7 @@ namespace hazelcast {
 
                 static void staticRun(util::ThreadArgs &args);
 
-                void run(util::Thread *currentThread);
+                void run(util::Thread *currentThread, int memberPort);
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/spi/ClusterService.h
+++ b/hazelcast/include/hazelcast/client/spi/ClusterService.h
@@ -16,8 +16,6 @@
 //
 // Created by sancar koyunlu on 5/21/13.
 
-
-
 #ifndef HAZELCAST_CLUSTER_SERVICE
 #define HAZELCAST_CLUSTER_SERVICE
 

--- a/hazelcast/include/hazelcast/client/spi/ClusterService.h
+++ b/hazelcast/include/hazelcast/client/spi/ClusterService.h
@@ -94,8 +94,6 @@ namespace hazelcast {
                 util::Mutex listenerLock;
                 util::Mutex membersLock;
 
-                util::AtomicBoolean active;
-
                 void initMembershipListeners();
 
                 std::vector<Address> findServerAddressesToConnect(const Address *previousConnectionAddr) const;

--- a/hazelcast/include/hazelcast/client/spi/LifecycleService.h
+++ b/hazelcast/include/hazelcast/client/spi/LifecycleService.h
@@ -22,6 +22,8 @@
 #include "hazelcast/util/HazelcastDll.h"
 #include "hazelcast/util/Mutex.h"
 #include "hazelcast/util/AtomicBoolean.h"
+#include "hazelcast/util/CountDownLatch.h"
+
 #include <set>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -46,6 +48,8 @@ namespace hazelcast {
 
                 LifecycleService(ClientContext &clientContext, const ClientConfig &clientConfig);
 
+                virtual ~LifecycleService();
+
                 bool start();
 
                 void fireLifecycleEvent(const LifecycleEvent &lifecycleEvent);
@@ -64,7 +68,7 @@ namespace hazelcast {
                 std::set<LifecycleListener *> listeners;
                 util::Mutex listenerLock;
                 util::AtomicBoolean active;
-                util::Mutex shutdownLock;
+                util::CountDownLatch shutdownLatch;
             };
 
         }

--- a/hazelcast/src/hazelcast/client/HazelcastClient.cpp
+++ b/hazelcast/src/hazelcast/client/HazelcastClient.cpp
@@ -52,9 +52,13 @@ namespace hazelcast {
             util::ILogger::getLogger().setPrefix(prefix.str());
             LoadBalancer *loadBalancer = clientConfig.getLoadBalancer();
 
-            if (!lifecycleService.start()) {
+            try {
+                if (!lifecycleService.start()) {
+                    throw exception::IllegalStateException("HazelcastClient","HazelcastClient could not be started!");
+                }
+            } catch (exception::IException &e) {
                 lifecycleService.shutdown();
-                throw exception::IllegalStateException("HazelcastClient","HazelcastClient could not be started!");
+                throw;
             }
             loadBalancer->init(cluster);
         }

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -119,8 +119,10 @@ namespace hazelcast {
                     conn.reset();
                     deletingConnection = false;
                 }
-                clusterListenerThread->cancel();
-                clusterListenerThread->join();
+                if (clusterListenerThread.get()) {
+                    clusterListenerThread->cancel();
+                    clusterListenerThread->join();
+                }
             }
 
             std::set<Address, addressComparator> ClusterListenerThread::getSocketAddresses() const {

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -113,6 +113,7 @@ namespace hazelcast {
             }
 
             void ClusterListenerThread::stop() {
+                startLatch.countDown();
                 if (deletingConnection.compareAndSet(false, true)) {
                     util::IOUtil::closeResource(conn.get(), "Cluster listener thread is stopping");
                     conn.reset();

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -390,8 +390,9 @@ namespace hazelcast {
                 }
             }
 
-            void ClusterListenerThread::awaitStart() {
+            bool ClusterListenerThread::awaitStart() {
                 startLatch.await();
+                return !clientContext.getClusterService().getMemberList().empty();
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -127,6 +127,7 @@ namespace hazelcast {
                     util::IOUtil::closeResource(conn.get(), "Cluster listener thread is stopping");
                     conn.reset();
                     deletingConnection = false;
+                    clientContext.getLifecycleService().fireLifecycleEvent(LifecycleEvent::CLIENT_DISCONNECTED);
                 }
                 if (clusterListenerThread.get()) {
                     clusterListenerThread->cancel();

--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -38,7 +38,8 @@ namespace hazelcast {
     namespace client {
         namespace connection {
             ClusterListenerThread::ClusterListenerThread(spi::ClientContext &clientContext)
-                    : startLatch(1), clientContext(clientContext), deletingConnection(false) {
+                    : startLatch(1), clientContext(clientContext), deletingConnection(false),
+                      workerThread((util::Thread *)NULL) {
                 config::ClientAwsConfig &awsConfig = clientContext.getClientConfig().getNetworkConfig().getAwsConfig();
                 if (awsConfig.isEnabled()) {
                     int port = clientContext.getClientProperties().getAwsMemberPort().getInteger();

--- a/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
@@ -49,8 +49,8 @@ namespace hazelcast {
                 util::Thread *t = new util::Thread("hz.clusterListenerThread",
                                                    connection::ClusterListenerThread::staticRun, &clusterThread);
                 clusterThread.setThread(t);
-                clusterThread.startLatch.await();
-                if (!clusterThread.isStartedSuccessfully) {
+                clusterThread.awaitStart();
+                if (!clientContext.getLifecycleService().isRunning()) {
                     return false;
                 }
                 initMembershipListeners();
@@ -68,12 +68,7 @@ namespace hazelcast {
             }
 
             void ClusterService::shutdown() {
-                if (NULL != clusterThread.getThread()) {
-                    // avoid anyone waiting on the start latch to get stuck
-                    clusterThread.startLatch.countDown();
-
-                    clusterThread.stop();
-                }
+                clusterThread.stop();
             }
 
             std::auto_ptr<Address> ClusterService::getMasterAddress() {

--- a/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
@@ -49,8 +49,7 @@ namespace hazelcast {
                 util::Thread *t = new util::Thread("hz.clusterListenerThread",
                                                    connection::ClusterListenerThread::staticRun, &clusterThread);
                 clusterThread.setThread(t);
-                clusterThread.awaitStart();
-                if (!clientContext.getLifecycleService().isRunning()) {
+                if (!clusterThread.awaitStart()) {
                     return false;
                 }
                 initMembershipListeners();

--- a/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
@@ -46,9 +46,12 @@ namespace hazelcast {
                 std::set<InitialMembershipListener *> const &initialMembershipListeners = config.getInitialMembershipListeners();
                 initialListeners.insert(initialMembershipListeners.begin(), initialMembershipListeners.end());
 
-                util::Thread *t = new util::Thread("hz.clusterListenerThread",
-                                                   connection::ClusterListenerThread::staticRun, &clusterThread);
-                clusterThread.setThread(t);
+                /**
+                 * This thread lifecycle is managed by ClusterListenerThread::stop method
+                 * which is guaranteed to be called during shutdown
+                 */
+                new util::Thread("hz.clusterListenerThread", connection::ClusterListenerThread::staticRun, &clusterThread);
+
                 if (!clusterThread.awaitStart()) {
                     return false;
                 }

--- a/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
@@ -72,8 +72,8 @@ namespace hazelcast {
                 }
                 fireLifecycleEvent(LifecycleEvent::SHUTTING_DOWN);
                 clientContext.getInvocationService().shutdown();
-                clientContext.getPartitionService().shutdown();
                 clientContext.getConnectionManager().shutdown();
+                clientContext.getPartitionService().shutdown();
                 clientContext.getClusterService().shutdown();
                 clientContext.getNearCacheManager().destroyAllNearCaches();
                 fireLifecycleEvent(LifecycleEvent::SHUTDOWN);

--- a/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
@@ -33,7 +33,7 @@ namespace hazelcast {
 
             LifecycleService::LifecycleService(ClientContext &clientContext, const ClientConfig &clientConfig)
             :clientContext(clientContext)
-            , active(false), shutdownLatch(1) {
+            , active(true), shutdownLatch(1) {
                 std::set<LifecycleListener *> const &lifecycleListeners = clientConfig.getLifecycleListeners();
                 listeners.insert(lifecycleListeners.begin(), lifecycleListeners.end());
 
@@ -41,7 +41,6 @@ namespace hazelcast {
 
             bool LifecycleService::start() {
                 fireLifecycleEvent(LifecycleEvent::STARTING);
-                active = true;
 
                 if (!clientContext.getInvocationService().start()) {
                     return false;

--- a/hazelcast/src/hazelcast/util/Thread.cpp
+++ b/hazelcast/src/hazelcast/util/Thread.cpp
@@ -191,6 +191,15 @@ namespace hazelcast {
         }
 
         void Thread::cancel() {
+            if (pthread_equal(thread, pthread_self())) {
+                /**
+                 * do not allow cancelling itself
+                 * at Linux, pthread_cancel may cause cancel by signal
+                 * and calling thread may be terminated.
+                 */
+                return;
+            }
+
             if (!isJoined) {
                 LockGuard guard(wakeupMutex);
                 wakeupCondition.notify();
@@ -200,13 +209,13 @@ namespace hazelcast {
         }
 
         bool Thread::join() {
-            if (!isJoined.compareAndSet(false, true)) {
-                return true;
-            }
-
             if (pthread_equal(thread, pthread_self())) {
                 // called from inside the thread, deadlock possibility
                 return false;
+            }
+
+            if (!isJoined.compareAndSet(false, true)) {
+                return true;
             }
 
             int err = pthread_join(thread, NULL);

--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -298,11 +298,11 @@ namespace hazelcast {
                 hazelcastClient.addLifecycleListener(&lifecycleListener);
 
                 std::auto_ptr<HazelcastServer> instance2 = startMember();
-                ASSERT_TRUE(lifecycleLatch.await(120));
+                ASSERT_TRUE(lifecycleLatch.await(60));
                 // Let enough time for the client to re-register the failed listeners
                 util::sleep(5);
                 m.put("sample", "entry");
-                ASSERT_TRUE(countDownLatch.await(60));
+                ASSERT_TRUE(countDownLatch.await(30));
                 ASSERT_TRUE(hazelcastClient.removeLifecycleListener(&lifecycleListener));
                 ASSERT_TRUE(m.removeEntryListener(entryListenerRegistrationId));
             }
@@ -338,7 +338,7 @@ namespace hazelcast {
 
                 ASSERT_TRUE(disconnectedLatch.await(3));
                 ASSERT_TRUE(shuttingDownLatch.await(5));
-                ASSERT_TRUE(shutdownLatch.await(500));
+                ASSERT_TRUE(shutdownLatch.await(10));
             }
 
             #ifdef HZ_BUILD_WITH_SSL

--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -341,6 +341,33 @@ namespace hazelcast {
                 ASSERT_TRUE(shutdownLatch.await(10));
             }
 
+            TEST_P(ClusterTest, testAllClientStatesWhenUserShutdown) {
+                HazelcastServer instance(*g_srvFactory);
+
+                ClientConfig clientConfig;
+                util::CountDownLatch startingLatch(1);
+                util::CountDownLatch startedLatch(1);
+                util::CountDownLatch connectedLatch(1);
+                util::CountDownLatch disconnectedLatch(1);
+                util::CountDownLatch shuttingDownLatch(1);
+                util::CountDownLatch shutdownLatch(1);
+                ClientAllStatesListener listener(&startingLatch, &startedLatch, &connectedLatch, &disconnectedLatch,
+                                                 &shuttingDownLatch, &shutdownLatch);
+                clientConfig.addListener(&listener);
+
+                HazelcastClient client(clientConfig);
+
+                ASSERT_TRUE(startingLatch.await(0));
+                ASSERT_TRUE(startedLatch.await(0));
+                ASSERT_TRUE(connectedLatch.await(0));
+
+                client.shutdown();
+
+                ASSERT_TRUE(disconnectedLatch.await(3));
+                ASSERT_TRUE(shuttingDownLatch.await(5));
+                ASSERT_TRUE(shutdownLatch.await(10));
+            }
+
             #ifdef HZ_BUILD_WITH_SSL
             INSTANTIATE_TEST_CASE_P(All,
                                     ClusterTest,


### PR DESCRIPTION
Remove the unneeded active flag for ClusterService, since it may cause the shutdown code being not executed.

Fix done while analysing #299 
