### PR TITLE
Increase test coverage for the new classes and fix ConditionVariable::calculateTimeFromNanos method

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/AbstractCallIdSequence.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/AbstractCallIdSequence.h
@@ -60,6 +60,8 @@ namespace hazelcast {
 
                         virtual int64_t getLastCallId();
 
+                        int64_t getTail();
+
                     protected:
                         virtual void handleNoSpaceLeft() = 0;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequence.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequence.h
@@ -21,11 +21,6 @@
 
 #include "hazelcast/util/HazelcastDll.h"
 
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(push)
-#pragma warning(disable: 4251) //for dll export
-#endif
-
 namespace hazelcast {
     namespace client {
         namespace spi {
@@ -53,7 +48,7 @@ namespace hazelcast {
                      * <li>not always being able to fully utilize the number of invocations.</li>
                      * </ol>
                      */
-                    class HAZELCAST_API CallIdSequence {
+                    class CallIdSequence {
                     public:
                         /**
                          * Returns the maximum concurrent invocations supported. INT32_MAX means there is no max.
@@ -93,9 +88,5 @@ namespace hazelcast {
         }
     }
 }
-
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(pop)
-#endif
 
 #endif //HAZELCAST_CLIENT_SPI_IMPL_SEQUENCE_CALLIDSEQUENCE_H_

--- a/hazelcast/include/hazelcast/util/concurrent/locks/LockSupport.h
+++ b/hazelcast/include/hazelcast/util/concurrent/locks/LockSupport.h
@@ -20,16 +20,11 @@
 
 #include "hazelcast/util/HazelcastDll.h"
 
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(push)
-#pragma warning(disable: 4251) //for dll export
-#endif
-
 namespace hazelcast {
     namespace util {
         namespace concurrent {
             namespace locks {
-                 class HAZELCAST_API LockSupport {
+                 class LockSupport {
                 public:
                      /**
                       * Disables the current thread for thread scheduling purposes, for up to
@@ -66,9 +61,5 @@ namespace hazelcast {
         }
     }
 }
-
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(pop)
-#endif
 
 #endif //HAZELCAST_UTIL_CONCURRENT_LOCKS_LOCKSUPPORT_H_

--- a/hazelcast/include/hazelcast/util/concurrent/locks/LockSupport.h
+++ b/hazelcast/include/hazelcast/util/concurrent/locks/LockSupport.h
@@ -24,7 +24,7 @@ namespace hazelcast {
     namespace util {
         namespace concurrent {
             namespace locks {
-                 class LockSupport {
+                 class HAZELCAST_API LockSupport {
                 public:
                      /**
                       * Disables the current thread for thread scheduling purposes, for up to

--- a/hazelcast/src/hazelcast/client/spi/impl/sequence/AbstractCallIdSequence.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/sequence/AbstractCallIdSequence.cpp
@@ -23,7 +23,6 @@ namespace hazelcast {
         namespace spi {
             namespace impl {
                 namespace sequence {
-
                     AbstractCallIdSequence::AbstractCallIdSequence(int32_t maxConcurrentInvocations) : longs(
                             3 * util::Bits::CACHE_LINE_LENGTH / util::Bits::LONG_SIZE_IN_BYTES) {
                         std::ostringstream out;
@@ -32,6 +31,9 @@ namespace hazelcast {
                         util::Preconditions::checkPositive(maxConcurrentInvocations, out.str());
 
                         this->maxConcurrentInvocations = maxConcurrentInvocations;
+                    }
+
+                    AbstractCallIdSequence::~AbstractCallIdSequence() {
                     }
 
                     int32_t AbstractCallIdSequence::getMaxConcurrentInvocations() const {
@@ -62,7 +64,8 @@ namespace hazelcast {
                         return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
                     }
 
-                    AbstractCallIdSequence::~AbstractCallIdSequence() {
+                    int64_t AbstractCallIdSequence::getTail() {
+                        return longs.get(INDEX_TAIL);
                     }
                 }
             }

--- a/hazelcast/src/hazelcast/util/ConditionVariable.cpp
+++ b/hazelcast/src/hazelcast/util/ConditionVariable.cpp
@@ -79,9 +79,9 @@ namespace hazelcast {
 
 namespace hazelcast {
     namespace util {
-        #define NANOS_IN_A_SECOND 1000 * 1000 * 1000
         #define MILLIS_IN_A_SECOND 1000
-        #define NANOS_IN_A_MILLISECOND 1000 * 1000
+        #define NANOS_IN_A_SECOND (NANOS_IN_A_MILLISECOND * MILLIS_IN_A_SECOND)
+        #define NANOS_IN_A_MILLISECOND (NANOS_IN_A_USECOND * 1000)
         #define NANOS_IN_A_USECOND 1000
 
         ConditionVariable::ConditionVariable() {
@@ -141,8 +141,8 @@ namespace hazelcast {
             if (seconds > std::numeric_limits<time_t>::max()) {
                 ts.tv_sec = std::numeric_limits<time_t>::max();
             } else {
-                ts.tv_sec += (time_t) (timeInMilliseconds / MILLIS_IN_A_SECOND);
-                long nsec = tv.tv_usec * NANOS_IN_A_USECOND + (timeInMilliseconds % MILLIS_IN_A_SECOND) * NANOS_IN_A_MILLISECOND;
+                ts.tv_sec += (time_t) seconds;
+                int64_t nsec = ts.tv_nsec + (timeInMilliseconds % MILLIS_IN_A_SECOND) * NANOS_IN_A_MILLISECOND;
                 if (nsec >= NANOS_IN_A_SECOND) {
                     nsec -= NANOS_IN_A_SECOND;
                     ++ts.tv_sec;
@@ -158,13 +158,13 @@ namespace hazelcast {
 
             struct timespec ts;
             ts.tv_sec = tv.tv_sec;
-            ts.tv_nsec = tv.tv_usec * 1000;
+            ts.tv_nsec = tv.tv_usec * NANOS_IN_A_USECOND;
             int64_t seconds = nanos / NANOS_IN_A_SECOND;
             if (seconds > std::numeric_limits<time_t>::max()) {
                 ts.tv_sec = std::numeric_limits<time_t>::max();
             } else {
-                ts.tv_sec += (time_t) (nanos / NANOS_IN_A_SECOND);
-                long nsec = tv.tv_usec * NANOS_IN_A_USECOND + (nanos % NANOS_IN_A_USECOND);
+                ts.tv_sec += (time_t) seconds;
+                int64_t nsec = ts.tv_nsec + (nanos % NANOS_IN_A_SECOND);
                 if (nsec >= NANOS_IN_A_SECOND) {
                     nsec -= NANOS_IN_A_SECOND;
                     ++ts.tv_sec;

--- a/hazelcast/test/src/spi/impl/sequence/FailFastCallIdSequenceTest.cpp
+++ b/hazelcast/test/src/spi/impl/sequence/FailFastCallIdSequenceTest.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <hazelcast/client/spi/impl/sequence/FailFastCallIdSequence.h>
+#include "ClientTestSupport.h"
+
+namespace hazelcast {
+    namespace client {
+        
+        namespace test {
+            class FailFastCallIdSequenceTest : public ClientTestSupport {
+            public:
+            };
+
+            TEST_F(FailFastCallIdSequenceTest, testGettersAndDefaults) {
+                spi::impl::sequence::FailFastCallIdSequence sequence(100);
+                ASSERT_EQ(0, sequence.getLastCallId());
+                ASSERT_EQ(100, sequence.getMaxConcurrentInvocations());
+            }
+
+            TEST_F(FailFastCallIdSequenceTest, whenNext_thenSequenceIncrements) {
+                spi::impl::sequence::FailFastCallIdSequence sequence(100);
+                int64_t oldSequence = sequence.getLastCallId();
+                int64_t result = sequence.next();
+                ASSERT_EQ(oldSequence + 1, result);
+                ASSERT_EQ(oldSequence + 1, sequence.getLastCallId());
+            }
+
+            TEST_F(FailFastCallIdSequenceTest, next_whenNoCapacity_thenThrowException) {
+                spi::impl::sequence::FailFastCallIdSequence sequence(1);
+
+                    // take the only slot available
+                    sequence.next();
+
+                    // this next is going to fail with an exception
+                    ASSERT_THROW(sequence.next(), exception::HazelcastOverloadException);
+            }
+
+            TEST_F(FailFastCallIdSequenceTest, when_overCapacityButPriorityItem_then_noException) {
+                spi::impl::sequence::FailFastCallIdSequence sequence(1);
+
+                // take the only slot available
+                ASSERT_EQ(1, sequence.next());
+
+                ASSERT_EQ(2, sequence.forceNext());
+            }
+
+            TEST_F(FailFastCallIdSequenceTest, whenComplete_thenTailIncrements) {
+                spi::impl::sequence::FailFastCallIdSequence sequence(100);
+                sequence.next();
+
+                int64_t oldSequence = sequence.getLastCallId();
+                int64_t oldTail = sequence.getTail();
+                sequence.complete();
+
+                ASSERT_EQ(oldSequence, sequence.getLastCallId());
+                ASSERT_EQ(oldTail + 1, sequence.getTail());
+            }
+
+        }
+    }
+}

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -22,6 +22,7 @@
 #include "hazelcast/util/Util.h"
 #include "hazelcast/util/Future.h"
 #include "hazelcast/util/Thread.h"
+#include "hazelcast/util/concurrent/locks/LockSupport.h"
 #include "hazelcast/util/CountDownLatch.h"
 #include "hazelcast/util/impl/SimpleExecutorService.h"
 #include "hazelcast/client/exception/IOException.h"
@@ -348,6 +349,15 @@ namespace hazelcast {
 
             TEST_F (ClientUtilTest, testStringUtilTimeToStringFriendly) {
                 ASSERT_EQ("never", util::StringUtil::timeToStringFriendly(0));
+            }
+
+            TEST_F (ClientUtilTest, testLockSupport) {
+                int64_t parkDuration = 1000 * 100;
+                int64_t start = util::currentTimeNanos();
+                util::concurrent::locks::LockSupport::parkNanos(parkDuration);
+                int64_t end = util::currentTimeNanos();
+                int64_t actualDuration = end - start;
+                ASSERT_GE(actualDuration, parkDuration);
             }
         }
     }


### PR DESCRIPTION
Fixed the ConditionVariable::calculateTimeFromNanos method. Added tests for test coverage.