### PR TITLE
Cluster thread is deleted while running

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -121,7 +121,6 @@ namespace hazelcast {
                     workerThread = (util::Thread *) NULL;
                     worker->cancel();
                     worker->join();
-                    delete worker;
                 }
             }
 


### PR DESCRIPTION
After the recent shutdown changes of the client, it is now possible that LifecycleService.shutdown is being called from within the cluster thread and this in turn calls ClusterService.shutdown and this call deletes the cluster thread object. The thread join to the calling thread always succeeds without waiting to avoid deadlocks, and this was one of the changes in recent PRs (https://github.com/hazelcast/hazelcast-cpp-client/pull/285), hence even though there is a join call in the ClusterService.shutdown, it actually will not wait since the calling thread was the cluster thread itself. It is really dangerous to delete the current running thread object. Solution: Shutdown the thread but do not delete the cluster thread on shutdown.