### PR TITLE
ClusterTest fails to compile when SSL is disabled

### DIFF
--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -205,7 +205,7 @@ namespace hazelcast {
             #else
             INSTANTIATE_TEST_CASE_P(All,
                                     ClusterTest,
-                                    ::testing::Values(new SmartTcpClientConfig(), new NonSmartTcpClientConfig()));
+                                    ::testing::Values(new SmartTcpClientConfig()));
             #endif
         }
     }


### PR DESCRIPTION
Fix for ClusterTest to compile correctly when SSL is disabled.