### PR TITLE
writeUTF method size calculation for UTF characters may sometimes be incorrect

### DIFF
--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
@@ -241,27 +241,11 @@ namespace hazelcast {
 
                 int DataOutput::getUTF8CharCount(const std::string &str) {
                     int size = 0;
-                    for (std::string::const_iterator it = str.begin();it != str.end();) {
-                        byte buffer[3];
-                        buffer[0] = (unsigned char)(*it);
-                        if (buffer[0] <= 0x7F) {
-                            ++it;
-                            ++size;
-                        } else {
-                            ++it;
-                            if (it != str.end()) {
-                                buffer[1] = (unsigned char)(*it);
-                                uint16_t twoByteChar = ((buffer[0] << 8) | (buffer[1]));
-                                if (twoByteChar > 0x07FF) {
-                                    it += 2;
-                                    ++size;
-                                } else {
-                                    ++it;
-                                    ++size;
-                                }
-                            }
-                        }
+                    for (std::string::const_iterator it = str.begin();it != str.end();++it) {
+                        // Any additional byte for an UTF character has a bit mask of 10xxxxxx
+                        size += (*it & 0xC0) != 0x80;
                     }
+
                     return size;
                 }
             }

--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -76,6 +76,27 @@ namespace hazelcast {
                         std::auto_ptr<std::string> prefix;
                     };
 
+                    /**
+                     * This processor validates that the string value for the entry is the same as the test string
+                     * "xyzä123 イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム"
+                     */
+                    class UTFValueValidatorProcessor : public serialization::IdentifiedDataSerializable {
+                    public:
+                        virtual int getFactoryId() const {
+                            return 666;
+                        }
+
+                        virtual int getClassId() const {
+                            return 9;
+                        }
+
+                        virtual void writeData(serialization::ObjectDataOutput &writer) const {
+                        }
+
+                        virtual void readData(serialization::ObjectDataInput &reader) {
+                        }
+                    };
+
                     virtual void TearDown() {
                         // clear maps
                         intMap->clear();
@@ -3371,6 +3392,18 @@ namespace hazelcast {
                     val = imap->get("key1");
                     ASSERT_NE((std::string *)NULL, val.get());
                     ASSERT_EQ(prefix + "value1", *val);
+                }
+
+                TEST_F(RawPointerMapTest, testReadUTFWrittenByJava) {
+                    std::string value = "xyzä123 イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム";
+                    std::string key = "myutfkey";
+                    IMap<std::string, std::string> map = client->getMap<std::string, std::string>(
+                            "testReadUTFWrittenByJavaMap");
+                    map.put(key, value);
+                    UTFValueValidatorProcessor processor;
+                    boost::shared_ptr<bool> result = map.executeOnKey<bool, UTFValueValidatorProcessor>(key, processor);
+                    ASSERT_NOTNULL(result.get(), bool);
+                    ASSERT_TRUE(*result);
                 }
             }
         }

--- a/hazelcast/test/src/serialization/ClientSerializationTest.cpp
+++ b/hazelcast/test/src/serialization/ClientSerializationTest.cpp
@@ -657,6 +657,22 @@ namespace hazelcast {
                 ASSERT_EQ(utfStr, *in.readObject<std::string>());
 
             }
+
+            TEST_F(ClientSerializationTest, testGetUTF8CharCount) {
+                std::string utfStr = "xyzä123";
+
+                serialization::pimpl::SerializationConstants constants;
+                serialization::pimpl::PortableContext context(1, constants);
+
+                serialization::pimpl::DataOutput dataOutput;
+                serialization::ObjectDataOutput out(dataOutput, context);
+
+
+                out.writeUTF(&utfStr);
+                std::auto_ptr<std::vector<byte> > byteArray = out.toByteArray();
+                int strLen = util::Bits::readIntB(*byteArray, 0);
+                ASSERT_EQ(7, strLen);
+            }
         }
     }
 }

--- a/java/src/main/java/CppClientListener.java
+++ b/java/src/main/java/CppClientListener.java
@@ -459,6 +459,39 @@ class EmployeeEntryKeyComparator extends EmployeeEntryComparator {
     }
 }
 
+class UTFValueValidatorProcessor
+        implements EntryProcessor<String, String>, IdentifiedDataSerializable {
+    @Override
+    public Object process(Map.Entry<String, String> entry) {
+        return entry.getKey().equals("myutfkey") && entry.getValue().equals("xyzä123 イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム");
+    }
+
+    @Override
+    public EntryBackupProcessor<String, String> getBackupProcessor() {
+        return null;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return 666;
+    }
+
+    @Override
+    public int getId() {
+        return 9;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput objectDataOutput)
+            throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput objectDataInput)
+            throws IOException {
+    }
+}
+
 class MapGetInterceptor implements MapInterceptor, IdentifiedDataSerializable {
     private String prefix;
 
@@ -648,6 +681,8 @@ public class CppClientListener {
                         return new KeyMultiplierWithNullableResult();
                     case 8:
                         return new WaitMultiplierProcessor();
+                    case 9:
+                        return new UTFValueValidatorProcessor();
                     default:
                         return null;
                 }


### PR DESCRIPTION
writeUTF method size calculation for UTF characters may sometimes be incorrect. This fix corrects this problem.

Added a test to verify interworking with Java deserialisation as expected for UTF strings which has multi-byte characters.

fixes #308