### PR TITLE
Future::get is not throwing the expected exception as derived but the base exception - Missing stream like constructor for an exception

### DIFF
--- a/hazelcast/include/hazelcast/client/exception/IException.h
+++ b/hazelcast/include/hazelcast/client/exception/IException.h
@@ -85,7 +85,7 @@ namespace hazelcast {
 
                 const boost::shared_ptr<IException> &getCause() const;
 
-                friend std::ostream &operator<<(std::ostream &os, const IException &exception);
+                friend std::ostream HAZELCAST_API &operator<<(std::ostream &os, const IException &exception);
 
                 virtual bool operator==(const IException &rhs) const;
 
@@ -97,6 +97,8 @@ namespace hazelcast {
                 std::string report;
                 boost::shared_ptr<IException> cause;
             };
+
+            std::ostream HAZELCAST_API &operator<<(std::ostream &os, const IException &exception);
 
             template <typename EXCEPTIONCLASS>
             class ExceptionBuilder {

--- a/hazelcast/include/hazelcast/client/exception/IException.h
+++ b/hazelcast/include/hazelcast/client/exception/IException.h
@@ -87,10 +87,6 @@ namespace hazelcast {
 
                 friend std::ostream HAZELCAST_API &operator<<(std::ostream &os, const IException &exception);
 
-                virtual bool operator==(const IException &rhs) const;
-
-                virtual bool operator!=(const IException &rhs) const;
-
             protected:
                 std::string src;
                 std::string msg;

--- a/hazelcast/include/hazelcast/client/exception/IException.h
+++ b/hazelcast/include/hazelcast/client/exception/IException.h
@@ -19,9 +19,15 @@
 #ifndef HAZELCAST_EXCEPTION
 #define HAZELCAST_EXCEPTION
 
-#include "hazelcast/util/HazelcastDll.h"
 #include <string>
+#include <sstream>
 #include <stdexcept>
+#include <ostream>
+#include <memory>
+
+#include <boost/shared_ptr.hpp>
+
+#include "hazelcast/util/HazelcastDll.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -48,23 +54,18 @@ namespace hazelcast {
              */
             class HAZELCAST_API IException : public std::exception {
             public:
-                /**
-                 * Constructor
-                 */
                 IException();
 
-                /**
-                 * Constructor
-                 */
                 IException(const std::string &source, const std::string &message);
 
-                /**
-                 * Destructor
-                 */
+                IException(const std::string &source, const std::string &message,
+                           const boost::shared_ptr<IException> &cause);
+
                 virtual ~IException() throw();
 
                 /**
-                 * return exception explanation string.
+                 *
+                 * return  pointer to the explanation string.
                  */
                 virtual char const *what() const throw();
 
@@ -72,12 +73,55 @@ namespace hazelcast {
 
                 const std::string &getMessage() const;
 
-                virtual void raise();
-            private:
+                virtual void raise() const;
+
+                /**
+                 * We need this method to clone the specific derived exception when needed. The exception has to be the
+                 * derived type so that the exception rethrowing works as expected by throwing the derived exception.
+                 * Exception throwing internals works by making a temporary copy of the exception.
+                 * @return The copy of this exception
+                 */
+                virtual std::auto_ptr<IException> clone() const;
+
+                const boost::shared_ptr<IException> &getCause() const;
+
+                friend std::ostream &operator<<(std::ostream &os, const IException &exception);
+
+                virtual bool operator==(const IException &rhs) const;
+
+                virtual bool operator!=(const IException &rhs) const;
+
+            protected:
                 std::string src;
                 std::string msg;
                 std::string report;
+                boost::shared_ptr<IException> cause;
             };
+
+            template <typename EXCEPTIONCLASS>
+            class ExceptionBuilder {
+            public:
+                ExceptionBuilder(const std::string &source) : source(source) {}
+
+                template <typename T>
+                ExceptionBuilder &operator<<(const T &message) {
+                    msg << message;
+                    return *this;
+                }
+
+                /**
+                 *
+                 * @return The constructed exception.
+                 */
+                EXCEPTIONCLASS build() {
+                    return EXCEPTIONCLASS(source, msg.str());
+                }
+
+            private:
+                std::string source;
+                std::ostringstream msg;
+            };
+
         }
     }
 }

--- a/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
+++ b/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
@@ -201,8 +201,7 @@ namespace hazelcast {
 
             class HAZELCAST_API UnknownHostException : public IException {
             public:
-                UnknownHostException(const std::string &source, const std::string &message) : IException(
-                        source, message) {}
+                UnknownHostException(const std::string &source, const std::string &message);
             };
 
         }

--- a/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
+++ b/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
@@ -49,10 +49,6 @@ namespace hazelcast {
 
                 int32_t getCauseErrorCode() const;
 
-                bool operator==(const ProtocolException &rhs) const;
-
-                bool operator!=(const ProtocolException &rhs) const;
-
                 virtual std::auto_ptr<IException> clone() const;
 
                 void raise() const;

--- a/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
@@ -36,7 +36,7 @@ namespace hazelcast {
         namespace protocol {
             class ClientMessage;
 
-            class ExceptionFactory {
+            class HAZELCAST_API ExceptionFactory {
             public:
                 virtual ~ExceptionFactory();
 

--- a/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
@@ -40,10 +40,22 @@ namespace hazelcast {
             public:
                 virtual ~ExceptionFactory();
 
-                virtual std::auto_ptr<exception::IException> createException(const std::string &message,
+                virtual std::auto_ptr<exception::IException> createException(const std::string &source,
+                                                                             const std::string &message,
                                                                              const std::string &details,
                                                                              int32_t errorCode,
                                                                              int32_t causeErrorCode) = 0;
+            };
+
+            template <typename EXCEPTION>
+            class ExceptionFactoryImpl : public ExceptionFactory {
+            public:
+                std::auto_ptr<exception::IException>
+                createException(const std::string &source, const std::string &message, const std::string &details,
+                                int32_t errorCode, int32_t causeErrorCode) {
+                    return std::auto_ptr<exception::IException>(
+                            new EXCEPTION(source, message + ". Details:" + details, errorCode, causeErrorCode));
+                }
             };
 
             class HAZELCAST_API ClientExceptionFactory {
@@ -52,7 +64,8 @@ namespace hazelcast {
 
                 virtual ~ClientExceptionFactory();
 
-                std::auto_ptr<exception::IException> createException(protocol::ClientMessage &message) const;
+                std::auto_ptr<exception::IException> createException(const std::string &source,
+                                                                     protocol::ClientMessage &message) const;
             private:
                 void registerException(int32_t errorCode, ExceptionFactory *factory);
 

--- a/hazelcast/include/hazelcast/util/Future.h
+++ b/hazelcast/include/hazelcast/util/Future.h
@@ -56,11 +56,6 @@ namespace hazelcast {
                 conditionVariable.notify_all();
             }
 
-            void set_exception(const client::exception::IException &exception) {
-                set_exception(std::auto_ptr<client::exception::IException>(
-                        new client::exception::IException(exception)));
-            }
-
             void set_exception(std::auto_ptr<client::exception::IException> exception) {
                 LockGuard guard(mutex);
 

--- a/hazelcast/src/hazelcast/client/exception/IException.cpp
+++ b/hazelcast/src/hazelcast/client/exception/IException.cpp
@@ -63,30 +63,6 @@ namespace hazelcast {
                 return os;
             }
 
-            bool IException::operator==(const IException &rhs) const {
-                if (src != rhs.src || msg != rhs.msg) {
-                    return false;
-                }
-
-                if (cause.get() == rhs.cause.get()) {
-                    return true;
-                }
-
-                if (!cause.get() && rhs.cause.get()) {
-                    return false;
-                }
-                
-                if (cause.get() && !rhs.cause.get()) {
-                    return false;
-                }
-
-                return *cause == *rhs.cause;
-            }
-
-            bool IException::operator!=(const IException &rhs) const {
-                return !(rhs == *this);
-            }
-
             const boost::shared_ptr<IException> &IException::getCause() const {
                 return cause;
             }

--- a/hazelcast/src/hazelcast/client/exception/ProtocolException.cpp
+++ b/hazelcast/src/hazelcast/client/exception/ProtocolException.cpp
@@ -105,6 +105,9 @@ namespace hazelcast {
             HazelcastClientOfflineException::~HazelcastClientOfflineException() throw() {
             }
 
+            UnknownHostException::UnknownHostException(const std::string &source, const std::string &message)
+                    : IException(source, message) {
+            }
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/exception/ProtocolException.cpp
+++ b/hazelcast/src/hazelcast/client/exception/ProtocolException.cpp
@@ -51,16 +51,6 @@ namespace hazelcast {
                 return causeErrorCode;
             }
 
-            bool ProtocolException::operator==(const ProtocolException &rhs) const {
-                return static_cast<const IException &>(*this) == static_cast<const IException &>(rhs) &&
-                       errorCode == rhs.errorCode &&
-                       causeErrorCode == rhs.causeErrorCode;
-            }
-
-            bool ProtocolException::operator!=(const ProtocolException &rhs) const {
-                return !(rhs == *this);
-            }
-
             std::auto_ptr<IException> ProtocolException::clone() const {
                 return std::auto_ptr<IException>(new ProtocolException(*this));
             }

--- a/hazelcast/src/hazelcast/client/exception/ProtocolException.cpp
+++ b/hazelcast/src/hazelcast/client/exception/ProtocolException.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hazelcast/client/exception/ProtocolExceptions.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace exception {
+            ProtocolException::ProtocolException(const std::string &source, const std::string &message,
+                                                 const std::string &details,
+                                                 int32_t errorNo,
+                                                 int32_t causeCode)
+                    : IException(source, message + ". Details:" + details), errorCode(errorNo),
+                      causeErrorCode(causeCode) {
+            }
+
+            ProtocolException::ProtocolException(const std::string &source, const std::string &message,
+                                                 int32_t errorNo, int32_t causeCode)
+                    : IException(source, message), errorCode(errorNo), causeErrorCode(causeCode) {
+            }
+
+            ProtocolException::ProtocolException(const std::string &source, const std::string &message)
+                    : IException(source, message), errorCode(-1), causeErrorCode(-1) {
+            }
+
+            ProtocolException::ProtocolException(const std::string &source, const std::string &message,
+                                                 const boost::shared_ptr<IException> &cause) : IException(source,
+                                                                                                          message,
+                                                                                                          cause),
+                                                                                               errorCode(-1),
+                                                                                               causeErrorCode(-1) {}
+
+            int32_t ProtocolException::getErrorCode() const {
+                return errorCode;
+            }
+
+            int32_t ProtocolException::getCauseErrorCode() const {
+                return causeErrorCode;
+            }
+
+            bool ProtocolException::operator==(const ProtocolException &rhs) const {
+                return static_cast<const IException &>(*this) == static_cast<const IException &>(rhs) &&
+                       errorCode == rhs.errorCode &&
+                       causeErrorCode == rhs.causeErrorCode;
+            }
+
+            bool ProtocolException::operator!=(const ProtocolException &rhs) const {
+                return !(rhs == *this);
+            }
+
+            std::auto_ptr<IException> ProtocolException::clone() const {
+                return std::auto_ptr<IException>(new ProtocolException(*this));
+            }
+
+            void ProtocolException::raise() const {
+                throw *this;
+            }
+
+            UndefinedErrorCodeException::UndefinedErrorCodeException(int32_t errorCode, int64_t correlationId,
+                                                                     std::string details)
+                    : error(errorCode), messageCallId(correlationId), detailedErrorMessage(details) {
+            }
+
+            int32_t UndefinedErrorCodeException::getErrorCode() const {
+                return error;
+            }
+
+            int64_t UndefinedErrorCodeException::getMessageCallId() const {
+                return messageCallId;
+            }
+
+            const std::string &UndefinedErrorCodeException::getDetailedErrorMessage() const {
+                return detailedErrorMessage;
+            }
+
+            UndefinedErrorCodeException::~UndefinedErrorCodeException() throw() {
+            }
+
+            HazelcastClientNotActiveException::HazelcastClientNotActiveException(const std::string &source,
+                                                                                 const std::string &message)
+                    : IException(
+                    source, message) {}
+
+            HazelcastClientNotActiveException::~HazelcastClientNotActiveException() throw() {
+
+            }
+
+            HazelcastClientOfflineException::HazelcastClientOfflineException(const std::string &source,
+                                                                             const std::string &message)
+                    : IllegalStateException(source, message) {}
+
+            HazelcastClientOfflineException::~HazelcastClientOfflineException() throw() {
+            }
+
+        }
+    }
+}
+

--- a/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/InvocationService.cpp
@@ -336,7 +336,8 @@ namespace hazelcast {
                 }
 
                 if (protocol::codec::ErrorCodec::TYPE == message->getMessageType()) {
-                    std::auto_ptr<exception::IException> exception = exceptionFactory.createException(*message);
+                    std::auto_ptr<exception::IException> exception = exceptionFactory.createException(
+                            "InvocationService::handleMessage", *message);
 
                     std::string addrString = util::IOUtil::to_string(serverAddr);
                     tryResend(exception, promise, addrString);

--- a/hazelcast/src/hazelcast/client/spi/impl/ProxyManager.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/ProxyManager.cpp
@@ -48,7 +48,7 @@ namespace hazelcast {
                     return clientProxy;
                 } catch (exception::IException &e) {
                     proxies.remove(ns);
-                    proxyFuture->set_exception(e);
+                    proxyFuture->set_exception(e.clone());
                     throw;
                 }
             }

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <errno.h>
 #include <gtest/gtest.h>
+#include <hazelcast/client/exception/IOException.h>
 
 namespace hazelcast {
     namespace client {
@@ -123,12 +124,37 @@ namespace hazelcast {
             TEST_F (ClientUtilTest, testFutureSetException) {
                 util::Future<int> future;
 
-                std::auto_ptr<client::exception::IException> exception(new exception::IException("exceptionName", "details"));
+                std::auto_ptr<client::exception::IException> exception(
+                        new client::exception::IException("testFutureSetException", "details"));
                 future.set_exception(exception);
 
-                ASSERT_THROW(future.get(), exception::IException);
+                ASSERT_THROW(future.get(), client::exception::IException);
             }
 
+            TEST_F (ClientUtilTest, testFutureSetClonedIOException) {
+                util::Future<int> future;
+
+                client::exception::IOException ioe("testFutureSetIOException", "details");
+                std::auto_ptr<client::exception::IException> exception(new client::exception::IException(ioe));
+                future.set_exception(ioe.clone());
+
+                ASSERT_THROW(future.get(), client::exception::IOException);
+            }
+
+            TEST_F (ClientUtilTest, testFutureSetUnclonedIOException) {
+                util::Future<int> future;
+
+                client::exception::IOException ioe("testFutureSetUnclonedIOException", "details");
+                std::auto_ptr<client::exception::IException> exception(new client::exception::IException(ioe));
+                future.set_exception(exception);
+
+                try {
+                    future.get();
+                } catch (client::exception::IOException &) {
+                    FAIL();
+                } catch (client::exception::IException &) {
+                }
+            }
 
             TEST_F (ClientUtilTest, testFutureSetValue_afterSomeTime) {
                 util::Future<int> future;

--- a/hazelcast/test/src/util/ExceptionTest.cpp
+++ b/hazelcast/test/src/util/ExceptionTest.cpp
@@ -35,7 +35,10 @@ namespace hazelcast {
 
                     boost::shared_ptr<exception::IException> exceptionCause = targetDisconnectedException.getCause();
                     ASSERT_NE(static_cast<exception::IException *>(NULL), exceptionCause.get());
-                    ASSERT_EQ(*cause, *exceptionCause);
+                    ASSERT_THROW((exceptionCause->raise()), exception::IOException);
+                    ASSERT_EQ(exceptionCause->getMessage(), cause->getMessage());
+                    ASSERT_EQ(exceptionCause->getSource(), cause->getSource());
+                    ASSERT_EQ((exception::IException *)NULL, exceptionCause->getCause().get());
                 }
 
                 TEST_F(ExceptionTest, testExceptionStreaming) {

--- a/hazelcast/test/src/util/ExceptionTest.cpp
+++ b/hazelcast/test/src/util/ExceptionTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <hazelcast/client/exception/IOException.h>
+#include <hazelcast/client/protocol/ClientExceptionFactory.h>
+#include <hazelcast/client/protocol/ClientProtocolErrorCodes.h>
+#include <hazelcast/util/IOUtil.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            namespace util {
+                class ExceptionTest : public ::testing::Test {
+                protected:
+                };
+
+                TEST_F(ExceptionTest, testExceptionCause) {
+                    boost::shared_ptr<exception::IException> cause = boost::shared_ptr<exception::IException>(
+                            new exception::IOException("testExceptionCause test", "this is a test exception"));
+                    exception::TargetDisconnectedException targetDisconnectedException("testExceptionCause",
+                                                                                       "test message", cause);
+
+                    boost::shared_ptr<exception::IException> exceptionCause = targetDisconnectedException.getCause();
+                    ASSERT_NE(static_cast<exception::IException *>(NULL), exceptionCause.get());
+                    ASSERT_EQ(*cause, *exceptionCause);
+                }
+
+                TEST_F(ExceptionTest, testExceptionStreaming) {
+                    std::string source("testException");
+                    std::string originalMessage("original message");
+                    exception::IOException e(source, originalMessage);
+
+                    ASSERT_EQ(source, e.getSource());
+                    ASSERT_EQ(originalMessage, e.getMessage());
+                    ASSERT_EQ(static_cast<exception::IException *>(NULL), e.getCause().get());
+
+                    std::string extendedMessage(" this is an extension message");
+                    int messageNumber = 1;
+                    exception::IOException ioException = (exception::ExceptionBuilder<exception::IOException>(source)
+                            << originalMessage << extendedMessage << messageNumber).build();
+
+                    ASSERT_EQ(source, ioException.getSource());
+                    ASSERT_EQ(
+                            originalMessage + extendedMessage + hazelcast::util::IOUtil::to_string<int>(messageNumber),
+                            ioException.getMessage());
+                    ASSERT_EQ(static_cast<exception::IException *>(NULL), e.getCause().get());
+                }
+
+                TEST_F(ExceptionTest, testRaiseException) {
+                    std::string source("testException");
+                    std::string originalMessage("original message");
+                    std::string details("detail message");
+                    int32_t code = protocol::IO;
+                    int32_t causeCode = protocol::ILLEGAL_STATE;
+
+                    protocol::ExceptionFactoryImpl<exception::IOException> ioExceptionFactory;
+                    boost::shared_ptr<exception::IException> exception(ioExceptionFactory.createException(source,
+                                                                                                          originalMessage,
+                                                                                                          details,
+                                                                                                          code,
+                                                                                                          causeCode));
+
+                    try {
+                        exception->raise();
+                    } catch (exception::IOException &e) {
+                        ASSERT_EQ(source, e.getSource());
+                        ASSERT_EQ(originalMessage + ". Details:" + details, e.getMessage());
+                        ASSERT_EQ(code, e.getErrorCode());
+                        ASSERT_EQ(causeCode, e.getCauseErrorCode());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added tests so that the future.get throws the expected protocol exception correctly. I had to introduce the IException::clone method to create derived exception when setting the future.set_exception so that when it is thrown it throws the derived exception.

Implemented the ExceptionBuilder class for easier setting of the exception message.
