### PR TITLE
Missing random uuid generator and address generator classes as defined at Java client

### DIFF
--- a/hazelcast/include/hazelcast/client/Address.h
+++ b/hazelcast/include/hazelcast/client/Address.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <sstream>
+#include <asio/ip/address.hpp>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -35,6 +36,8 @@ namespace hazelcast {
          */
         class HAZELCAST_API Address : public serialization::IdentifiedDataSerializable {
         public:
+            Address(const std::string &hostname, const asio::ip::address &inetAddress, int port);
+
             static const int ID;
 
             /**
@@ -65,6 +68,12 @@ namespace hazelcast {
             int getPort() const;
 
             /**
+             *
+             * @return true if the address is ip V4 address, false otherwise.
+             */
+            bool isIpV4() const;
+
+            /**
              * @return host address as string
              */
             const std::string& getHost() const;
@@ -80,15 +89,22 @@ namespace hazelcast {
 
             /***** serialization::IdentifiedDataSerializable interface implementation end here ************************/
 
+            unsigned long getScopeId() const;
+
             bool operator<(const Address &rhs) const;
 
         private:
             std::string host;
             int port;
             byte type;
+            asio::ip::address inetAddress;
 
             static const byte IPV4;
             static const byte IPV6;
+
+            void init();
+
+            void setType();
         };
 
         /**

--- a/hazelcast/include/hazelcast/client/Address.h
+++ b/hazelcast/include/hazelcast/client/Address.h
@@ -79,6 +79,9 @@ namespace hazelcast {
             virtual void readData(serialization::ObjectDataInput &reader);
 
             /***** serialization::IdentifiedDataSerializable interface implementation end here ************************/
+
+            bool operator<(const Address &rhs) const;
+
         private:
             std::string host;
             int port;

--- a/hazelcast/include/hazelcast/client/Address.h
+++ b/hazelcast/include/hazelcast/client/Address.h
@@ -21,6 +21,12 @@
 
 #include <string>
 #include <sstream>
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+// We need to include this header before asio/ip/address.hpp
+#include <winsock2.h>
+#endif
+
 #include <asio/ip/address.hpp>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)

--- a/hazelcast/include/hazelcast/client/exception/IException.h
+++ b/hazelcast/include/hazelcast/client/exception/IException.h
@@ -87,5 +87,3 @@ namespace hazelcast {
 #endif 
 
 #endif //HAZELCAST_EXCEPTION
-
-

--- a/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
+++ b/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
@@ -181,6 +181,12 @@ namespace hazelcast {
                 HazelcastClientNotActiveException(const std::string &source, const std::string &message) : IException(
                         source, message) {}
             };
+
+            class HAZELCAST_API UnknownHostException : public IException {
+            public:
+                UnknownHostException(const std::string &source, const std::string &message) : IException(
+                        source, message) {}
+            };
         }
     }
 }

--- a/hazelcast/include/hazelcast/client/internal/socket/TcpSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/TcpSocket.h
@@ -16,17 +16,6 @@
 #ifndef HAZELCAST_CLIENT_INTERNAL_SOCKET_TCPSOCKET_H_
 #define HAZELCAST_CLIENT_INTERNAL_SOCKET_TCPSOCKET_H_
 
-#include "hazelcast/client/Socket.h"
-
-#include "hazelcast/client/Address.h"
-#include "hazelcast/util/AtomicBoolean.h"
-#include <string>
-
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(push)
-#pragma warning(disable: 4251) //for dll export	
-#endif
-
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma comment(lib, "Ws2_32.lib")
 #include <winsock2.h>
@@ -47,6 +36,17 @@ typedef int socklen_t;
 #include <sys/select.h>
 #include <fcntl.h>
 
+#endif
+
+#include "hazelcast/client/Socket.h"
+
+#include "hazelcast/client/Address.h"
+#include "hazelcast/util/AtomicBoolean.h"
+#include <string>
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export	
 #endif
 
 #if !defined(MSG_NOSIGNAL)

--- a/hazelcast/include/hazelcast/util/AddressHelper.h
+++ b/hazelcast/include/hazelcast/util/AddressHelper.h
@@ -53,7 +53,6 @@ namespace hazelcast {
         class HAZELCAST_API AddressHelper {
         public:
             static std::vector<client::Address> getSocketAddresses(const std::string &address);
-
         private:
             static const int MAX_PORT_TRIES;
             static const int INITIAL_FIRST_PORT;

--- a/hazelcast/include/hazelcast/util/AddressHelper.h
+++ b/hazelcast/include/hazelcast/util/AddressHelper.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAZELCAST_UTIL_ADDRESSHELPER_H_
+#define HAZELCAST_UTIL_ADDRESSHELPER_H_
+
+#include "hazelcast/client/Address.h"
+#include <ostream>
+#include "hazelcast/util/HazelcastDll.h"
+
+namespace hazelcast {
+    namespace util {
+        /**
+         * Holds address
+         */
+        class HAZELCAST_API AddressHolder {
+        public:
+            AddressHolder(const std::string &address, const std::string &scopeId, int port);
+
+            const std::string &getAddress() const;
+
+            const std::string &getScopeId() const;
+
+            int getPort() const;
+
+            friend std::ostream &operator<<(std::ostream &os, const AddressHolder &holder);
+
+        private:
+            std::string address;
+            std::string scopeId;
+            int port;
+        };
+
+
+        /**
+         * This is a client side utility class for working with addresses and cluster connections
+         */
+        class HAZELCAST_API AddressHelper {
+        public:
+            static std::vector<client::Address> getSocketAddresses(const std::string &address);
+
+        private:
+            static const int MAX_PORT_TRIES;
+            static const int INITIAL_FIRST_PORT;
+
+            static std::vector<client::Address>
+            getPossibleSocketAddresses(int port, const std::string &scopedAddress, int portTryCount);
+        };
+    }
+}
+
+
+#endif //HAZELCAST_UTIL_ADDRESSHELPER_H_
+

--- a/hazelcast/include/hazelcast/util/AddressHelper.h
+++ b/hazelcast/include/hazelcast/util/AddressHelper.h
@@ -17,8 +17,10 @@
 #ifndef HAZELCAST_UTIL_ADDRESSHELPER_H_
 #define HAZELCAST_UTIL_ADDRESSHELPER_H_
 
-#include "hazelcast/client/Address.h"
 #include <ostream>
+#include <vector>
+
+#include "hazelcast/client/Address.h"
 #include "hazelcast/util/HazelcastDll.h"
 
 namespace hazelcast {

--- a/hazelcast/include/hazelcast/util/AddressHelper.h
+++ b/hazelcast/include/hazelcast/util/AddressHelper.h
@@ -23,6 +23,11 @@
 #include "hazelcast/client/Address.h"
 #include "hazelcast/util/HazelcastDll.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
 namespace hazelcast {
     namespace util {
         /**
@@ -63,6 +68,9 @@ namespace hazelcast {
     }
 }
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_UTIL_ADDRESSHELPER_H_
 

--- a/hazelcast/include/hazelcast/util/AddressUtil.h
+++ b/hazelcast/include/hazelcast/util/AddressUtil.h
@@ -18,7 +18,7 @@
 #define HAZELCAST_UTIL_ADDRESSUTIL_H_
 
 #include "hazelcast/util/HazelcastDll.h"
-#include "AddressHelper.h"
+#include "hazelcast/util/AddressHelper.h"
 
 namespace hazelcast {
     namespace util {
@@ -27,6 +27,15 @@ namespace hazelcast {
             static AddressHolder getAddressHolder(const std::string &address);
 
             static AddressHolder getAddressHolder(const std::string &address, int defaultPort);
+
+            static bool isIpV4(const std::string &scopedAddress);
+
+            static asio::ip::address getByName(const std::string &host);
+
+            static asio::ip::address getByName(const std::string &host, int port);
+
+        private:
+            static asio::ip::address getByName(const std::string &host, const std::string &service);
         };
 
     }

--- a/hazelcast/include/hazelcast/util/AddressUtil.h
+++ b/hazelcast/include/hazelcast/util/AddressUtil.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAZELCAST_UTIL_ADDRESSUTIL_H_
+#define HAZELCAST_UTIL_ADDRESSUTIL_H_
+
+#include "hazelcast/util/HazelcastDll.h"
+#include "AddressHelper.h"
+
+namespace hazelcast {
+    namespace util {
+        class HAZELCAST_API AddressUtil {
+        public:
+            static AddressHolder getAddressHolder(const std::string &address);
+
+            static AddressHolder getAddressHolder(const std::string &address, int defaultPort);
+        };
+
+    }
+}
+
+
+#endif //HAZELCAST_UTIL_ADDRESSUTIL_H_
+

--- a/hazelcast/include/hazelcast/util/UUID.h
+++ b/hazelcast/include/hazelcast/util/UUID.h
@@ -20,6 +20,8 @@
 #define HAZELCAST_UTIL_UUID_H_
 
 #include <stdint.h>
+#include <string>
+#include <ostream>
 
 #include "hazelcast/util/HazelcastDll.h"
 
@@ -64,7 +66,41 @@ namespace hazelcast {
              *          <code>false</code> otherwise.
              */
             bool equals(const UUID &rhs) const;
+
+            bool operator==(const UUID &rhs) const;
+
+            bool operator!=(const UUID &rhs) const;
+
+            friend std::ostream &operator<<(std::ostream &os, const UUID &uuid);
+
+            /**
+             * Returns a {@code String} object representing this {@code UUID}.
+             *
+             * <p> The UUID string representation is as described by this BNF:
+             * <blockquote><pre>
+             * {@code
+             * UUID                   = <time_low> "-" <time_mid> "-"
+             *                          <time_high_and_version> "-"
+             *                          <variant_and_sequence> "-"
+             *                          <node>
+             * time_low               = 4*<hexOctet>
+             * time_mid               = 2*<hexOctet>
+             * time_high_and_version  = 2*<hexOctet>
+             * variant_and_sequence   = 2*<hexOctet>
+             * node                   = 6*<hexOctet>
+             * hexOctet               = <hexDigit><hexDigit>
+             * hexDigit               =
+             *       "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+             *       | "a" | "b" | "c" | "d" | "e" | "f"
+             *       | "A" | "B" | "C" | "D" | "E" | "F"
+             * }</pre></blockquote>
+             *
+             * @return  A string representation of this {@code UUID}
+             */
+            std::string toString() const;
         private:
+            static std::string digits(int64_t val, int32_t digits);
+
             const int64_t mostSigBits;
             const int64_t leastSigBits;
         };

--- a/hazelcast/include/hazelcast/util/UUID.h
+++ b/hazelcast/include/hazelcast/util/UUID.h
@@ -71,8 +71,6 @@ namespace hazelcast {
 
             bool operator!=(const UUID &rhs) const;
 
-            friend std::ostream &operator<<(std::ostream &os, const UUID &uuid);
-
             /**
              * Returns a {@code String} object representing this {@code UUID}.
              *
@@ -104,6 +102,7 @@ namespace hazelcast {
             const int64_t mostSigBits;
             const int64_t leastSigBits;
         };
+
     }
 }
 

--- a/hazelcast/include/hazelcast/util/UuidUtil.h
+++ b/hazelcast/include/hazelcast/util/UuidUtil.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAZELCAST_UTIL_UUIDUTIL_H_
+#define HAZELCAST_UTIL_UUIDUTIL_H_
+
+#include <string>
+
+#include "hazelcast/util/HazelcastDll.h"
+#include "UUID.h"
+
+namespace hazelcast {
+    namespace util {
+        class HAZELCAST_API UuidUtil {
+        public:
+            /**
+             * Static factory to retrieve a type 4 (pseudo randomly generated) UUID based string.
+             *
+             * The {@code UUID} string is generated using a cryptographically weak pseudo random number generator.
+             *
+             * @return A randomly generated {@code UUID} base string
+             */
+            static std::string newUnsecureUuidString();
+
+            /**
+             * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
+             *
+             * The {@code UUID} is generated using a cryptographically weak pseudo random number generator.
+             *
+             * @return A randomly generated {@code UUID}
+             */
+            static UUID newUnsecureUUID();
+        };
+    }
+}
+
+
+#endif //HAZELCAST_UTIL_UUIDUTIL_H_
+

--- a/hazelcast/include/hazelcast/util/UuidUtil.h
+++ b/hazelcast/include/hazelcast/util/UuidUtil.h
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "hazelcast/util/HazelcastDll.h"
-#include "UUID.h"
+#include "hazelcast/util/UUID.h"
 
 namespace hazelcast {
     namespace util {

--- a/hazelcast/src/hazelcast/client/Address.cpp
+++ b/hazelcast/src/hazelcast/client/Address.cpp
@@ -76,6 +76,22 @@ namespace hazelcast {
             }
         }
 
+        bool Address::operator<(const Address &rhs) const {
+            if (host < rhs.host) {
+                return true;
+            }
+            if (rhs.host < host) {
+                return false;
+            }
+            if (port < rhs.port) {
+                return true;
+            }
+            if (rhs.port < port) {
+                return false;
+            }
+            return type < rhs.type;
+        }
+
         bool addressComparator::operator ()(const Address &lhs, const Address &rhs) const {
             int i = lhs.getHost().compare(rhs.getHost());
             if (i == 0) {

--- a/hazelcast/src/hazelcast/client/connection/Connection.cpp
+++ b/hazelcast/src/hazelcast/client/connection/Connection.cpp
@@ -17,7 +17,7 @@
 // Created by sancar koyunlu on 5/21/13.
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif
 
 #include "hazelcast/client/connection/Connection.h"

--- a/hazelcast/src/hazelcast/util/AddressHelper.cpp
+++ b/hazelcast/src/hazelcast/util/AddressHelper.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hazelcast/util/AddressUtil.h"
+#include <asio/asio/include/asio/io_service.hpp>
+#include <asio/asio/include/asio/ip/tcp.hpp>
+#include "hazelcast/util/ILogger.h"
+#include "hazelcast/util/AddressHelper.h"
+
+namespace hazelcast {
+    namespace util {
+        const int AddressHelper::MAX_PORT_TRIES = 3;
+        const int AddressHelper::INITIAL_FIRST_PORT = 5701;
+
+        std::vector<client::Address> AddressHelper::getSocketAddresses(const std::string &address) {
+            const AddressHolder addressHolder = AddressUtil::getAddressHolder(address, -1);
+            const std::string scopedAddress = !addressHolder.getScopeId().empty()
+                                         ? addressHolder.getAddress() + '%' + addressHolder.getScopeId()
+                                         : addressHolder.getAddress();
+
+            int port = addressHolder.getPort();
+            int maxPortTryCount = 1;
+            if (port == -1) {
+                maxPortTryCount = MAX_PORT_TRIES;
+            }
+            return getPossibleSocketAddresses(port, scopedAddress, maxPortTryCount);
+        }
+
+        std::vector<client::Address>
+        AddressHelper::getPossibleSocketAddresses(int port, const std::string &scopedAddress, int portTryCount) {
+            std::string inetAddress;
+            bool isIpV4;
+            try {
+                asio::io_service ioService;
+                asio::ip::tcp::resolver res(ioService);
+                asio::ip::tcp::resolver::query query(scopedAddress, "");
+                asio::ip::basic_resolver<asio::ip::tcp>::iterator iterator = res.resolve(query);
+                isIpV4 = iterator->endpoint().address().is_v4();
+            } catch (asio::system_error &ignored) {
+                util::ILogger::getLogger().getLogger().finest() << "Address not available" << ignored.what();
+            }
+
+            int possiblePort = port;
+            if (possiblePort == -1) {
+                possiblePort = INITIAL_FIRST_PORT;
+            }
+            std::vector<client::Address> addresses;
+
+            if (inetAddress.empty()) {
+                for (int i = 0; i < portTryCount; i++) {
+                    addresses.push_back(client::Address(scopedAddress, possiblePort + i));
+                }
+            } else if (isIpV4) {
+                for (int i = 0; i < portTryCount; i++) {
+                    //TODO addresses.push_back(client::Address(scopedAddress, inetAddress, possiblePort + i));
+                    addresses.push_back(client::Address(inetAddress, possiblePort + i));
+                }
+            }/* TODO: else if (isIpV6) {
+                final Collection<Inet6Address> possibleInetAddresses = getPossibleInetAddressesFor((Inet6Address) inetAddress);
+                for (Inet6Address inet6Address : possibleInetAddresses) {
+                    for (int i = 0; i < portTryCount; i++) {
+                        addresses.add(new Address(scopedAddress, inet6Address, possiblePort + i));
+                    }
+                }
+            }*/
+
+            return addresses;
+        }
+
+        AddressHolder::AddressHolder(const std::string &address, const std::string &scopeId, int port) : address(
+                address), scopeId(scopeId), port(port) {}
+
+        std::ostream &operator<<(std::ostream &os, const AddressHolder &holder) {
+            os << "AddressHolder [" << holder.address + "]:" << holder.port;
+            return os;
+        }
+
+        const std::string &AddressHolder::getAddress() const {
+            return address;
+        }
+
+        const std::string &AddressHolder::getScopeId() const {
+            return scopeId;
+        }
+
+        int AddressHolder::getPort() const {
+            return port;
+        }
+    }
+}

--- a/hazelcast/src/hazelcast/util/AddressUtil.cpp
+++ b/hazelcast/src/hazelcast/util/AddressUtil.cpp
@@ -20,14 +20,14 @@ namespace hazelcast {
     namespace util {
 
         AddressHolder AddressUtil::getAddressHolder(const std::string &address, int defaultPort) {
-            std::string::size_type indexBracketStart = address.find('[');
-            std::string::size_type indexBracketEnd = address.find(']', indexBracketStart);
-            std::string::size_type indexColon = address.find(':');
-            std::string::size_type lastIndexColon = address.rfind(':');
+            int indexBracketStart = static_cast<int>(address.find('['));
+            int indexBracketEnd = static_cast<int>(address.find(']', indexBracketStart));
+            int indexColon = static_cast<int>(address.find(':'));
+            int lastIndexColon = static_cast<int>(address.rfind(':'));
             std::string host;
             int port = defaultPort;
             std::string scopeId;
-            if (indexColon != std::string::npos && lastIndexColon > indexColon) {
+            if (indexColon > -1 && lastIndexColon > indexColon) {
                 // IPv6
                 if (indexBracketStart == 0 && indexBracketEnd > indexBracketStart) {
                     host = address.substr(indexBracketStart + 1, indexBracketEnd - (indexBracketStart + 1));
@@ -37,12 +37,12 @@ namespace hazelcast {
                 } else {
                     host = address;
                 }
-                std::string::size_type indexPercent = host.find('%');
-                if (indexPercent != std::string::npos) {
+                int indexPercent = static_cast<int>(host.find('%'));
+                if (indexPercent != -1) {
                     scopeId = host.substr(indexPercent + 1);
                     host = host.substr(0, indexPercent);
                 }
-            } else if (indexColon != 0 && indexColon == lastIndexColon) {
+            } else if (indexColon > 0 && indexColon == lastIndexColon) {
                 host = address.substr(0, indexColon);
                 port = atoi(address.substr(indexColon + 1).c_str());
             } else {

--- a/hazelcast/src/hazelcast/util/AddressUtil.cpp
+++ b/hazelcast/src/hazelcast/util/AddressUtil.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hazelcast/util/AddressUtil.h"
+
+namespace hazelcast {
+    namespace util {
+
+        AddressHolder AddressUtil::getAddressHolder(const std::string &address, int defaultPort) {
+            std::string::size_type indexBracketStart = address.find('[');
+            std::string::size_type indexBracketEnd = address.find(']', indexBracketStart);
+            std::string::size_type indexColon = address.find(':');
+            std::string::size_type lastIndexColon = address.rfind(':');
+            std::string host;
+            int port = defaultPort;
+            std::string scopeId;
+            if (indexColon != std::string::npos && lastIndexColon > indexColon) {
+                // IPv6
+                if (indexBracketStart == 0 && indexBracketEnd > indexBracketStart) {
+                    host = address.substr(indexBracketStart + 1, indexBracketEnd - (indexBracketStart + 1));
+                    if (lastIndexColon == indexBracketEnd + 1) {
+                        port = atoi(address.substr(lastIndexColon + 1).c_str());
+                    }
+                } else {
+                    host = address;
+                }
+                std::string::size_type indexPercent = host.find('%');
+                if (indexPercent != std::string::npos) {
+                    scopeId = host.substr(indexPercent + 1);
+                    host = host.substr(0, indexPercent);
+                }
+            } else if (indexColon != 0 && indexColon == lastIndexColon) {
+                host = address.substr(0, indexColon);
+                port = atoi(address.substr(indexColon + 1).c_str());
+            } else {
+                host = address;
+            }
+            return AddressHolder(host, scopeId, port);
+        }
+
+        AddressHolder AddressUtil::getAddressHolder(const std::string &address) {
+            return getAddressHolder(address, -1);
+        }
+    }
+}

--- a/hazelcast/src/hazelcast/util/SyncHttpClient.cpp
+++ b/hazelcast/src/hazelcast/util/SyncHttpClient.cpp
@@ -17,7 +17,7 @@
 //  Created by ihsan demir on 12 Jan 2017
 //
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif
 
 #include "hazelcast/util/SyncHttpClient.h"

--- a/hazelcast/src/hazelcast/util/SyncHttpsClient.cpp
+++ b/hazelcast/src/hazelcast/util/SyncHttpsClient.cpp
@@ -18,7 +18,7 @@
 //
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#include <WinSock2.h>
+#include <winsock2.h>
 #endif
 
 #ifdef HZ_BUILD_WITH_SSL

--- a/hazelcast/src/hazelcast/util/UUID.cpp
+++ b/hazelcast/src/hazelcast/util/UUID.cpp
@@ -52,7 +52,7 @@ namespace hazelcast {
         }
 
         std::string UUID::digits(int64_t val, int32_t digits) {
-            int64_t hi = 1L << (digits * 4);
+            int64_t hi = 1LL << (digits * 4);
             std::ostringstream out;
             out << std::hex << (hi | (val & (hi - 1)));
             std::string value = out.str();

--- a/hazelcast/src/hazelcast/util/UUID.cpp
+++ b/hazelcast/src/hazelcast/util/UUID.cpp
@@ -18,6 +18,7 @@
 //  Copyright (c) 2015 ihsan demir. All rights reserved.
 //
 
+#include <sstream>
 #include "hazelcast/util/UUID.h"
 
 namespace hazelcast {
@@ -40,6 +41,34 @@ namespace hazelcast {
 
         bool UUID::equals(const UUID &rhs) const {
             return (mostSigBits == rhs.mostSigBits && leastSigBits == rhs.leastSigBits);
+        }
+
+        std::string UUID::toString() const {
+            return (digits(mostSigBits >> 32, 8) + "-" +
+                    digits(mostSigBits >> 16, 4) + "-" +
+                    digits(mostSigBits, 4) + "-" +
+                    digits(leastSigBits >> 48, 4) + "-" +
+                    digits(leastSigBits, 12));
+        }
+
+        std::string UUID::digits(int64_t val, int32_t digits) {
+            int64_t hi = 1L << (digits * 4);
+            std::ostringstream out;
+            out << std::hex << (hi | (val & (hi - 1)));
+            return out.str().substr(1);
+        }
+
+        bool UUID::operator==(const UUID &rhs) const {
+            return this->equals(rhs);
+        }
+
+        bool UUID::operator!=(const UUID &rhs) const {
+            return !(rhs == *this);
+        }
+
+        std::ostream &util::operator<<(std::ostream &os, const UUID &uuid) {
+            os << uuid.toString();
+            return os;
         }
     }
 }

--- a/hazelcast/src/hazelcast/util/UUID.cpp
+++ b/hazelcast/src/hazelcast/util/UUID.cpp
@@ -55,7 +55,8 @@ namespace hazelcast {
             int64_t hi = 1L << (digits * 4);
             std::ostringstream out;
             out << std::hex << (hi | (val & (hi - 1)));
-            return out.str().substr(1);
+            std::string value = out.str();
+            return value.substr(1);
         }
 
         bool UUID::operator==(const UUID &rhs) const {
@@ -66,9 +67,5 @@ namespace hazelcast {
             return !(rhs == *this);
         }
 
-        std::ostream &util::operator<<(std::ostream &os, const UUID &uuid) {
-            os << uuid.toString();
-            return os;
-        }
     }
 }

--- a/hazelcast/src/hazelcast/util/UuidUtil.cpp
+++ b/hazelcast/src/hazelcast/util/UuidUtil.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hazelcast/util/UuidUtil.h"
+
+namespace hazelcast {
+    namespace util {
+        std::string UuidUtil::newUnsecureUuidString() {
+            return newUnsecureUUID().toString();
+        }
+
+        UUID UuidUtil::newUnsecureUUID() {
+            byte data[16];
+            // TODO: Use a better random bytes generator
+            for (int j = 0; j < 16; ++j) {
+                data[j] = rand() % 16;
+            }
+
+            // clear version
+            data[6] &= 0x0f;
+            // set to version 4
+            data[6] |= 0x40;
+            // clear variant
+            data[8] &= 0x3f;
+            // set to IETF variant
+            data[8] |= 0x80;
+
+            int64_t mostSigBits = 0;
+            int64_t leastSigBits = 0;
+            for (int i = 0; i < 8; i++) {
+                mostSigBits = (mostSigBits << 8) | (data[i] & 0xff);
+            }
+            for (int i = 8; i < 16; i++) {
+                leastSigBits = (leastSigBits << 8) | (data[i] & 0xff);
+            }
+            return UUID(mostSigBits, leastSigBits);
+        }
+    }
+}

--- a/hazelcast/test/src/util/AddressHelperTest.cpp
+++ b/hazelcast/test/src/util/AddressHelperTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <hazelcast/util/AddressHelper.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class AddressHelperTest : public ::testing::Test {
+            };
+
+            TEST_F(AddressHelperTest, testGetPossibleSocketAddresses) {
+                std::string address("10.2.3.1");
+                std::vector<Address> addresses = util::AddressHelper::getSocketAddresses(address);
+                ASSERT_EQ(4U, addresses.size());
+                std::set<Address> socketAddresses;
+                socketAddresses.insert(addresses.begin(), addresses.end());
+                ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5701)));
+                ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5702)));
+                ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5703)));
+                ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5704)));
+            }
+
+            TEST_F(AddressHelperTest, testAddressHolder) {
+                util::AddressHolder holder("127.0.0.1", "en0", 8000);
+                ASSERT_EQ("127.0.0.1", holder.getAddress());
+                ASSERT_EQ(8000, holder.getPort());
+                ASSERT_EQ("en0", holder.getScopeId());
+            }
+        }
+    }
+}
+

--- a/hazelcast/test/src/util/AddressHelperTest.cpp
+++ b/hazelcast/test/src/util/AddressHelperTest.cpp
@@ -26,13 +26,12 @@ namespace hazelcast {
             TEST_F(AddressHelperTest, testGetPossibleSocketAddresses) {
                 std::string address("10.2.3.1");
                 std::vector<Address> addresses = util::AddressHelper::getSocketAddresses(address);
-                ASSERT_EQ(4U, addresses.size());
+                ASSERT_EQ(3U, addresses.size());
                 std::set<Address> socketAddresses;
                 socketAddresses.insert(addresses.begin(), addresses.end());
                 ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5701)));
                 ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5702)));
                 ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5703)));
-                ASSERT_NE(socketAddresses.end(), socketAddresses.find(Address(address, 5704)));
             }
 
             TEST_F(AddressHelperTest, testAddressHolder) {

--- a/hazelcast/test/src/util/AddressUtilTest.cpp
+++ b/hazelcast/test/src/util/AddressUtilTest.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 #include <hazelcast/util/AddressUtil.h>
-#include <hazelcast/util/AddressHelper.h>
 
 namespace hazelcast {
     namespace client {
@@ -42,6 +41,25 @@ namespace hazelcast {
                 addressHolder = util::AddressUtil::getAddressHolder("hazelcast.com:80");
                 ASSERT_EQ("hazelcast.com", addressHolder.getAddress());
                 ASSERT_EQ(80, addressHolder.getPort());
+            }
+            
+            TEST_F(AddressUtilTest, testGetByNameIpV6) {
+                std::string addrString("::1");
+                asio::ip::address address = util::AddressUtil::getByName(addrString);
+                ASSERT_TRUE(address.is_v6());
+                ASSERT_FALSE(address.is_v4());
+                ASSERT_TRUE(address.is_loopback());
+                ASSERT_EQ(0, address.to_v6().scope_id());
+                ASSERT_EQ(0, address.to_v6().scope_id());
+                ASSERT_EQ(addrString, address.to_string());
+            }
+
+            TEST_F(AddressUtilTest, testGetByNameIpV4) {
+                std::string addrString("127.0.0.1");
+                asio::ip::address address = util::AddressUtil::getByName(addrString);
+                ASSERT_TRUE(address.is_v4());
+                ASSERT_FALSE(address.is_v6());
+                ASSERT_EQ(addrString, address.to_string());
             }
         }
     }

--- a/hazelcast/test/src/util/AddressUtilTest.cpp
+++ b/hazelcast/test/src/util/AddressUtilTest.cpp
@@ -44,11 +44,12 @@ namespace hazelcast {
             }
             
             TEST_F(AddressUtilTest, testGetByNameIpV6) {
-                std::string addrString("::1");
+                std::string addrString("www.v6.facebook.com");
+                std::string expectedResolveIp("2a03:2880:20:cf04:face:b00c::12c");
                 asio::ip::address address = util::AddressUtil::getByName(addrString);
                 ASSERT_TRUE(address.is_v6());
                 ASSERT_FALSE(address.is_v4());
-                ASSERT_EQ(addrString, address.to_string());
+                ASSERT_EQ(expectedResolveIp, address.to_string());
             }
 
             TEST_F(AddressUtilTest, testGetByNameIpV4) {

--- a/hazelcast/test/src/util/AddressUtilTest.cpp
+++ b/hazelcast/test/src/util/AddressUtilTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <hazelcast/util/AddressUtil.h>
+#include <hazelcast/util/AddressHelper.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class AddressUtilTest : public ::testing::Test {
+            };
+
+            TEST_F(AddressUtilTest, testParsingHostAndPort) {
+                util::AddressHolder addressHolder = util::AddressUtil::getAddressHolder(
+                        "[fe80::62c5:*:fe05:480a%en0]:8080");
+                ASSERT_EQ("fe80::62c5:*:fe05:480a", addressHolder.getAddress());
+                ASSERT_EQ(8080, addressHolder.getPort());
+                ASSERT_EQ("en0", addressHolder.getScopeId());
+
+                addressHolder = util::AddressUtil::getAddressHolder("[::ffff:192.0.2.128]:5700");
+                ASSERT_EQ("::ffff:192.0.2.128", addressHolder.getAddress());
+                ASSERT_EQ(5700, addressHolder.getPort());
+
+                addressHolder = util::AddressUtil::getAddressHolder("192.168.1.1:5700");
+                ASSERT_EQ("192.168.1.1", addressHolder.getAddress());
+                ASSERT_EQ(5700, addressHolder.getPort());
+
+                addressHolder = util::AddressUtil::getAddressHolder("hazelcast.com:80");
+                ASSERT_EQ("hazelcast.com", addressHolder.getAddress());
+                ASSERT_EQ(80, addressHolder.getPort());
+            }
+        }
+    }
+}

--- a/hazelcast/test/src/util/AddressUtilTest.cpp
+++ b/hazelcast/test/src/util/AddressUtilTest.cpp
@@ -42,15 +42,6 @@ namespace hazelcast {
                 ASSERT_EQ("hazelcast.com", addressHolder.getAddress());
                 ASSERT_EQ(80, addressHolder.getPort());
             }
-            
-            TEST_F(AddressUtilTest, testGetByNameIpV6) {
-                std::string addrString("www.v6.facebook.com");
-                std::string expectedResolveIp("2a03:2880:20:cf04:face:b00c::12c");
-                asio::ip::address address = util::AddressUtil::getByName(addrString);
-                ASSERT_TRUE(address.is_v6());
-                ASSERT_FALSE(address.is_v4());
-                ASSERT_EQ(expectedResolveIp, address.to_string());
-            }
 
             TEST_F(AddressUtilTest, testGetByNameIpV4) {
                 std::string addrString("127.0.0.1");

--- a/hazelcast/test/src/util/AddressUtilTest.cpp
+++ b/hazelcast/test/src/util/AddressUtilTest.cpp
@@ -48,9 +48,6 @@ namespace hazelcast {
                 asio::ip::address address = util::AddressUtil::getByName(addrString);
                 ASSERT_TRUE(address.is_v6());
                 ASSERT_FALSE(address.is_v4());
-                ASSERT_TRUE(address.is_loopback());
-                ASSERT_EQ(0, address.to_v6().scope_id());
-                ASSERT_EQ(0, address.to_v6().scope_id());
                 ASSERT_EQ(addrString, address.to_string());
             }
 

--- a/hazelcast/test/src/util/UuidUtilTest.cpp
+++ b/hazelcast/test/src/util/UuidUtilTest.cpp
@@ -31,22 +31,30 @@ namespace hazelcast {
                 std::string uuid1String = uuid1.toString();
                 std::string uuid2String = uuid2.toString();
                 ASSERT_NE(uuid1String, uuid2String);
-                ASSERT_EQ(36, uuid1String.length());
-                ASSERT_EQ(36, uuid2String.length());
+                ASSERT_EQ(36U, uuid1String.length());
+                ASSERT_EQ(36U, uuid2String.length());
 
                 std::stringstream ss(uuid1String);
                 std::string token;
                 ASSERT_TRUE(std::getline(ss, token, '-'));
-                ASSERT_EQ(8, token.length());
+                ASSERT_EQ(8U, token.length());
                 ASSERT_TRUE(std::getline(ss, token, '-'));
-                ASSERT_EQ(4, token.length());
+                ASSERT_EQ(4U, token.length());
                 ASSERT_TRUE(std::getline(ss, token, '-'));
-                ASSERT_EQ(4, token.length());
+                ASSERT_EQ(4U, token.length());
                 ASSERT_TRUE(std::getline(ss, token, '-'));
-                ASSERT_EQ(4, token.length());
+                ASSERT_EQ(4U, token.length());
                 ASSERT_TRUE(std::getline(ss, token, '-'));
-                ASSERT_EQ(12, token.length());
+                ASSERT_EQ(12U, token.length());
                 ASSERT_FALSE(std::getline(ss, token, '-'));
+            }
+
+            TEST_F(UuidUtilTest, testUuidToString) {
+                int64_t msb = 0xfb34567812345678L;
+                int64_t lsb = 0xabcd123412345678L;
+                util::UUID uuid(msb, lsb);
+                std::string uuidString = uuid.toString();
+                ASSERT_EQ("fb345678-1234-5678-abcd-123412345678", uuidString);
             }
         }
     }

--- a/hazelcast/test/src/util/UuidUtilTest.cpp
+++ b/hazelcast/test/src/util/UuidUtilTest.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <hazelcast/util/UuidUtil.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class UuidUtilTest : public ::testing::Test {
+            };
+
+            TEST_F(UuidUtilTest, testUnsecureUuid) {
+                util::UUID uuid1 = util::UuidUtil::newUnsecureUUID();
+                util::UUID uuid2 = util::UuidUtil::newUnsecureUUID();
+                ASSERT_NE(uuid1, uuid2);
+
+                std::string uuid1String = uuid1.toString();
+                std::string uuid2String = uuid2.toString();
+                ASSERT_NE(uuid1String, uuid2String);
+                ASSERT_EQ(36, uuid1String.length());
+                ASSERT_EQ(36, uuid2String.length());
+
+                std::stringstream ss(uuid1String);
+                std::string token;
+                ASSERT_TRUE(std::getline(ss, token, '-'));
+                ASSERT_EQ(8, token.length());
+                ASSERT_TRUE(std::getline(ss, token, '-'));
+                ASSERT_EQ(4, token.length());
+                ASSERT_TRUE(std::getline(ss, token, '-'));
+                ASSERT_EQ(4, token.length());
+                ASSERT_TRUE(std::getline(ss, token, '-'));
+                ASSERT_EQ(4, token.length());
+                ASSERT_TRUE(std::getline(ss, token, '-'));
+                ASSERT_EQ(12, token.length());
+                ASSERT_FALSE(std::getline(ss, token, '-'));
+            }
+        }
+    }
+}

--- a/hazelcast/test/src/util/UuidUtilTest.cpp
+++ b/hazelcast/test/src/util/UuidUtilTest.cpp
@@ -50,8 +50,8 @@ namespace hazelcast {
             }
 
             TEST_F(UuidUtilTest, testUuidToString) {
-                int64_t msb = 0xfb34567812345678L;
-                int64_t lsb = 0xabcd123412345678L;
+                int64_t msb = static_cast<int64_t>(0xfb34567812345678LL);
+                int64_t lsb = static_cast<int64_t>(0xabcd123412345678LL);
                 util::UUID uuid(msb, lsb);
                 std::string uuidString = uuid.toString();
                 ASSERT_EQ("fb345678-1234-5678-abcd-123412345678", uuidString);


### PR DESCRIPTION
Added UuidUtil and AddressHelper classes. UuidUtil lets you to generate random uuid. AddressHelper gets possible address list for a provided hostname. These will be used by the client services.