### PR TITLE
Release builds fails due to dependency to boost/foreach and boost/posix_time dependencies

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
@@ -75,7 +75,7 @@ namespace hazelcast {
                     ClientContext &client;
                     boost::shared_ptr<ClientMembershipListener> clientMembershipListener;
                     util::Atomic<std::map<Address, boost::shared_ptr<Member> > > members;
-                    util::SynchronizedValueMap<std::string, boost::shared_ptr<MembershipListener> > listeners;
+                    util::SynchronizedMap<std::string, MembershipListener> listeners;
 
                     util::Mutex initialMembershipListenerMutex;
 

--- a/hazelcast/include/hazelcast/util/PosixThread.inl
+++ b/hazelcast/include/hazelcast/util/PosixThread.inl
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "hazelcast/util/impl/AbstractThread.h"
 #include "hazelcast/util/LockGuard.h"

--- a/hazelcast/include/hazelcast/util/TimeUtil.h
+++ b/hazelcast/include/hazelcast/util/TimeUtil.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAZELCAST_UTIL_TIMEUTIL_H_
+#define HAZELCAST_UTIL_TIMEUTIL_H_
+
+#include <boost/date_time/posix_time/ptime.hpp>
+
+namespace hazelcast {
+    namespace util {
+        class TimeUtil {
+        public:
+            /**
+             * @return the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+             */
+            static boost::posix_time::time_duration getDurationSinceEpoch();
+        };
+    }
+}
+
+#endif //HAZELCAST_UTIL_TIMEUTIL_H_

--- a/hazelcast/include/hazelcast/util/Util.h
+++ b/hazelcast/include/hazelcast/util/Util.h
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//
-// Created by sancar koyunlu on 5/3/13.
 
-#ifndef HAZELCAST_UTIL_FUNCTIONS
-#define HAZELCAST_UTIL_FUNCTIONS
+#ifndef HAZELCAST_UTIL_UTIL_H_
+#define HAZELCAST_UTIL_UTIL_H_
 
-#include "hazelcast/util/HazelcastDll.h"
 #include <time.h>
 #include <algorithm>
 #include <string>
 #include <vector>
 #include <assert.h>
 #include <stdint.h>
-#include <boost/date_time/posix_time/ptime.hpp>
+
+#include "hazelcast/util/HazelcastDll.h"
 
 #define HAZELCAST_STRINGIZE(STR) STRINGIZE(STR)
 #define STRINGIZE(STR) #STR
@@ -58,11 +56,6 @@ namespace hazelcast {
          * @param date The date to be modified
          */
         HAZELCAST_API void gitDateToHazelcastLogDate(std::string &date);
-
-        /**
-         * @return the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
-         */
-        boost::posix_time::time_duration getDurationSinceEpoch();
 
         /**
          * @return the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
@@ -150,5 +143,5 @@ namespace hazelcast {
 }
 
 
-#endif //HAZELCAST_UTIL_FUNCTIONS
+#endif //HAZELCAST_UTIL_UTIL_H_
 

--- a/hazelcast/src/hazelcast/client/proxy/IMapImpl.cpp
+++ b/hazelcast/src/hazelcast/client/proxy/IMapImpl.cpp
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//
-// Created by sancar koyunlu on 29/09/14.
-//
+#include <climits>
+#include <boost/foreach.hpp>
 
 #include "hazelcast/client/proxy/IMapImpl.h"
 #include "hazelcast/client/spi/ClientListenerService.h"
@@ -76,8 +75,6 @@
 #include "hazelcast/client/protocol/codec/MapEntriesWithPagingPredicateCodec.h"
 #include "hazelcast/client/protocol/codec/MapExecuteOnKeysCodec.h"
 #include "hazelcast/client/protocol/codec/MapRemoveAllCodec.h"
-
-#include <climits>
 
 namespace hazelcast {
     namespace client {

--- a/hazelcast/src/hazelcast/client/spi/impl/sequence/CallIdSequenceWithBackpressure.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/sequence/CallIdSequenceWithBackpressure.cpp
@@ -17,7 +17,7 @@
 
 #include "hazelcast/client/spi/impl/sequence/CallIdSequenceWithBackpressure.h"
 #include "hazelcast/util/Preconditions.h"
-#include "hazelcast/util/Util.h"
+#include "hazelcast/util/TimeUtil.h"
 #include "hazelcast/util/concurrent/BackoffIdleStrategy.h"
 
 namespace hazelcast {
@@ -41,9 +41,9 @@ namespace hazelcast {
                     }
 
                     void CallIdSequenceWithBackpressure::handleNoSpaceLeft() {
-                        boost::posix_time::time_duration start = util::getDurationSinceEpoch();
+                        boost::posix_time::time_duration start = util::TimeUtil::getDurationSinceEpoch();
                         for (int64_t idleCount = 0;; idleCount++) {
-                            int64_t elapsedNanos = (util::getDurationSinceEpoch() - start).total_nanoseconds();
+                            int64_t elapsedNanos = (util::TimeUtil::getDurationSinceEpoch() - start).total_nanoseconds();
                             if (elapsedNanos > backoffTimeoutNanos) {
                                 exception::ExceptionBuilder<exception::HazelcastOverloadException>(
                                         "CallIdSequenceWithBackpressure::handleNoSpaceLeft")

--- a/hazelcast/src/hazelcast/util/TimeUtil.cpp
+++ b/hazelcast/src/hazelcast/util/TimeUtil.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include "hazelcast/util/TimeUtil.h"
+
+namespace hazelcast {
+    namespace util {
+        boost::posix_time::time_duration TimeUtil::getDurationSinceEpoch() {
+            boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
+            boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
+            boost::posix_time::time_duration diff = now - epoch;
+            return diff;
+        }
+    }
+}

--- a/hazelcast/src/hazelcast/util/Util.cpp
+++ b/hazelcast/src/hazelcast/util/Util.cpp
@@ -17,12 +17,11 @@
 // Created by sancar koyunlu on 5/3/13.
 
 #include "hazelcast/util/Util.h"
+#include "hazelcast/util/TimeUtil.h"
 
-#include <boost/date_time/posix_time/ptime.hpp>
-#include <boost/date_time/microsec_time_clock.hpp>
-#include <boost/date_time.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <string.h>
 #include <algorithm>
@@ -110,20 +109,13 @@ namespace hazelcast {
             }
         }
 
-        boost::posix_time::time_duration getDurationSinceEpoch() {
-            boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
-            boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
-            boost::posix_time::time_duration diff = now - epoch;
-            return diff;
-        }
-
         int64_t currentTimeMillis() {
-            boost::posix_time::time_duration diff = getDurationSinceEpoch();
+            boost::posix_time::time_duration diff = TimeUtil::getDurationSinceEpoch();
             return diff.total_milliseconds();
         }
 
         int64_t currentTimeNanos() {
-            boost::posix_time::time_duration diff = getDurationSinceEpoch();
+            boost::posix_time::time_duration diff = TimeUtil::getDurationSinceEpoch();
             return diff.total_nanoseconds();
         }
 


### PR DESCRIPTION
Reverted the changes in SynchronizedMap to the previous released version just adding a method, because the I wanted to remove boost/foreach.hpp dependency and there is no need for the intermediate SynchronizedValueMap anymore.

Separated the util::getDurationSinceEpoch into a separate class TimeUtil since it causes dependency to boost::posix_time::time_duration for the users if exists at the Util.h header which is included from library user headers.