### PR TITLE
Remove Address dependency to external asio

### DIFF
--- a/hazelcast/include/hazelcast/client/Address.h
+++ b/hazelcast/include/hazelcast/client/Address.h
@@ -27,8 +27,6 @@
 #include <winsock2.h>
 #endif
 
-#include <asio/ip/address.hpp>
-
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
 #pragma warning(disable: 4251) //for dll export
@@ -42,7 +40,7 @@ namespace hazelcast {
          */
         class HAZELCAST_API Address : public serialization::IdentifiedDataSerializable {
         public:
-            Address(const std::string &hostname, const asio::ip::address &inetAddress, int port);
+            Address(const std::string &hostname, int port, unsigned long scopeId);
 
             static const int ID;
 
@@ -103,14 +101,10 @@ namespace hazelcast {
             std::string host;
             int port;
             byte type;
-            asio::ip::address inetAddress;
+            unsigned long scopeId;
 
             static const byte IPV4;
             static const byte IPV6;
-
-            void init();
-
-            void setType();
         };
 
         /**

--- a/hazelcast/include/hazelcast/util/AddressUtil.h
+++ b/hazelcast/include/hazelcast/util/AddressUtil.h
@@ -17,6 +17,8 @@
 #ifndef HAZELCAST_UTIL_ADDRESSUTIL_H_
 #define HAZELCAST_UTIL_ADDRESSUTIL_H_
 
+#include <asio/ip/address.hpp>
+
 #include "hazelcast/util/HazelcastDll.h"
 #include "hazelcast/util/AddressHelper.h"
 

--- a/hazelcast/src/hazelcast/client/Address.cpp
+++ b/hazelcast/src/hazelcast/client/Address.cpp
@@ -26,27 +26,15 @@ namespace hazelcast {
         const byte Address::IPV4 = 4;
         const byte Address::IPV6 = 6;
 
-        Address::Address():host("localhost") {
-            init();
+        Address::Address():host("localhost"), type(IPV4) {
         }
-
-        void Address::init() {
-            inetAddress = util::AddressUtil::getByName(host);
-            setType();
-        }
-
-        void Address::setType() { type = isIpV4() ? IPV4 : IPV6; }
 
         Address::Address(const std::string &url, int port)
-        : host(url), port(port) {
-            init();
+        : host(url), port(port), type(IPV4) {
         }
 
-        Address::Address(const std::string &hostname, const asio::ip::address &inetAddress, int port) : host(hostname),
-                                                                                                        port(port),
-                                                                                                        inetAddress(
-                                                                                                                inetAddress) {
-            setType();
+        Address::Address(const std::string &hostname, int port,  unsigned long scopeId) : host(hostname), port(port),
+                                                                                         type(IPV6), scopeId(scopeId) {
         }
 
         bool Address::operator ==(const Address &rhs) const {
@@ -110,11 +98,11 @@ namespace hazelcast {
         }
 
         bool Address::isIpV4() const {
-            return inetAddress.is_v4();
+            return type == IPV4;
         }
 
         unsigned long Address::getScopeId() const {
-            return inetAddress.is_v6() ? inetAddress.to_v6().scope_id() : 0;
+            return scopeId;
         }
 
         bool addressComparator::operator ()(const Address &lhs, const Address &rhs) const {
@@ -123,7 +111,6 @@ namespace hazelcast {
                 return lhs.getPort() > rhs.getPort();
             }
             return i > 0;
-
         }
 
         std::ostream &operator <<(std::ostream &stream, const Address &address) {

--- a/hazelcast/src/hazelcast/util/AddressHelper.cpp
+++ b/hazelcast/src/hazelcast/util/AddressHelper.cpp
@@ -68,7 +68,12 @@ namespace hazelcast {
                 }
             } else if (inetAddress->is_v4() || inetAddress->is_v6()) {
                 for (int i = 0; i < portTryCount; i++) {
-                    addresses.push_back(client::Address(scopedAddress, *inetAddress, possiblePort + i));
+                    if (inetAddress->is_v4()) {
+                        addresses.push_back(client::Address(scopedAddress, possiblePort + i));
+                    } else {
+                        addresses.push_back(
+                                client::Address(scopedAddress, possiblePort + i, inetAddress->to_v6().scope_id()));
+                    }
                 }
             }
             // TODO: Add ip v6 addresses using interfaces as done in Java client.


### PR DESCRIPTION
Nigthly release fails due to the unreleased external asio dependency and Address class implicitly depen on the asio::address::ip class. As a fix, I removed this dependency so that Address has no dependency on the asio and it just uses resolved ip address and scope id on construction provided as parameters.