### PR TITLE
Can not write objects to logger without using ostringstream

### DIFF
--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -286,10 +286,18 @@ namespace hazelcast {
             *  set SEVERE to see only serious errors
             *
             *  Default log level is INFO
+            * @param loggerLevel The log level to be set.
             * @return itself ClientConfig
             */
-            ClientConfig &setLogLevel(LogLevel loggerLevel);
+            ClientConfig &setLogLevel(LoggerLevel::Level loggerLevel);
 
+            /**
+             * @deprecated Please use setLogLevel(LoggerLevel::Level loggerLevel) instead.
+             *
+             * @param loggerLevel The log level to be set.
+             * @return The configured client configuration for chaining.
+             */
+            ClientConfig &setLogLevel(LogLevel loggerLevel);
 
             /**
             *

--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -280,22 +280,14 @@ namespace hazelcast {
             ClientConfig &setLoadBalancer(LoadBalancer *loadBalancer);
 
             /**
-            *  enum LogLevel { SEVERE = 100, WARNING = 90, INFO = 50 };
+            *  enum LogLevel { SEVERE, WARNING, INFO, FINEST };
             *  set INFO to see every log.
             *  set WARNING to see only possible warnings and serious errors.
             *  set SEVERE to see only serious errors
+            *  set FINEST to see all messages including debug messages.
             *
-            *  Default log level is INFO
             * @param loggerLevel The log level to be set.
-            * @return itself ClientConfig
-            */
-            ClientConfig &setLogLevel(LoggerLevel::Level loggerLevel);
-
-            /**
-             * @deprecated Please use setLogLevel(LoggerLevel::Level loggerLevel) instead.
-             *
-             * @param loggerLevel The log level to be set.
-             * @return The configured client configuration for chaining.
+            * @return The configured client configuration for chaining.
              */
             ClientConfig &setLogLevel(LogLevel loggerLevel);
 

--- a/hazelcast/include/hazelcast/client/Ringbuffer.h
+++ b/hazelcast/include/hazelcast/client/Ringbuffer.h
@@ -23,6 +23,11 @@
 
 #include "hazelcast/client/IDistributedObject.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
 namespace hazelcast {
     namespace client {
         /**
@@ -169,6 +174,10 @@ namespace hazelcast {
         };
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HZELCAST_CLIENT_RINGBUFFER_H_
 

--- a/hazelcast/include/hazelcast/client/mixedtype/Ringbuffer.h
+++ b/hazelcast/include/hazelcast/client/mixedtype/Ringbuffer.h
@@ -22,6 +22,11 @@
 #include "hazelcast/client/proxy/ProxyImpl.h"
 #include "hazelcast/client/protocol/codec/RingbufferAddCodec.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace mixedtype {
@@ -203,6 +208,10 @@ namespace hazelcast {
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_CLIENT_MIXEDTYPE_RINGBUFFER_H_
 

--- a/hazelcast/include/hazelcast/util/ILogger.h
+++ b/hazelcast/include/hazelcast/util/ILogger.h
@@ -142,6 +142,7 @@ namespace hazelcast {
             LeveledLogger();
 
             ILogger &logger;
+            client::LoggerLevel::Level requestedLogLevel;
         };
     }
 }

--- a/hazelcast/include/hazelcast/util/ILogger.h
+++ b/hazelcast/include/hazelcast/util/ILogger.h
@@ -37,14 +37,10 @@ namespace hazelcast {
         class HAZELCAST_API LoggerLevel {
         public:
             enum Level {
-                SEVERE = 3, WARNING = 2, INFO = 1, FINEST = 0
+                SEVERE = 100, WARNING = 90, INFO = 50, FINEST = 20
             };
 
-            static const char *getLevelString(const Level &level) {
-                return levelStrings[level];
-            }
-        private:
-            static const char *levelStrings[4];
+            static const char *getLevelString(const Level &level);
         };
 
         enum LogLevel {

--- a/hazelcast/include/hazelcast/util/ILogger.h
+++ b/hazelcast/include/hazelcast/util/ILogger.h
@@ -58,12 +58,6 @@ namespace hazelcast {
         public:
             static ILogger& getLogger();
 
-            /**
-             * @deprecated Please use setLogLevel(const client::LogLevel::Level &logLevel)
-             * @param logLevel The log level values
-             */
-            void setLogLevel(int logLevel);
-
             void setLogLevel(const client::LoggerLevel::Level &logLevel);
 
             void severe(const std::string& message);

--- a/hazelcast/include/hazelcast/util/ILogger.h
+++ b/hazelcast/include/hazelcast/util/ILogger.h
@@ -17,13 +17,15 @@
 // Created by sancar koyunlu on 20/02/14.
 //
 
-
 #ifndef HAZELCAST_ILogger
 #define HAZELCAST_ILogger
 
 #include "hazelcast/util/HazelcastDll.h"
-#include "Mutex.h"
+#include "hazelcast/util/Mutex.h"
+#include "hazelcast/util/LockGuard.h"
+
 #include <string>
+#include <iostream>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -32,17 +34,41 @@
 
 namespace hazelcast {
     namespace client {
+        class HAZELCAST_API LoggerLevel {
+        public:
+            enum Level {
+                SEVERE = 3, WARNING = 2, INFO = 1, FINEST = 0
+            };
+
+            static const char *getLevelString(const Level &level) {
+                return levelStrings[level];
+            }
+        private:
+            static const char *levelStrings[4];
+        };
+
         enum LogLevel {
-            SEVERE = 100, WARNING = 90, INFO = 50, FINEST = 20
+            SEVERE = LoggerLevel::SEVERE, WARNING = LoggerLevel::WARNING, INFO = LoggerLevel::INFO, FINEST = LoggerLevel::FINEST
         };
     }
 
     namespace util {
+        #define TIME_STRING_LENGTH 25
+
+        class LeveledLogger;
+
         class HAZELCAST_API ILogger {
+            friend class LeveledLogger;
         public:
             static ILogger& getLogger();
 
+            /**
+             * @deprecated Please use setLogLevel(const client::LogLevel::Level &logLevel)
+             * @param logLevel The log level values
+             */
             void setLogLevel(int logLevel);
+
+            void setLogLevel(const client::LoggerLevel::Level &logLevel);
 
             void severe(const std::string& message);
 
@@ -54,11 +80,26 @@ namespace hazelcast {
 
             void setPrefix(const std::string& prefix);
 
+            LeveledLogger finest();
+
+            LeveledLogger info();
+
+            LeveledLogger warning();
+
+            LeveledLogger severe();
+
+            bool isEnabled(const client::LoggerLevel::Level &logLevel) const;
+
+            /**
+             * @deprecated Please use isEnabled(const client::LogLevel::Level &logLevel)
+             * @param logLevel The level of the logger for which it will print the logs.
+             * @return true if the level is enabled.
+             */
             bool isEnabled(int logLevel) const;
 
             bool isFinestEnabled() const;
         private:
-            int HazelcastLogLevel;
+            client::LoggerLevel::Level logLevel;
             std::string prefix;
 
             ILogger();
@@ -67,11 +108,44 @@ namespace hazelcast {
 
             const char *getTime(char * buffer, size_t length) const;
 
+            const char *getLevelString(client::LoggerLevel::Level logLevel) const;
+
+            void printMessagePrefix(client::LoggerLevel::Level logLevel) const;
+
             ILogger(const ILogger&);
 
             ILogger& operator=(const ILogger&);
 
             util::Mutex lockMutex;
+
+            static ILogger singletonLogger;
+
+            void printLog(client::LoggerLevel::Level level, const std::string &message);
+        };
+
+        /**
+         * TODO: The lock may not be released on thread cancellations since the destructor may not be called.
+         */
+        class HAZELCAST_API LeveledLogger {
+        public:
+            // Gets the logger lock
+            LeveledLogger(ILogger &logger, client::LoggerLevel::Level logLevel);
+
+            // Releases the logger lock.
+            virtual ~LeveledLogger();
+
+            template <typename T>
+            LeveledLogger &operator<<(const T &value) {
+                if (logger.isEnabled(logger.logLevel)) {
+                    std::cout << value;
+                }
+                return *this;
+            }
+
+        private:
+            LeveledLogger();
+
+            ILogger &logger;
         };
     }
 }

--- a/hazelcast/src/hazelcast/client/ClientConfig.cpp
+++ b/hazelcast/src/hazelcast/client/ClientConfig.cpp
@@ -105,9 +105,14 @@ namespace hazelcast {
             return *this;
         }
 
-        ClientConfig& ClientConfig::setLogLevel(LogLevel loggerLevel) {
+        ClientConfig& ClientConfig::setLogLevel(LoggerLevel::Level loggerLevel) {
             util::ILogger::getLogger().setLogLevel(loggerLevel);
             return *this;
+        }
+
+        ClientConfig &ClientConfig::setLogLevel(LogLevel loggerLevel) {
+            return setLogLevel((LoggerLevel::Level) loggerLevel);
+
         }
 
         ClientConfig& ClientConfig::addListener(LifecycleListener *listener) {

--- a/hazelcast/src/hazelcast/client/ClientConfig.cpp
+++ b/hazelcast/src/hazelcast/client/ClientConfig.cpp
@@ -105,14 +105,9 @@ namespace hazelcast {
             return *this;
         }
 
-        ClientConfig& ClientConfig::setLogLevel(LoggerLevel::Level loggerLevel) {
-            util::ILogger::getLogger().setLogLevel(loggerLevel);
-            return *this;
-        }
-
         ClientConfig &ClientConfig::setLogLevel(LogLevel loggerLevel) {
-            return setLogLevel((LoggerLevel::Level) loggerLevel);
-
+            util::ILogger::getLogger().setLogLevel(static_cast<LoggerLevel::Level>(loggerLevel));
+            return *this;
         }
 
         ClientConfig& ClientConfig::addListener(LifecycleListener *listener) {

--- a/hazelcast/src/hazelcast/util/ILogger.cpp
+++ b/hazelcast/src/hazelcast/util/ILogger.cpp
@@ -29,7 +29,21 @@
 
 namespace hazelcast {
     namespace client {
-        const char *client::LoggerLevel::levelStrings[4] = {"FINEST", "INFO", "WARNING", "SEVERE"};
+        const char *LoggerLevel::getLevelString(const Level &level) {
+            switch (level) {
+                case SEVERE:
+                    return "SEVERE";
+                case WARNING:
+                    return "WARNING";
+                case INFO:
+                    return "INFO";
+                case FINEST:
+                    return "FINEST";
+                default:
+                    assert(0);
+            }
+            return NULL;
+        }
     }
 
     namespace util {
@@ -50,7 +64,7 @@ namespace hazelcast {
         }
 
         void ILogger::setLogLevel(int logLevel) {
-            this->logLevel = (client::LoggerLevel::Level) logLevel;
+            this->logLevel = static_cast<client::LoggerLevel::Level>(logLevel);
         }
 
         void ILogger::severe(const std::string& message) {
@@ -94,7 +108,7 @@ namespace hazelcast {
         }
 
         bool ILogger::isEnabled(int level) const {
-            return isEnabled((client::LoggerLevel::Level) level);
+            return isEnabled(static_cast<client::LoggerLevel::Level>(level));
         }
 
         const char *ILogger::getTime(char *buffer, size_t length) const {

--- a/hazelcast/src/hazelcast/util/ILogger.cpp
+++ b/hazelcast/src/hazelcast/util/ILogger.cpp
@@ -63,10 +63,6 @@ namespace hazelcast {
             this->logLevel = logLevel;
         }
 
-        void ILogger::setLogLevel(int logLevel) {
-            this->logLevel = static_cast<client::LoggerLevel::Level>(logLevel);
-        }
-
         void ILogger::severe(const std::string& message) {
             printLog(client::LoggerLevel::SEVERE, message);
         }

--- a/hazelcast/src/hazelcast/util/ILogger.cpp
+++ b/hazelcast/src/hazelcast/util/ILogger.cpp
@@ -160,14 +160,21 @@ namespace hazelcast {
             std::flush(std::cout);
         }
 
-        LeveledLogger::LeveledLogger(ILogger &logger, client::LoggerLevel::Level logLevel) : logger(logger) {
-            if (logger.isEnabled(logLevel)) {
-                logger.lockMutex.lock();
-                logger.printMessagePrefix(logLevel);
+        LeveledLogger::LeveledLogger(ILogger &logger, client::LoggerLevel::Level logLevel) : logger(logger),
+                                                                                             requestedLogLevel(logLevel) {
+            if (!logger.isEnabled(requestedLogLevel)) {
+                return;
             }
+
+            logger.lockMutex.lock();
+            logger.printMessagePrefix(requestedLogLevel);
         }
 
         LeveledLogger::~LeveledLogger() {
+            if (!logger.isEnabled(requestedLogLevel)) {
+                return;
+            }
+
             std::cout << std::endl;
             logger.lockMutex.unlock();
             std::flush(std::cout);

--- a/hazelcast/src/hazelcast/util/ILogger.cpp
+++ b/hazelcast/src/hazelcast/util/ILogger.cpp
@@ -149,11 +149,6 @@ namespace hazelcast {
                 printMessagePrefix(level);
                 std::cout << message;
             }
-            // Due to the problem faced in Linux environment which is described
-            // in https://gcc.gnu.org/ml/gcc/2003-12/msg00743.html, we could not use
-            // std::cout here. outstream flush() function in stdlib 3.4.4 does not handle pthread_cancel call
-            // appropriately.
-            std::flush(std::cout);
         }
 
         LeveledLogger::LeveledLogger(ILogger &logger, client::LoggerLevel::Level logLevel) : logger(logger),

--- a/hazelcast/src/hazelcast/util/ILogger.cpp
+++ b/hazelcast/src/hazelcast/util/ILogger.cpp
@@ -28,72 +28,73 @@
 #include <assert.h>
 
 namespace hazelcast {
-    namespace util {
+    namespace client {
+        const char *client::LoggerLevel::levelStrings[4] = {"FINEST", "INFO", "WARNING", "SEVERE"};
+    }
 
-#define TIME_STRING_LENGTH 25
+    namespace util {
+        ILogger ILogger::singletonLogger;
 
         ILogger& ILogger::getLogger() {
-            static ILogger singleton;
-            return singleton;
+            return singletonLogger;
         }
 
-        ILogger::ILogger() : HazelcastLogLevel(client::INFO) {
+        ILogger::ILogger() : logLevel(client::LoggerLevel::INFO) {
         }
 
         ILogger::~ILogger() {
         }
 
+        void ILogger::setLogLevel(const client::LoggerLevel::Level &logLevel) {
+            this->logLevel = logLevel;
+        }
+
         void ILogger::setLogLevel(int logLevel) {
-            HazelcastLogLevel = logLevel;
+            this->logLevel = (client::LoggerLevel::Level) logLevel;
         }
 
         void ILogger::severe(const std::string& message) {
-            if (isEnabled(client::SEVERE)) {
-                char buffer [TIME_STRING_LENGTH];
-                util::LockGuard l(lockMutex);
-                // Due to the problem faced in Linux environment which is described
-                // in https://gcc.gnu.org/ml/gcc/2003-12/msg00743.html, we could not use
-                // std::cout here. outstream flush() function in stdlib 3.4.4 does not handle pthread_cancel call
-                // appropriately.
-                printf("%s SEVERE: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
-                fflush(stdout);
-            }
+            printLog(client::LoggerLevel::SEVERE, message);
         }
 
         void ILogger::warning(const std::string& message) {
-            if (isEnabled(client::WARNING)) {
-                char buffer [TIME_STRING_LENGTH];
-                util::LockGuard l(lockMutex);
-                printf("%s WARNING: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
-                fflush(stdout);
-            }
+            printLog(client::LoggerLevel::WARNING, message);
         }
 
         void ILogger::info(const std::string& message) {
-            if (isEnabled(client::INFO)) {
-                char buffer [TIME_STRING_LENGTH];
-                util::LockGuard l(lockMutex);
-                printf("%s INFO: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
-                fflush(stdout);
-            }
+            printLog(client::LoggerLevel::INFO, message);
         }
 
-
         void ILogger::finest(const std::string& message) {
-            if (isEnabled(client::FINEST)) {
-                char buffer [TIME_STRING_LENGTH];
-                util::LockGuard l(lockMutex);
-                printf("%s FINEST: %s [%ld] %s\n", getTime(buffer, TIME_STRING_LENGTH), prefix.c_str(), util::getThreadId(), message.c_str());
-                fflush(stdout);
-            }
+            printLog(client::LoggerLevel::FINEST, message);
+        }
+
+        LeveledLogger ILogger::finest() {
+            return LeveledLogger(*this, client::LoggerLevel::FINEST);
+        }
+
+        LeveledLogger ILogger::info() {
+            return LeveledLogger(*this, client::LoggerLevel::INFO);
+        }
+
+        LeveledLogger ILogger::warning() {
+            return LeveledLogger(*this, client::LoggerLevel::WARNING);
+        }
+
+        LeveledLogger ILogger::severe() {
+            return LeveledLogger(*this, client::LoggerLevel::SEVERE);
         }
 
         void ILogger::setPrefix(const std::string& prefix) {
             this->prefix = prefix;
         }
 
-        bool ILogger::isEnabled(int logLevel) const {
-            return logLevel >= HazelcastLogLevel;
+        bool ILogger::isEnabled(const client::LoggerLevel::Level &logLevel) const {
+            return logLevel >= this->logLevel;
+        }
+
+        bool ILogger::isEnabled(int level) const {
+            return isEnabled((client::LoggerLevel::Level) level);
         }
 
         const char *ILogger::getTime(char *buffer, size_t length) const {
@@ -115,7 +116,47 @@ namespace hazelcast {
         }
 
         bool ILogger::isFinestEnabled() const {
-            return isEnabled(client::FINEST);
+            return isEnabled(client::LoggerLevel::FINEST);
+        }
+
+        const char *ILogger::getLevelString(client::LoggerLevel::Level logLevel) const {
+            return client::LoggerLevel::getLevelString(logLevel);
+        }
+
+        void ILogger::printMessagePrefix(client::LoggerLevel::Level logLevel) const {
+            char buffer[TIME_STRING_LENGTH];
+            std::cout << getTime(buffer, TIME_STRING_LENGTH) << " " << getLevelString(logLevel) << ": [" << getThreadId()
+                      << "] " << prefix << " ";
+        }
+
+        void ILogger::printLog(client::LoggerLevel::Level level, const std::string &message) {
+            if (!isEnabled(level)) {
+                return;
+            }
+
+            {
+                util::LockGuard l(lockMutex);
+                printMessagePrefix(level);
+                std::cout << message;
+            }
+            // Due to the problem faced in Linux environment which is described
+            // in https://gcc.gnu.org/ml/gcc/2003-12/msg00743.html, we could not use
+            // std::cout here. outstream flush() function in stdlib 3.4.4 does not handle pthread_cancel call
+            // appropriately.
+            std::flush(std::cout);
+        }
+
+        LeveledLogger::LeveledLogger(ILogger &logger, client::LoggerLevel::Level logLevel) : logger(logger) {
+            if (logger.isEnabled(logLevel)) {
+                logger.lockMutex.lock();
+                logger.printMessagePrefix(logLevel);
+            }
+        }
+
+        LeveledLogger::~LeveledLogger() {
+            std::cout << std::endl;
+            logger.lockMutex.unlock();
+            std::flush(std::cout);
         }
     }
 }

--- a/hazelcast/test/src/util/LoggerTest.cpp
+++ b/hazelcast/test/src/util/LoggerTest.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <hazelcast/util/ILogger.h>
+#include <ostream>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class LoggerTest : public ::testing::Test {
+            public:
+                LoggerTest() : logger(util::ILogger::getLogger()) {
+                }
+
+            protected:
+                virtual void SetUp() {
+                    originalStdout = std::cout.rdbuf();
+
+                    std::cout.rdbuf(buffer.rdbuf());
+                }
+
+                virtual void TearDown() {
+                    std::cout.rdbuf(originalStdout);
+                    logger.setLogLevel(LoggerLevel::INFO);
+                }
+
+                class TestObject {
+                public:
+                    TestObject(int objectCount) : objectCount(objectCount) {}
+
+                    friend std::ostream &operator<<(std::ostream &os, const TestObject &object) {
+                        os << "objectCount: " << object.objectCount;
+                        return os;
+                    }
+
+                private:
+                    int objectCount;
+                };
+
+                util::ILogger &logger;
+                std::stringstream buffer;
+                std::streambuf *originalStdout;
+                LoggerLevel::Level originalLogLevel;
+            };
+
+            TEST_F(LoggerTest, testPrintObject) {
+                logger.info() << "This is an info message. " << TestObject(5);
+
+                const std::string &printedString = buffer.str();
+                size_t index = printedString.find("This is an info message. objectCount: 5");
+
+                ASSERT_NE(printedString.npos, index);
+            }
+
+            TEST_F(LoggerTest, testDefaultLogLevel) {
+                ASSERT_FALSE(logger.isFinestEnabled());
+                ASSERT_FALSE(logger.isEnabled(client::LoggerLevel::FINEST));
+                ASSERT_TRUE(logger.isEnabled(client::LoggerLevel::INFO));
+                ASSERT_TRUE(logger.isEnabled(client::LoggerLevel::WARNING));
+                ASSERT_TRUE(logger.isEnabled(client::LoggerLevel::SEVERE));
+
+                logger.finest("Warning level message");
+                ASSERT_TRUE(buffer.str().empty());
+
+                logger.info("info message");
+                std::string value = buffer.str();
+                ASSERT_NE(std::string::npos, value.find("info message"));
+
+                logger.warning("warning message");
+                ASSERT_NE(std::string::npos, buffer.str().find("warning message"));
+
+                logger.severe("severe message");
+                ASSERT_NE(std::string::npos, buffer.str().find("severe message"));
+            }
+
+            TEST_F(LoggerTest, testLogLevel) {
+                logger.setLogLevel(client::LoggerLevel::WARNING);
+
+                ASSERT_FALSE(logger.isFinestEnabled());
+                ASSERT_FALSE(logger.isEnabled(client::LoggerLevel::FINEST));
+                ASSERT_FALSE(logger.isEnabled(client::LoggerLevel::INFO));
+                ASSERT_TRUE(logger.isEnabled(client::LoggerLevel::WARNING));
+                ASSERT_TRUE(logger.isEnabled(client::LoggerLevel::SEVERE));
+
+                logger.finest("Warning level message");
+                ASSERT_TRUE(buffer.str().empty());
+
+                logger.info("info message");
+                ASSERT_TRUE(buffer.str().empty());
+
+                logger.warning("warning message");
+                ASSERT_NE(std::string::npos, buffer.str().find("warning message"));
+
+                logger.severe("severe message");
+                ASSERT_NE(std::string::npos, buffer.str().find("severe message"));
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This PR extends the logger with stream operator support so that you can easily log different objects and it is appendable.