### PR TITLE
Fix for data race detected by sanitizer run. The race is between acce…

### DIFF
--- a/hazelcast/src/hazelcast/client/spi/impl/ClientInvocation.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/ClientInvocation.cpp
@@ -319,9 +319,7 @@ namespace hazelcast {
                 }
 
                 const std::string ClientInvocation::getName() const {
-                    std::ostringstream out;
-                    out << *this;
-                    return out.str();
+                    return "ClientInvocation";
                 }
 
                 void ClientInvocation::onComplete() {


### PR DESCRIPTION
Fix for data race detected by sanitizer run. The race is between accessing client message on thread finalization when printing the name of the runnable in finest log level and changing the client message during retry.