### PR TITLE
Closing socket writes warning "Receive failed. An operation was attempted on something that is not a socket"

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/Connection.cpp
+++ b/hazelcast/src/hazelcast/client/connection/Connection.cpp
@@ -106,14 +106,18 @@ namespace hazelcast {
                 if (!_isOwnerConnection) {
                     readHandler.deRegisterSocket();
                 }
-                socket->close();
-                if (_isOwnerConnection) {
-                    return;
+
+                if (!_isOwnerConnection) {
+                    /**
+                     * Remove connection and socket from the list before closing the socket
+                     * in order to prevent the use of closed socket descriptor.
+                     */
+                    clientContext.getConnectionManager().onConnectionClose(serverAddr, socketId);
+
+                    clientContext.getInvocationService().cleanResources(*this);
                 }
 
-                clientContext.getConnectionManager().onConnectionClose(serverAddr, socketId);
-
-                clientContext.getInvocationService().cleanResources(*this);
+                socket->close();
             }
 
 


### PR DESCRIPTION
I saw the following log for a closing connection at some builds:
Jun 21, 2017 10:49:29 PM WARNING: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [4044] Closing connection (id:3) to Address[127.0.0.1:5702] with socket id 584.
Jun 21, 2017 10:49:29 PM WARNING: [HazelcastCppClient3.8.2-SNAPSHOT] [dev] [3780] [IOHandler::handleSocketException] Closing socket to endpoint 127.0.0.1:5702, Cause:ExceptionMessage {Receive failed. An operation was attempted on something that is not a socket.
} at TcpSocket::receive

The second log line can actually be avoided and we should not see it for a closing socket.
Process socket data only if the connection is not closed.