### PR TITLE
Nightly cpp-linux-nightly-release build failed due to missing header: boost/scoped_array.hpp

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.h
@@ -17,7 +17,6 @@
 #define HAZELCAST_CLIENT_INTERNAL_NEARCACHE_IMPL_NEARCACHE_KEYSTATEMARKERIMPL_H_
 
 #include <stdint.h>
-#include <boost/scoped_array.hpp>
 
 #include "hazelcast/client/map/impl/nearcache/KeyStateMarker.h"
 #include "hazelcast/util/Atomic.h"
@@ -53,7 +52,7 @@ namespace hazelcast {
                         int getSlot(const serialization::pimpl::Data &key);
 
                         const int markCount;
-                        boost::scoped_array<util::Atomic<int32_t> > marks;
+                        util::Atomic<int32_t> *marks;
                     };
                 }
             }

--- a/hazelcast/src/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.cpp
+++ b/hazelcast/src/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.cpp
@@ -30,6 +30,7 @@ namespace hazelcast {
                     }
 
                     KeyStateMarkerImpl::~KeyStateMarkerImpl() {
+                        delete[] marks;
                     }
 
                     bool KeyStateMarkerImpl::tryMark(const serialization::pimpl::Data &key) {


### PR DESCRIPTION
Nightly cpp-linux-nightly-release build failed due to missing header at the release. The error is:

cpp-linux-nightly-release/ws/cpp/Linux_32/hazelcast/include/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.h>:20:34: boost/scoped_array.hpp: No such file or directory

I am reverting the last change to not use boost::scoped_array.