### PR TITLE
Remove pending packet count from client connection since it has no use

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -114,12 +114,6 @@ namespace hazelcast {
 
                 const std::string &getCloseReason() const;
 
-                void incrementPendingPacketCount();
-
-                void decrementPendingPacketCount();
-
-                int32_t getPendingPacketCount();
-
                 bool operator==(const Connection &rhs) const;
 
                 bool operator!=(const Connection &rhs) const;
@@ -153,7 +147,6 @@ namespace hazelcast {
                 std::string closeReason;
                 boost::shared_ptr<exception::IException> closeCause;
 
-                util::Atomic<int32_t> pendingPacketCount;
                 std::string connectedServerVersionString;
                 int connectedServerVersion;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/AbstractClientInvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/AbstractClientInvocationService.h
@@ -41,26 +41,6 @@ namespace hazelcast {
             namespace impl {
                 class HAZELCAST_API AbstractClientInvocationService : public ClientInvocationService {
                 public:
-                    class ClientPacket {
-                        friend class ResponseThread;
-
-                    public:
-                        ClientPacket();
-
-                        ClientPacket(const boost::shared_ptr<connection::Connection> &clientConnection,
-                                     const boost::shared_ptr<protocol::ClientMessage> &clientMessage);
-
-                        const boost::shared_ptr<connection::Connection> &getClientConnection() const;
-
-                        const boost::shared_ptr<protocol::ClientMessage> &getClientMessage() const;
-
-                        friend std::ostream &operator<<(std::ostream &os, const ClientPacket &packet);
-
-                    private:
-                        boost::shared_ptr<connection::Connection> clientConnection;
-                        boost::shared_ptr<protocol::ClientMessage> clientMessage;
-                    };
-
                     AbstractClientInvocationService(ClientContext &client);
 
                     virtual ~AbstractClientInvocationService();
@@ -97,7 +77,7 @@ namespace hazelcast {
                         void start();
 
                         // TODO: implement java MPSCQueue and replace this
-                        util::BlockingConcurrentQueue<ClientPacket> responseQueue;
+                        util::BlockingConcurrentQueue<boost::shared_ptr<protocol::ClientMessage> > responseQueue;
                     private:
                         util::ILogger &invocationLogger;
                         AbstractClientInvocationService &invocationService;
@@ -106,7 +86,7 @@ namespace hazelcast {
 
                         void doRun();
 
-                        void process(const ClientPacket &packet);
+                        void process(const boost::shared_ptr<protocol::ClientMessage> &clientMessage);
 
                         void handleClientMessage(const boost::shared_ptr<protocol::ClientMessage> &clientMessage);
                     };

--- a/hazelcast/include/hazelcast/client/spi/impl/listener/AbstractClientListenerService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/listener/AbstractClientListenerService.h
@@ -78,7 +78,6 @@ namespace hazelcast {
                                                  util::ILogger &logger);
 
                             const boost::shared_ptr<protocol::ClientMessage> clientMessage;
-                            const boost::shared_ptr<connection::Connection> connection;
                             util::SynchronizedMap<int64_t, EventHandler<protocol::ClientMessage> > &eventHandlerMap;
                             util::ILogger &logger;
                         };

--- a/hazelcast/src/hazelcast/client/connection/Connection.cpp
+++ b/hazelcast/src/hazelcast/client/connection/Connection.cpp
@@ -53,24 +53,12 @@ namespace hazelcast {
                       invocationService(clientContext.getInvocationService()),
                       readHandler(*this, iListener, 16 << 10, clientContext),
                       writeHandler(*this, oListener, 16 << 10),
-                      heartBeating(true), connectionId(connectionId), pendingPacketCount(0),
+                      heartBeating(true), connectionId(connectionId),
                       connectedServerVersion(impl::BuildInfo::UNKNOWN_HAZELCAST_VERSION) {
                 socket = socketFactory.create(address);
             }
 
             Connection::~Connection() {
-            }
-
-            void Connection::incrementPendingPacketCount() {
-                ++pendingPacketCount;
-            }
-
-            void Connection::decrementPendingPacketCount() {
-                --pendingPacketCount;
-            }
-
-            int32_t Connection::getPendingPacketCount() {
-                return pendingPacketCount;
             }
 
             void Connection::connect(int timeoutInMillis) {
@@ -149,7 +137,6 @@ namespace hazelcast {
 
             void Connection::handleClientMessage(const boost::shared_ptr<Connection> &connection,
                                                  const boost::shared_ptr<protocol::ClientMessage> &message) {
-                incrementPendingPacketCount();
                 if (message->isFlagSet(protocol::ClientMessage::LISTENER_EVENT_FLAG)) {
                     spi::impl::listener::AbstractClientListenerService &listenerService =
                             (spi::impl::listener::AbstractClientListenerService &) clientContext.getClientListenerService();

--- a/hazelcast/src/hazelcast/client/spi/impl/AbstractClientInvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/AbstractClientInvocationService.cpp
@@ -279,15 +279,11 @@ namespace hazelcast {
 
                 void AbstractClientInvocationService::ResponseThread::process(
                         const AbstractClientInvocationService::ClientPacket &packet) {
-                    boost::shared_ptr<connection::Connection> conn = packet.getClientConnection();
                     try {
                         handleClientMessage(packet.getClientMessage());
-                        conn->decrementPendingPacketCount();
                     } catch (exception::IException &e) {
                         invocationLogger.severe() << "Failed to process task: " << packet << " on responseThread: "
                                                   << getName() << e;
-                    } catch (...) {
-                        conn->decrementPendingPacketCount();
                     }
                 }
 

--- a/hazelcast/src/hazelcast/client/spi/impl/AbstractClientInvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/AbstractClientInvocationService.cpp
@@ -91,7 +91,7 @@ namespace hazelcast {
                 void AbstractClientInvocationService::handleClientMessage(
                         const boost::shared_ptr<connection::Connection> &connection,
                         const boost::shared_ptr<protocol::ClientMessage> &clientMessage) {
-                    responseThread.responseQueue.push(ClientPacket(connection, clientMessage));
+                    responseThread.responseQueue.push(clientMessage);
                 }
 
                 boost::shared_ptr<ClientInvocation> AbstractClientInvocationService::deRegisterCallId(int64_t callId) {
@@ -220,31 +220,6 @@ namespace hazelcast {
                     return "AbstractClientInvocationService::CleanResourcesTask";
                 }
 
-                AbstractClientInvocationService::ClientPacket::ClientPacket(
-                        const boost::shared_ptr<connection::Connection> &clientConnection,
-                        const boost::shared_ptr<protocol::ClientMessage> &clientMessage) : clientConnection(
-                        clientConnection), clientMessage(clientMessage) {
-                }
-
-                const boost::shared_ptr<connection::Connection> &
-                AbstractClientInvocationService::ClientPacket::getClientConnection() const {
-                    return clientConnection;
-                }
-
-                const boost::shared_ptr<protocol::ClientMessage> &
-                AbstractClientInvocationService::ClientPacket::getClientMessage() const {
-                    return clientMessage;
-                }
-
-                AbstractClientInvocationService::ClientPacket::ClientPacket() {}
-
-                std::ostream &
-                operator<<(std::ostream &os, const AbstractClientInvocationService::ClientPacket &packet) {
-                    os << "clientConnection: " << *packet.clientConnection << " clientMessage: "
-                       << *packet.clientMessage;
-                    return os;
-                }
-
                 AbstractClientInvocationService::~AbstractClientInvocationService() {
                 }
 
@@ -267,7 +242,7 @@ namespace hazelcast {
 
                 void AbstractClientInvocationService::ResponseThread::doRun() {
                     while (!invocationService.isShutdown) {
-                        ClientPacket task;
+                        boost::shared_ptr<protocol::ClientMessage> task;
                         try {
                             task = responseQueue.pop();
                         } catch (exception::InterruptedException &) {
@@ -278,11 +253,11 @@ namespace hazelcast {
                 }
 
                 void AbstractClientInvocationService::ResponseThread::process(
-                        const AbstractClientInvocationService::ClientPacket &packet) {
+                        const boost::shared_ptr<protocol::ClientMessage> &clientMessage) {
                     try {
-                        handleClientMessage(packet.getClientMessage());
+                        handleClientMessage(clientMessage);
                     } catch (exception::IException &e) {
-                        invocationLogger.severe() << "Failed to process task: " << packet << " on responseThread: "
+                        invocationLogger.severe() << "Failed to process task: " << clientMessage << " on responseThread: "
                                                   << getName() << e;
                     }
                 }

--- a/hazelcast/src/hazelcast/client/spi/impl/listener/AbstractClientListenerService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/listener/AbstractClientListenerService.cpp
@@ -69,20 +69,16 @@ namespace hazelcast {
                     }
 
                     void AbstractClientListenerService::ClientEventProcessor::run() {
-                        try {
-                            int64_t correlationId = clientMessage->getCorrelationId();
-                            boost::shared_ptr<EventHandler<protocol::ClientMessage> > eventHandler = eventHandlerMap.get(
-                                    correlationId);
-                            if (eventHandler.get() == NULL) {
-                                logger.warning() << "No eventHandler for callId: " << correlationId << ", event: "
-                                                 << *clientMessage << ", connection: " << *connection;
-                                return;
-                            }
-
-                            eventHandler->handle(clientMessage);
-                        } catch (...) {
-                            connection->decrementPendingPacketCount();
+                        int64_t correlationId = clientMessage->getCorrelationId();
+                        boost::shared_ptr<EventHandler<protocol::ClientMessage> > eventHandler = eventHandlerMap.get(
+                                correlationId);
+                        if (eventHandler.get() == NULL) {
+                            logger.warning() << "No eventHandler for callId: " << correlationId << ", event: "
+                                             << *clientMessage;
+                            return;
                         }
+
+                        eventHandler->handle(clientMessage);
                     }
 
                     const std::string AbstractClientListenerService::ClientEventProcessor::getName() const {
@@ -98,8 +94,7 @@ namespace hazelcast {
                             const boost::shared_ptr<connection::Connection> &connection,
                             util::SynchronizedMap<int64_t, EventHandler<protocol::ClientMessage> > &eventHandlerMap,
                             util::ILogger &logger)
-                            : clientMessage(clientMessage), connection(connection), eventHandlerMap(eventHandlerMap),
-                              logger(logger) {
+                            : clientMessage(clientMessage), eventHandlerMap(eventHandlerMap), logger(logger) {
                     }
 
                     AbstractClientListenerService::ClientEventProcessor::~ClientEventProcessor() {


### PR DESCRIPTION
Removing pending packet count from client connection since it has no use anymore.

fixes #4 