### PR TITLE
The previously connected server address needs to be put at the end of the server adress list

### DIFF
--- a/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClusterService.cpp
@@ -177,8 +177,9 @@ namespace hazelcast {
                         if (*previousConnectionAddr != *it) {
                             addresses.push_back(*it);
                         }
+                    } else {
+                        addresses.push_back(*it);
                     }
-                    addresses.push_back(*it);
                 }
                 if ((Address *) NULL != previousConnectionAddr) {
                     addresses.push_back(*previousConnectionAddr);


### PR DESCRIPTION
The previously connected server address needs to be put at the end of the server list when reconnecting. Current code puts the address twice and it may put the previous address earlier in the list.