### PR TITLE
Inefficient ObjectDataInput array reads and ClientMessage Data get

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,11 @@ message(STATUS "Preparing hazelcast client ..... ")
 #detect endianness
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if (${IS_BIG_ENDIAN})
+	message(STATUS "Current system is a BIG-ENDIAN system")
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DHZ_BIG_ENDIAN")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DHZ_BIG_ENDIAN")
+else()
+	message(STATUS "Current system is a LITTLE-ENDIAN system")
 ENDIF (${IS_BIG_ENDIAN})
 
 FILE(GLOB_RECURSE HZ_SOURCES "./hazelcast/src/*cpp")

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <memory>
 #include <stdint.h>
+#include <sstream>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -119,16 +120,21 @@ namespace hazelcast {
                             return std::auto_ptr<std::vector<T> > (NULL);
                         }
 
-                        if (len > 0) {
-                            checkAvailable((size_t)len * getSize((T *)NULL));
-                            std::auto_ptr<std::vector<T> > values(new std::vector<T>((size_t)len));
-                            for (int32_t i = 0; i < len; i++) {
-                                (*values)[i] = read<T>();
-                            }
-                            return values;
+                        if (len == 0) {
+                            return std::auto_ptr<std::vector<T> > (new std::vector<T>(0));
                         }
 
-                        return std::auto_ptr<std::vector<T> > (new std::vector<T>(0));
+                        if (len < 0) {
+                            std::ostringstream out;
+                            out << "Incorrect negative array size found in the byte stream. The size is: " << len;
+                            throw exception::HazelcastSerializationException("DataInput::readArray", out.str());
+                        }
+
+                        std::auto_ptr<std::vector<T> > values(new std::vector<T>((size_t)len));
+                        for (int32_t i = 0; i < len; i++) {
+                            (*values)[i] = read<T>();
+                        }
+                        return values;
                     }
 
                     int getNumBytesForUtf8Char(const byte *start) const;
@@ -154,6 +160,22 @@ namespace hazelcast {
                     int getSize(float *dummy);
 
                     int getSize(double *dummy);
+
+                    char readCharUnchecked();
+
+                    int16_t readShortUnchecked();
+
+                    int32_t readIntUnchecked();
+
+                    int64_t readLongUnchecked();
+
+                    byte readByteUnchecked();
+
+                    bool readBooleanUnchecked();
+
+                    float readFloatUnchecked();
+
+                    double readDoubleUnchecked();
                 };
 
                 template <>

--- a/hazelcast/include/hazelcast/util/LittleEndianBufferWrapper.h
+++ b/hazelcast/include/hazelcast/util/LittleEndianBufferWrapper.h
@@ -229,19 +229,19 @@ namespace hazelcast {
             }
 
             inline bool checkWriteAvailable(int32_t requestedBytes) const {
-                bool result = false;
-                if (!readOnly) {
-                    return checkAvailable(requestedBytes);
+                if (readOnly) {
+                    return false;
                 }
-                return result;
+
+                return checkAvailable(requestedBytes);
             }
 
             inline bool checkReadAvailable(int32_t requestedBytes) const {
-                bool result = false;
-                if (readOnly) {
-                    return checkAvailable(requestedBytes);
+                if (!readOnly) {
+                    return false;
                 }
-                return result;
+
+                return checkAvailable(requestedBytes);
             }
 
             inline bool checkAvailable(int32_t requestedBytes) const {

--- a/hazelcast/src/hazelcast/client/protocol/ClientMessage.cpp
+++ b/hazelcast/src/hazelcast/client/protocol/ClientMessage.cpp
@@ -295,9 +295,9 @@ namespace hazelcast {
 
                 checkAvailable(len);
 
-                std::auto_ptr<std::vector<byte> > bytes = std::auto_ptr<std::vector<byte> >(
-                        new std::vector<byte>(buffer, buffer + len));
-
+                byte *start = ix();
+                std::auto_ptr<std::vector<byte> > bytes = std::auto_ptr<std::vector<byte> >(new std::vector<byte>(start,
+                                                                                                                  start + len));
                 index += len;
 
                 return serialization::pimpl::Data(bytes);

--- a/hazelcast/src/hazelcast/client/protocol/ClientMessage.cpp
+++ b/hazelcast/src/hazelcast/client/protocol/ClientMessage.cpp
@@ -366,7 +366,7 @@ namespace hazelcast {
 
             int32_t ClientMessage::calculateDataSize(const std::string &param) {
                 return INT32_SIZE +  // bytes for the length field
-                       param.length();
+                       (int32_t) param.length();
             }
 
             int32_t ClientMessage::calculateDataSize(const std::string *param) {

--- a/hazelcast/src/hazelcast/client/protocol/ClientMessage.cpp
+++ b/hazelcast/src/hazelcast/client/protocol/ClientMessage.cpp
@@ -291,8 +291,16 @@ namespace hazelcast {
 
             template<>
             serialization::pimpl::Data ClientMessage::get() {
-                return serialization::pimpl::Data(
-                        std::auto_ptr<std::vector<byte> >(new std::vector<byte>(getArray<byte>())));
+                int32_t len = getInt32();
+
+                checkAvailable(len);
+
+                std::auto_ptr<std::vector<byte> > bytes = std::auto_ptr<std::vector<byte> >(
+                        new std::vector<byte>(buffer, buffer + len));
+
+                index += len;
+
+                return serialization::pimpl::Data(bytes);
             }
 
             template<>

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
@@ -16,13 +16,8 @@
 //
 // Created by sancar koyunlu on 8/7/13.
 
-
-
 #include "hazelcast/client/serialization/pimpl/DataOutput.h"
 #include "hazelcast/util/IOUtil.h"
-#include "hazelcast/util/Bits.h"
-
-#include <algorithm>
 
 namespace hazelcast {
     namespace client {
@@ -72,8 +67,11 @@ namespace hazelcast {
                 }
 
                 void DataOutput::writeShort(int32_t v) {
-                    writeByte((byte)(v >> 8));
-                    writeByte((byte)v);
+                    int16_t value = (int16_t) v;
+                    int16_t result;
+                    byte *target = (byte *) &result;
+                    util::Bits::nativeToBigEndian2(&value, &result);
+                    outputStream->insert(outputStream->end(), target, target + util::Bits::SHORT_SIZE_IN_BYTES);
                 }
 
                 void DataOutput::writeChar(int32_t i) {
@@ -82,21 +80,17 @@ namespace hazelcast {
                 }
 
                 void DataOutput::writeInt(int32_t v) {
-                    writeByte((byte)(v >> 24));
-                    writeByte((byte)(v >> 16));
-                    writeByte((byte)(v >> 8));
-                    writeByte((byte)v);
+                    int32_t result;
+                    byte *target = (byte *) &result;
+                    util::Bits::nativeToBigEndian4(&v, &result);
+                    outputStream->insert(outputStream->end(), target, target + util::Bits::INT_SIZE_IN_BYTES);
                 }
 
                 void DataOutput::writeLong(int64_t l) {
-                    writeByte((byte)(l >> 56));
-                    writeByte((byte)(l >> 48));
-                    writeByte((byte)(l >> 40));
-                    writeByte((byte)(l >> 32));
-                    writeByte((byte)(l >> 24));
-                    writeByte((byte)(l >> 16));
-                    writeByte((byte)(l >> 8));
-                    writeByte((byte)l);
+                    int64_t result;
+                    byte *target = (byte *) &result;
+                    util::Bits::nativeToBigEndian8(&l, &result);
+                    outputStream->insert(outputStream->end(), target, target + util::Bits::LONG_SIZE_IN_BYTES);
                 }
 
                 void DataOutput::writeFloat(float x) {
@@ -126,10 +120,13 @@ namespace hazelcast {
                 }
 
                 void DataOutput::writeInt(int index, int32_t v) {
-                    writeByte(index++, (v >> 24));
-                    writeByte(index++, (v >> 16));
-                    writeByte(index++, (v >> 8));
-                    writeByte(index, v);
+                    int32_t result;
+                    byte *target = (byte *) &result;
+                    util::Bits::nativeToBigEndian4(&v, &result);
+                    (*outputStream)[index++] = *target++;
+                    (*outputStream)[index++] = *target++;
+                    (*outputStream)[index++] = *target++;
+                    (*outputStream)[index] = *target;
                 }
 
                 void DataOutput::writeBytes(const byte *bytes, size_t len) {
@@ -137,91 +134,39 @@ namespace hazelcast {
                 }
 
                 void DataOutput::writeByteArray(const std::vector<byte> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        outputStream->insert(outputStream->end(), data->begin(), data->end());
-                    }
+                    writeArray<byte>(data);
                 }
 
                 void DataOutput::writeCharArray(const std::vector<char> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeChar((*data)[i]);
-                        }
-                    }
+                    writeArray<char>(data);
                 }
 
                 void DataOutput::writeBooleanArray(const std::vector<bool> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeBoolean((*data)[i]);
-                        }
-                    }
+                    writeArray<bool>(data);
                 }
 
                 void DataOutput::writeShortArray(const std::vector<int16_t> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeShort((*data)[i]);
-                        }
-                    }
+                    writeArray<int16_t>(data);
                 }
 
                 void DataOutput::writeIntArray(const std::vector<int32_t> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeInt((*data)[i]);
-                        }
-                    }
+                    writeArray<int32_t>(data);
                 }
 
                 void DataOutput::writeLongArray(const std::vector<int64_t> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeLong((*data)[i]);
-                        }
-                    }
+                    writeArray<int64_t>(data);
                 }
 
                 void DataOutput::writeFloatArray(const std::vector<float> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeFloat((*data)[i]);
-                        }
-                    }
+                    writeArray<float>(data);
                 }
 
                 void DataOutput::writeDoubleArray(const std::vector<double> *data) {
-                    int32_t len = (NULL == data ? util::Bits::NULL_ARRAY : (int32_t) data->size());
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeDouble((*data)[i]);
-                        }
-                    }
+                    writeArray<double>(data);
                 }
 
                 void DataOutput::writeUTFArray(const std::vector<std::string> *data) {
-                    int32_t len = (NULL != data) ? (int32_t)data->size() : util::Bits::NULL_ARRAY;
-                    writeInt(len);
-                    if (len > 0) {
-                        for (int32_t i = 0; i < len; ++i) {
-                            writeUTF(&((*data)[i]));
-                        }
-                    }
+                    writeArray<std::string>(data);
                 }
 
                 void DataOutput::writeZeroBytes(int numberOfBytes) {
@@ -248,8 +193,52 @@ namespace hazelcast {
 
                     return size;
                 }
-            }
 
+                template<>
+                void DataOutput::write(const byte &value) {
+                    writeByte(value);
+                }
+
+                template<>
+                void DataOutput::write(const char &value) {
+                    writeChar(value);
+                }
+
+                template<>
+                void DataOutput::write(const bool &value) {
+                    writeBoolean(value);
+                }
+
+                template<>
+                void DataOutput::write(const int16_t &value) {
+                    writeShort(value);
+                }
+
+                template<>
+                void DataOutput::write(const int32_t &value) {
+                    writeInt(value);
+                }
+
+                template<>
+                void DataOutput::write(const int64_t &value) {
+                    writeLong(value);
+                }
+
+                template<>
+                void DataOutput::write(const float &value) {
+                    writeFloat(value);
+                }
+
+                template<>
+                void DataOutput::write(const double &value) {
+                    writeDouble(value);
+                }
+
+                template<>
+                void DataOutput::write(const std::string &value) {
+                    writeUTF(&value);
+                }
+            }
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
@@ -70,7 +70,7 @@ namespace hazelcast {
                     int16_t value = (int16_t) v;
                     int16_t result;
                     byte *target = (byte *) &result;
-                    util::Bits::nativeToBigEndian2(&value, &result);
+                    util::Bits::nativeToBigEndian2(&value, target);
                     outputStream->insert(outputStream->end(), target, target + util::Bits::SHORT_SIZE_IN_BYTES);
                 }
 
@@ -82,14 +82,14 @@ namespace hazelcast {
                 void DataOutput::writeInt(int32_t v) {
                     int32_t result;
                     byte *target = (byte *) &result;
-                    util::Bits::nativeToBigEndian4(&v, &result);
+                    util::Bits::nativeToBigEndian4(&v, target);
                     outputStream->insert(outputStream->end(), target, target + util::Bits::INT_SIZE_IN_BYTES);
                 }
 
                 void DataOutput::writeLong(int64_t l) {
                     int64_t result;
                     byte *target = (byte *) &result;
-                    util::Bits::nativeToBigEndian8(&l, &result);
+                    util::Bits::nativeToBigEndian8(&l, target);
                     outputStream->insert(outputStream->end(), target, target + util::Bits::LONG_SIZE_IN_BYTES);
                 }
 

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataOutput.cpp
@@ -123,9 +123,9 @@ namespace hazelcast {
                     int32_t result;
                     byte *target = (byte *) &result;
                     util::Bits::nativeToBigEndian4(&v, &result);
-                    (*outputStream)[index++] = *target++;
-                    (*outputStream)[index++] = *target++;
-                    (*outputStream)[index++] = *target++;
+                    (*outputStream)[index++] = *(target++);
+                    (*outputStream)[index++] = *(target++);
+                    (*outputStream)[index++] = *(target++);
                     (*outputStream)[index] = *target;
                 }
 

--- a/hazelcast/test/src/util/DataInputTest.cpp
+++ b/hazelcast/test/src/util/DataInputTest.cpp
@@ -178,7 +178,7 @@ namespace hazelcast {
                     bytes.push_back(0x34);
                     bytes.push_back(0x56);
                     bytes.push_back(0x78);
-                    bytes.push_back(0x9A);
+                    bytes.push_back(0x1A);
                     bytes.push_back(0xBC);
                     bytes.push_back(0xDE);
                     bytes.push_back(0xEF);
@@ -187,7 +187,7 @@ namespace hazelcast {
                     ASSERT_NE((std::vector<int32_t> *) NULL, array.get());
                     ASSERT_EQ(2U, array->size());
                     ASSERT_EQ(INT32_C(0x12345678), (*array)[0]);
-                    ASSERT_EQ(INT32_C(0x9ABCDEEF), (*array)[1]);
+                    ASSERT_EQ(INT32_C(0x1ABCDEEF), (*array)[1]);
                 }
 
                 TEST_F(DataInputTest, testReadLongArray) {
@@ -204,7 +204,7 @@ namespace hazelcast {
                     bytes.push_back(0xBC);
                     bytes.push_back(0xDE);
                     bytes.push_back(0xEF);
-                    bytes.push_back(0xA1);
+                    bytes.push_back(0x11);
                     bytes.push_back(0xA2);
                     bytes.push_back(0xA3);
                     bytes.push_back(0xA4);
@@ -217,7 +217,7 @@ namespace hazelcast {
                     ASSERT_NE((std::vector<int64_t> *) NULL, array.get());
                     ASSERT_EQ(2U, array->size());
                     ASSERT_EQ(INT64_C(0x123456789ABCDEEF), (*array)[0]);
-                    ASSERT_EQ(INT64_C(0xA1A2A3A4A5A6A7A8), (*array)[1]);
+                    ASSERT_EQ(INT64_C(0x11A2A3A4A5A6A7A8), (*array)[1]);
                 }
             }
         }

--- a/hazelcast/test/src/util/DataInputTest.cpp
+++ b/hazelcast/test/src/util/DataInputTest.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <hazelcast/client/serialization/pimpl/DataInput.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            namespace util {
+                class DataInputTest : public ::testing::Test
+                {};
+
+                TEST_F(DataInputTest, testReadByte) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x01);
+                    bytes.push_back(0x12);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    ASSERT_EQ(0x01, dataInput.readByte());
+                    ASSERT_EQ(0x12, dataInput.readByte());
+                }
+
+                TEST_F(DataInputTest, testReadBoolean) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x10);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    ASSERT_EQ(false, dataInput.readBoolean());
+                    ASSERT_EQ(true, dataInput.readBoolean());
+                }
+
+                TEST_F(DataInputTest, testReadChar) {
+                    std::vector<byte> bytes;
+                    bytes.push_back('a');
+                    bytes.push_back('b');
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    ASSERT_EQ('b', dataInput.readChar());
+                }
+
+                TEST_F(DataInputTest, testReadShort) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    bytes.push_back(0x56);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    ASSERT_EQ(0x1234, dataInput.readShort());
+                }
+
+                TEST_F(DataInputTest, testReadInteger) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    bytes.push_back(0x56);
+                    bytes.push_back(0x78);
+                    bytes.push_back(0x90);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    ASSERT_EQ(0x12345678, dataInput.readInt());
+                }
+
+                TEST_F(DataInputTest, testReadLong) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    bytes.push_back(0x56);
+                    bytes.push_back(0x78);
+                    bytes.push_back(0x90);
+                    bytes.push_back(0x9A);
+                    bytes.push_back(0x9B);
+                    bytes.push_back(0x9C);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    ASSERT_EQ(0x12345678909A9B9C, dataInput.readLong());
+                }
+
+                TEST_F(DataInputTest, testReadUTF) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x04);
+                    bytes.push_back('b');
+                    bytes.push_back('d');
+                    bytes.push_back('f');
+                    bytes.push_back('h');
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::string> utf = dataInput.readUTF();
+                    ASSERT_NE((std::string *) NULL, utf.get());
+                    ASSERT_EQ("bdfh", *utf);
+                }
+
+                TEST_F(DataInputTest, testReadByteArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    std::vector<byte> actualDataBytes;
+                    actualDataBytes.push_back(0x12);
+                    actualDataBytes.push_back(0x34);
+                    bytes.insert(bytes.end(), actualDataBytes.begin(), actualDataBytes.end());
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::vector<byte> > readBytes = dataInput.readByteArray();
+                    ASSERT_NE((std::vector<byte> *) NULL, readBytes.get());
+                    ASSERT_EQ(actualDataBytes, *readBytes);
+                }
+
+                TEST_F(DataInputTest, testReadBooleanArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x01);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::vector<bool> > booleanArray = dataInput.readBooleanArray();
+                    ASSERT_NE((std::vector<bool> *) NULL, booleanArray.get());
+                    ASSERT_EQ(2U, booleanArray->size());
+                    ASSERT_EQ(false, (*booleanArray)[0]);
+                    ASSERT_EQ(true, (*booleanArray)[1]);
+                }
+
+                TEST_F(DataInputTest, testReadCharArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    bytes.push_back(0);
+                    bytes.push_back('f');
+                    bytes.push_back(0);
+                    bytes.push_back('h');
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::vector<char> > charArray = dataInput.readCharArray();
+                    ASSERT_NE((std::vector<char> *) NULL, charArray.get());
+                    ASSERT_EQ(2U, charArray->size());
+                    ASSERT_EQ('f', (*charArray)[0]);
+                    ASSERT_EQ('h', (*charArray)[1]);
+            }
+
+                TEST_F(DataInputTest, testReadShortArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    bytes.push_back(0x56);
+                    bytes.push_back(0x78);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::vector<int16_t> > array = dataInput.readShortArray();
+                    ASSERT_NE((std::vector<int16_t> *) NULL, array.get());
+                    ASSERT_EQ(2U, array->size());
+                    ASSERT_EQ(0x1234, (*array)[0]);
+                    ASSERT_EQ(0x5678, (*array)[1]);
+                }
+
+                TEST_F(DataInputTest, testReadIntegerArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    bytes.push_back(0x56);
+                    bytes.push_back(0x78);
+                    bytes.push_back(0x9A);
+                    bytes.push_back(0xBC);
+                    bytes.push_back(0xDE);
+                    bytes.push_back(0xEF);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::vector<int32_t> > array = dataInput.readIntArray();
+                    ASSERT_NE((std::vector<int32_t> *) NULL, array.get());
+                    ASSERT_EQ(2U, array->size());
+                    ASSERT_EQ(0x12345678, (*array)[0]);
+                    ASSERT_EQ(0x9ABCDEEF, (*array)[1]);
+                }
+
+                TEST_F(DataInputTest, testReadLongArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    bytes.push_back(0x56);
+                    bytes.push_back(0x78);
+                    bytes.push_back(0x9A);
+                    bytes.push_back(0xBC);
+                    bytes.push_back(0xDE);
+                    bytes.push_back(0xEF);
+                    bytes.push_back(0xA1);
+                    bytes.push_back(0xA2);
+                    bytes.push_back(0xA3);
+                    bytes.push_back(0xA4);
+                    bytes.push_back(0xA5);
+                    bytes.push_back(0xA6);
+                    bytes.push_back(0xA7);
+                    bytes.push_back(0xA8);
+                    serialization::pimpl::DataInput dataInput(bytes);
+                    std::auto_ptr<std::vector<int64_t> > array = dataInput.readLongArray();
+                    ASSERT_NE((std::vector<int64_t> *) NULL, array.get());
+                    ASSERT_EQ(2U, array->size());
+                    ASSERT_EQ(0x123456789ABCDEEF, (*array)[0]);
+                    ASSERT_EQ(0xA1A2A3A4A5A6A7A8, (*array)[1]);
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/test/src/util/DataOutputTest.cpp
+++ b/hazelcast/test/src/util/DataOutputTest.cpp
@@ -15,62 +15,65 @@
  */
 
 #include <gtest/gtest.h>
-#include <hazelcast/client/serialization/pimpl/DataInput.h>
+#include <hazelcast/client/serialization/pimpl/DataOutput.h>
 
 namespace hazelcast {
     namespace client {
         namespace test {
             namespace util {
-                class DataInputTest : public ::testing::Test
+                class DataOutputTest : public ::testing::Test
                 {};
 
-                TEST_F(DataInputTest, testReadByte) {
+                TEST_F(DataOutputTest, testWriteByte) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x01);
                     bytes.push_back(0x12);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    ASSERT_EQ(0x01, dataInput.readByte());
-                    ASSERT_EQ(0x12, dataInput.readByte());
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeByte((byte)0x01);
+                    dataOutput.writeByte(0x12);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadBoolean) {
+                TEST_F(DataOutputTest, testWriteBoolean) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
-                    bytes.push_back(0x10);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    ASSERT_EQ(false, dataInput.readBoolean());
-                    ASSERT_EQ(true, dataInput.readBoolean());
+                    bytes.push_back(0x01);
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeBoolean(false);
+                    dataOutput.writeBoolean(true);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadChar) {
+                TEST_F(DataOutputTest, testWriteChar) {
                     std::vector<byte> bytes;
-                    bytes.push_back('a');
+                    bytes.push_back(0);
                     bytes.push_back('b');
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    ASSERT_EQ('b', dataInput.readChar());
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeChar('b');
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadShort) {
+                TEST_F(DataOutputTest, testWriteShort) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x12);
                     bytes.push_back(0x34);
-                    bytes.push_back(0x56);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    ASSERT_EQ(0x1234, dataInput.readShort());
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeShort(0x1234);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadInteger) {
+                TEST_F(DataOutputTest, testWriteInteger) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x12);
                     bytes.push_back(0x34);
                     bytes.push_back(0x56);
                     bytes.push_back(0x78);
-                    bytes.push_back(0x90);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    ASSERT_EQ(INT32_C(0x12345678), dataInput.readInt());
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeInt(0x12345678);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadLong) {
+                TEST_F(DataOutputTest, testWriteLong) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x12);
                     bytes.push_back(0x34);
@@ -80,11 +83,12 @@ namespace hazelcast {
                     bytes.push_back(0x9A);
                     bytes.push_back(0x9B);
                     bytes.push_back(0x9C);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    ASSERT_EQ(INT64_C(0x12345678909A9B9C), dataInput.readLong());
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeLong(0x12345678909A9B9C);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadUTF) {
+                TEST_F(DataOutputTest, testWriteUTF) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
@@ -94,13 +98,13 @@ namespace hazelcast {
                     bytes.push_back('d');
                     bytes.push_back('f');
                     bytes.push_back('h');
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::string> utf = dataInput.readUTF();
-                    ASSERT_NE((std::string *) NULL, utf.get());
-                    ASSERT_EQ("bdfh", *utf);
+                    serialization::pimpl::DataOutput dataOutput;
+                    std::string value("bdfh");
+                    dataOutput.writeUTF(&value);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadByteArray) {
+                TEST_F(DataOutputTest, testWriteByteArray) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
@@ -110,13 +114,12 @@ namespace hazelcast {
                     actualDataBytes.push_back(0x12);
                     actualDataBytes.push_back(0x34);
                     bytes.insert(bytes.end(), actualDataBytes.begin(), actualDataBytes.end());
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::vector<byte> > readBytes = dataInput.readByteArray();
-                    ASSERT_NE((std::vector<byte> *) NULL, readBytes.get());
-                    ASSERT_EQ(actualDataBytes, *readBytes);
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeByteArray(&actualDataBytes);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadBooleanArray) {
+                TEST_F(DataOutputTest, testWriteBooleanArray) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
@@ -124,73 +127,73 @@ namespace hazelcast {
                     bytes.push_back(0x02);
                     bytes.push_back(0x00);
                     bytes.push_back(0x01);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::vector<bool> > booleanArray = dataInput.readBooleanArray();
-                    ASSERT_NE((std::vector<bool> *) NULL, booleanArray.get());
-                    ASSERT_EQ(2U, booleanArray->size());
-                    ASSERT_EQ(false, (*booleanArray)[0]);
-                    ASSERT_EQ(true, (*booleanArray)[1]);
+                    std::vector<bool> actualValues;
+                    actualValues.push_back(false);
+                    actualValues.push_back(true);
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeBooleanArray(&actualValues);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadCharArray) {
+                TEST_F(DataOutputTest, testWriteCharArray) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
                     bytes.push_back(0x02);
+                    std::vector<char> actualChars;
                     bytes.push_back(0);
                     bytes.push_back('f');
+                    actualChars.push_back('f');
                     bytes.push_back(0);
                     bytes.push_back('h');
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::vector<char> > charArray = dataInput.readCharArray();
-                    ASSERT_NE((std::vector<char> *) NULL, charArray.get());
-                    ASSERT_EQ(2U, charArray->size());
-                    ASSERT_EQ('f', (*charArray)[0]);
-                    ASSERT_EQ('h', (*charArray)[1]);
-            }
-
-                TEST_F(DataInputTest, testReadShortArray) {
-                    std::vector<byte> bytes;
-                    bytes.push_back(0x00);
-                    bytes.push_back(0x00);
-                    bytes.push_back(0x00);
-                    bytes.push_back(0x02);
-                    bytes.push_back(0x12);
-                    bytes.push_back(0x34);
-                    bytes.push_back(0x56);
-                    bytes.push_back(0x78);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::vector<int16_t> > array = dataInput.readShortArray();
-                    ASSERT_NE((std::vector<int16_t> *) NULL, array.get());
-                    ASSERT_EQ(2U, array->size());
-                    ASSERT_EQ(0x1234, (*array)[0]);
-                    ASSERT_EQ(0x5678, (*array)[1]);
+                    actualChars.push_back('h');
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeCharArray(&actualChars);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadIntegerArray) {
+                TEST_F(DataOutputTest, testWriteShortArray) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
                     bytes.push_back(0x02);
+                    std::vector<int16_t> actualValues;
+                    bytes.push_back(0x12);
+                    bytes.push_back(0x34);
+                    actualValues.push_back(0x1234);
+                    bytes.push_back(0x56);
+                    bytes.push_back(0x78);
+                    actualValues.push_back(0x5678);
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeShortArray(&actualValues);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
+                }
+
+                TEST_F(DataOutputTest, testWriteIntegerArray) {
+                    std::vector<byte> bytes;
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x00);
+                    bytes.push_back(0x02);
+                    std::vector<int32_t> actualValues;
                     bytes.push_back(0x12);
                     bytes.push_back(0x34);
                     bytes.push_back(0x56);
                     bytes.push_back(0x78);
+                    actualValues.push_back(0x12345678);
                     bytes.push_back(0x9A);
                     bytes.push_back(0xBC);
                     bytes.push_back(0xDE);
                     bytes.push_back(0xEF);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::vector<int32_t> > array = dataInput.readIntArray();
-                    ASSERT_NE((std::vector<int32_t> *) NULL, array.get());
-                    ASSERT_EQ(2U, array->size());
-                    ASSERT_EQ(INT32_C(0x12345678), (*array)[0]);
-                    ASSERT_EQ(INT32_C(0x9ABCDEEF), (*array)[1]);
+                    actualValues.push_back(0x9ABCDEEF);
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeIntArray(&actualValues);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
-                TEST_F(DataInputTest, testReadLongArray) {
+                TEST_F(DataOutputTest, testWriteLongArray) {
                     std::vector<byte> bytes;
                     bytes.push_back(0x00);
                     bytes.push_back(0x00);
@@ -212,12 +215,12 @@ namespace hazelcast {
                     bytes.push_back(0xA6);
                     bytes.push_back(0xA7);
                     bytes.push_back(0xA8);
-                    serialization::pimpl::DataInput dataInput(bytes);
-                    std::auto_ptr<std::vector<int64_t> > array = dataInput.readLongArray();
-                    ASSERT_NE((std::vector<int64_t> *) NULL, array.get());
-                    ASSERT_EQ(2U, array->size());
-                    ASSERT_EQ(INT64_C(0x123456789ABCDEEF), (*array)[0]);
-                    ASSERT_EQ(INT64_C(0xA1A2A3A4A5A6A7A8), (*array)[1]);
+                    std::vector<int64_t> actualValues;
+                    actualValues.push_back(0x123456789ABCDEEF);
+                    actualValues.push_back(0xA1A2A3A4A5A6A7A8);
+                    serialization::pimpl::DataOutput dataOutput;
+                    dataOutput.writeLongArray(&actualValues);
+                    ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
             }
         }

--- a/hazelcast/test/src/util/DataOutputTest.cpp
+++ b/hazelcast/test/src/util/DataOutputTest.cpp
@@ -69,7 +69,7 @@ namespace hazelcast {
                     bytes.push_back(0x56);
                     bytes.push_back(0x78);
                     serialization::pimpl::DataOutput dataOutput;
-                    dataOutput.writeInt(0x12345678);
+                    dataOutput.writeInt(INT32_C(0x12345678));
                     ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
@@ -84,7 +84,7 @@ namespace hazelcast {
                     bytes.push_back(0x9B);
                     bytes.push_back(0x9C);
                     serialization::pimpl::DataOutput dataOutput;
-                    dataOutput.writeLong(0x12345678909A9B9C);
+                    dataOutput.writeLong(INT64_C(0x12345678909A9B9C));
                     ASSERT_EQ(bytes, *dataOutput.toByteArray());
                 }
 
@@ -182,12 +182,12 @@ namespace hazelcast {
                     bytes.push_back(0x34);
                     bytes.push_back(0x56);
                     bytes.push_back(0x78);
-                    actualValues.push_back(0x12345678);
+                    actualValues.push_back(INT32_C(0x12345678));
                     bytes.push_back(0x9A);
                     bytes.push_back(0xBC);
                     bytes.push_back(0xDE);
                     bytes.push_back(0xEF);
-                    actualValues.push_back(0x9ABCDEEF);
+                    actualValues.push_back(INT32_C(0x9ABCDEEF));
                     serialization::pimpl::DataOutput dataOutput;
                     dataOutput.writeIntArray(&actualValues);
                     ASSERT_EQ(bytes, *dataOutput.toByteArray());
@@ -216,8 +216,8 @@ namespace hazelcast {
                     bytes.push_back(0xA7);
                     bytes.push_back(0xA8);
                     std::vector<int64_t> actualValues;
-                    actualValues.push_back(0x123456789ABCDEEF);
-                    actualValues.push_back(0xA1A2A3A4A5A6A7A8);
+                    actualValues.push_back(INT64_C(0x123456789ABCDEEF));
+                    actualValues.push_back(INT64_C(0xA1A2A3A4A5A6A7A8));
                     serialization::pimpl::DataOutput dataOutput;
                     dataOutput.writeLongArray(&actualValues);
                     ASSERT_EQ(bytes, *dataOutput.toByteArray());


### PR DESCRIPTION
Makes the array reads more efficient.

Makes array writes work similar way as the array reads.

Makes the client message data read more efficient by minimising the size checks and reading the full byte array at a single api call.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/328