### PR TITLE
ConnectionManager object destructed before LifecycleService may cause illegal memory access

### DIFF
--- a/hazelcast/include/hazelcast/client/HazelcastClient.h
+++ b/hazelcast/include/hazelcast/client/HazelcastClient.h
@@ -713,6 +713,7 @@ namespace hazelcast {
 
             ClientConfig clientConfig;
             ClientProperties clientProperties;
+            util::CountDownLatch shutdownLatch;
             spi::ClientContext clientContext;
             spi::LifecycleService lifecycleService;
             serialization::pimpl::SerializationService serializationService;

--- a/hazelcast/include/hazelcast/client/spi/LifecycleService.h
+++ b/hazelcast/include/hazelcast/client/spi/LifecycleService.h
@@ -46,7 +46,8 @@ namespace hazelcast {
             class HAZELCAST_API LifecycleService {
             public:
 
-                LifecycleService(ClientContext &clientContext, const ClientConfig &clientConfig);
+                LifecycleService(ClientContext &clientContext, const ClientConfig &clientConfig,
+                                 util::CountDownLatch &shutdownLatch);
 
                 virtual ~LifecycleService();
 
@@ -68,7 +69,7 @@ namespace hazelcast {
                 std::set<LifecycleListener *> listeners;
                 util::Mutex listenerLock;
                 util::AtomicBoolean active;
-                util::CountDownLatch shutdownLatch;
+                util::CountDownLatch &shutdownLatch;
             };
 
         }

--- a/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/LifecycleService.cpp
@@ -31,12 +31,12 @@ namespace hazelcast {
     namespace client {
         namespace spi {
 
-            LifecycleService::LifecycleService(ClientContext &clientContext, const ClientConfig &clientConfig)
+            LifecycleService::LifecycleService(ClientContext &clientContext, const ClientConfig &clientConfig,
+                                               util::CountDownLatch &shutdownLatch)
             :clientContext(clientContext)
-            , active(true), shutdownLatch(1) {
+            , active(true), shutdownLatch(shutdownLatch) {
                 std::set<LifecycleListener *> const &lifecycleListeners = clientConfig.getLifecycleListeners();
                 listeners.insert(lifecycleListeners.begin(), lifecycleListeners.end());
-
             }
 
             bool LifecycleService::start() {


### PR DESCRIPTION
HazelcastClient destruction should guarantee that the lifecycle service shutdown is completed so that no one accesses ConnectionManager object which is destructed before LifecycleService object. The construction order is LifecycleService first and then the ConnectionManager, and the destruction is in the opposite order (see https://stackoverflow.com/questions/2254263/order-of-member-constructor-and-destructor-calls and http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf page 255 item 8). Hence, we need to wait for LifecycleService finish its shutdown before leaving the HazelcastClient destructor to avoid illegal memory access. It is not only the ConnectionManager but the ClusterService and other objects created after LifecycleService.

Windows environment IssueTest::testIssue221 failures at windows may be due to this reason.

Solution: Let the client provide the shutdownLatch (remove the one in LifecycleService) on LifecycleService construction and client waits on this latch before destructor exit.

