### PR TITLE
Update the License documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,7 +1289,7 @@ Please join the mail group if you are interested in using or developing Hazelcas
 
 # License
 
-Hazelcast C++ Client is available under the Apache 2 License. Please see the [Licensing appendix](http://docs.hazelcast.org/docs/latest/manual/html-single/hazelcast-documentation.html#license-questions) for more information.
+Hazelcast C++ Client is available under the Apache 2 License. Please see the [Licensing appendix](http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#license-questions) for more information.
 
 # Copyright
 


### PR DESCRIPTION
Corrected the License documentation link to the current working link.