### PR TITLE
Client proper shutdown fix (windows)

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClusterListenerThread.cpp
@@ -57,7 +57,7 @@ namespace hazelcast {
                 spi::LifecycleService &lifecycleService = clientContext.getLifecycleService();
                 while (lifecycleService.isRunning()) {
                     try {
-                        if (conn.get() == NULL) {
+                        if (conn.get() == NULL || !conn->live) {
                             try {
                                 conn = clientContext.getClusterService().connectToOne(previousConnectionAddrPtr);
                                 previousConnectionAddr = conn->getRemoteEndpoint();
@@ -94,7 +94,6 @@ namespace hazelcast {
                         if (deletingConnection.compareAndSet(false, true)) {
                             if (conn.get()) {
                                 util::IOUtil::closeResource(conn.get(), "Error while listening cluster events");
-                                conn.reset();
                                 lifecycleService.fireLifecycleEvent(LifecycleEvent::CLIENT_DISCONNECTED);
                             }
                             deletingConnection = false;
@@ -111,7 +110,6 @@ namespace hazelcast {
                 if (deletingConnection.compareAndSet(false, true)) {
                     if (conn.get()) {
                         util::IOUtil::closeResource(conn.get(), "Cluster listener thread is stopping");
-                        conn.reset();
                         clientContext.getLifecycleService().fireLifecycleEvent(LifecycleEvent::CLIENT_DISCONNECTED);
                     }
                     deletingConnection = false;


### PR DESCRIPTION
Removed connection resets. Added connection alive check to be used in addition to the null check at the ClusterListenerThread thread loop.

The problem case:
1. Due to connection reset, the connection is destroyed and the underlying receiveBuffer is deleted.
2.  ClusterListenerThread is still at listenMembershipEvents call blocked at the readBlocking call which uses the deleted receiveBuffer of the connection. The receiveBuffer is accessed after the blocking read and this is an illegal memory access.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/369

Attached is the logs that I added which were used at windows to determine where the problem was.
[windows_failure_with_logs_added_issue_369.txt](https://github.com/hazelcast/hazelcast-cpp-client/files/1579628/windows_failure_with_logs_added_issue_369.txt)

