### PR TITLE
Missing example and documentation for global serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * [Serialization Support](#serialization-support)
   * [Custom Serialization](#custom-serialization) 
   * [Polymorphic Types Serialization](#polymorphic-types-serialization) 
+  * [Global Serializer](#global-serializer) 
 * [Raw Pointer API](#raw-pointer-api)
 * [Mixed Object Types Supporting HazelcastClient](#mixed-object-types-supporting-hazelcastclient)
   * [TypedData API](#typeddata-api) 
@@ -366,6 +367,19 @@ If you want to use custom objects which are polymorphic, you need to register bo
     serializationConfig.registerSerializer(
             boost::shared_ptr<serialization::StreamSerializer>(new Derived1CustomSerializer));
 ```
+
+## Global Serializer
+Sometimes you may want to use your own serialization for some objects and you may not want to define the Hazelcast serialization for that object or you just do not want to define the getHazelcastTypeId free function for that object, then you can use the global serializer configuration for this purpose. You set the global serializer and you manage how you serialize and deserialize the objects. Here is how you register a global serializer:
+```
+    hazelcast::client::ClientConfig config;
+    hazelcast::client::SerializationConfig serializationConfig;
+    serializationConfig.setGlobalSerializer(boost::shared_ptr<hazelcast::client::serialization::StreamSerializer>(
+            new MyGlobalSerializer()));
+    config.setSerializationConfig(serializationConfig);
+    hazelcast::client::HazelcastClient hz(config);
+```
+
+MyGlobalSerializer is your implementation of StreamSerializer interface. You do not need to write the getHazelcastTypeId function for your objects which are handled by MyGlobalSerializer class.
 
 # Raw Pointer API
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If you want to use custom objects which are polymorphic, you need to register bo
 ```
 
 ## Global Serializer
-Sometimes you may want to use your own serialization for some objects and you may not want to define the Hazelcast serialization for that object or you just do not want to define the getHazelcastTypeId free function for that object, then you can use the global serializer configuration for this purpose. You set the global serializer and you manage how you serialize and deserialize the objects. Here is how you register a global serializer:
+Sometimes you may want to use your own serialization for some objects and do not want to define the Hazelcast serialization for those objects. Or, you may not want to define the getHazelcastTypeId free function for those objects. In these cases, you can use the global serializer configuration for this purpose. You set the global serializer and manage how you serialize and deserialize the objects. Here is how you register a global serializer:
 ```
     hazelcast::client::ClientConfig config;
     hazelcast::client::SerializationConfig serializationConfig;

--- a/examples/serialization/globalserializer/CMakeLists.txt
+++ b/examples/serialization/globalserializer/CMakeLists.txt
@@ -13,7 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(identified-data-serializable)
-add_subdirectory(portable)
-add_subdirectory(custom)
-add_subdirectory(globalserializer)
+add_executable(globalSerializerExample ./main.cpp)

--- a/examples/serialization/globalserializer/main.cpp
+++ b/examples/serialization/globalserializer/main.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <hazelcast/client/HazelcastClient.h>
+#include <hazelcast/client/serialization/ObjectDataInput.h>
+#include <hazelcast/client/serialization/ObjectDataOutput.h>
+
+class Person {
+public:
+    Person() {
+    }
+
+    Person(const std::string& n) : name(n) {
+    }
+
+    void setName(const std::string& n) {
+        name = n;
+    }
+
+    const std::string& getName() const {
+        return name;
+    }
+
+private:
+    std::string name;
+};
+
+class GlobalSerializer : public hazelcast::client::serialization::StreamSerializer {
+public:
+
+    virtual void write(hazelcast::client::serialization::ObjectDataOutput &out, const void *object) {
+        const Person *p = static_cast<const Person *>(object);
+        out.writeUTF(&p->getName());
+    }
+
+    virtual void *read(hazelcast::client::serialization::ObjectDataInput &in) {
+        return new Person(*(in.readUTF()));
+    }
+
+    int getHazelcastTypeId() const {
+        // type id for the global serializer
+        return 345;
+    };
+};
+
+std::ostream &operator<<(std::ostream &out, const Person &p) {
+    const std::string & str = p.getName();
+    out << str;
+    return out;
+}
+
+int main() {
+    hazelcast::client::ClientConfig config;
+    hazelcast::client::SerializationConfig serializationConfig;
+    serializationConfig.setGlobalSerializer(boost::shared_ptr<hazelcast::client::serialization::StreamSerializer>(
+            new GlobalSerializer()));
+    config.setSerializationConfig(serializationConfig);
+    hazelcast::client::HazelcastClient hz(config);
+
+    hazelcast::client::IMap<std::string, Person> map = hz.getMap<std::string, Person>("map");
+    Person testPerson("bar");
+    map.put("foo", testPerson);
+    std::cout << "Got value \"" << *(map.get("foo")) << "\" from the map." << std::endl;
+    std::cout << "Finished" << std::endl;
+
+    return 0;
+}

--- a/hazelcast/include/hazelcast/client/serialization/Serializer.h
+++ b/hazelcast/include/hazelcast/client/serialization/Serializer.h
@@ -40,8 +40,9 @@ namespace hazelcast {
 
                 /**
                  * unique type id for this serializer. It will be used to decide which serializer needs to be used
-                 * for your classes. Also note that for your serialized classes you need to implement as free function
-                 * in same namespace with your class
+                 * for your classes. Also note that for your serialized classes you need to implement the following
+                 * free function in same namespace with your class (except when you want to use the global serializer
+                 * for your class)
                  *
                  *      int32_t getHazelcastTypeId(const MyClass*);
                  *
@@ -59,10 +60,11 @@ namespace hazelcast {
              * Implement this interface and register to the SerializationConfig. See examples folder for usage examples.
              *
              * Important note:
-             * you need to implement as free function in same namespace with your class
+             * Except for the global serializer implementation, you need to implement the following free function in
+             * same namespace with your class
              *            int32_t getHazelcastTypeId(const MyClass*);
              *
-             * which should return same id with its serializer.
+             * which should return same id with its serializer's getHazelcastTypeId() method.
              *
              *
              */

--- a/hazelcast/test/src/map/MapGlobalSerializerTest.cpp
+++ b/hazelcast/test/src/map/MapGlobalSerializerTest.cpp
@@ -15,12 +15,9 @@
  */
 
 #include "hazelcast/util/Util.h"
-#include "hazelcast/client/EntryAdapter.h"
 #include "hazelcast/client/HazelcastClient.h"
 
 #include "ClientTestSupport.h"
-#include "hazelcast/client/ClientConfig.h"
-#include "hazelcast/client/IMap.h"
 #include "HazelcastServer.h"
 #include "HazelcastServerFactory.h"
 


### PR DESCRIPTION
Added globalSerializerExample example for global serializer usage.

Updated javadoc for global serializer.

Added the global serializer documentation.