### PR TITLE
SimpleMapTest is not working

### DIFF
--- a/hazelcast/test/src/SimpleMapTest.h
+++ b/hazelcast/test/src/SimpleMapTest.h
@@ -201,8 +201,10 @@ public:
         std::vector<boost::shared_ptr<hazelcast::util::Thread> > threads;
 
         for (int i = 0; i < THREAD_COUNT; i++) {
-            threads.push_back(boost::shared_ptr<hazelcast::util::Thread>(new hazelcast::util::Thread(
-                    boost::shared_ptr<hazelcast::util::Runnable>(new Task(stats, map)))));
+            boost::shared_ptr<hazelcast::util::Thread> thread = boost::shared_ptr<hazelcast::util::Thread>(new hazelcast::util::Thread(
+                                boost::shared_ptr<hazelcast::util::Runnable>(new Task(stats, map))));
+            thread->start();
+            threads.push_back(thread);
         }
 
         monitor.start();

--- a/hazelcast/test/src/main.cpp
+++ b/hazelcast/test/src/main.cpp
@@ -58,6 +58,6 @@ int main(int argc, char** argv) {
 
     return RUN_ALL_TESTS();
 
-    //SimpleMapTest(address, 5701).start();
+    //SimpleMapTest("127.0.0.1", 5701).start();
 }
 


### PR DESCRIPTION
When the the thread class changed it was forgotten to start the threads in the SimpleMapTest. This fixes it.