### PR TITLE
Mixed API IMap.getAll with near-cache does not work return near-cached entries as expected

### DIFF
--- a/hazelcast/include/hazelcast/client/mixedtype/ClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/mixedtype/ClientMapProxy.h
@@ -1069,18 +1069,7 @@ namespace hazelcast {
 
                 virtual bool evictInternal(const serialization::pimpl::Data &keyData);
 
-                EntryVector getAllInternal(const PID_TO_KEY_MAP &partitionToKeyData) {
-                    std::map<int, std::vector<serialization::pimpl::Data> > datas;
-                    for (PID_TO_KEY_MAP::const_iterator it = partitionToKeyData.begin();
-                         it != partitionToKeyData.end(); ++it) {
-                        const std::vector<boost::shared_ptr<serialization::pimpl::Data> > &valueDatas = it->second;
-                        for (std::vector<boost::shared_ptr<serialization::pimpl::Data> >::const_iterator valueIt = valueDatas.begin();
-                             valueIt != valueDatas.end(); ++valueIt) {
-                            datas[it->first].push_back(*(*valueIt));
-                        }
-                    }
-                    return proxy::IMapImpl::getAllData(datas);
-                }
+                virtual EntryVector getAllInternal(const PID_TO_KEY_MAP &partitionToKeyData);
 
                 virtual std::auto_ptr<serialization::pimpl::Data>
                 executeOnKeyInternal(const serialization::pimpl::Data &keyData,

--- a/hazelcast/include/hazelcast/client/mixedtype/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/mixedtype/NearCachedClientMapProxy.h
@@ -109,7 +109,7 @@ namespace hazelcast {
 
                 virtual bool evictInternal(const serialization::pimpl::Data &keyData);
 
-                EntryVector getAllInternal(ClientMapProxy::PID_TO_KEY_MAP &pIdToKeyData);
+                virtual EntryVector getAllInternal(const ClientMapProxy::PID_TO_KEY_MAP &pIdToKeyData);
 
                 virtual std::auto_ptr<serialization::pimpl::Data>
                 executeOnKeyInternal(const serialization::pimpl::Data &keyData,
@@ -231,10 +231,12 @@ namespace hazelcast {
                  * Populates the result from near cache if the data was near cached for the key. Also removes, the cached
                  * entries from pIdToKeyData.
                  * @param pIdToKeyData Partition Id to key data vector mapping
+                 * @param nonCachedPidToKeyMap The key that are not cached.
                  * @param markers The markers to be used
                  * @return The found cached data entries.
                  */
-                EntryVector populateFromNearCache(PID_TO_KEY_MAP &pIdToKeyData, MARKER_MAP &markers);
+                EntryVector populateFromNearCache(const PID_TO_KEY_MAP &pIdToKeyData, PID_TO_KEY_MAP &nonCachedPidToKeyMap,
+                                                  MARKER_MAP &markers);
             };
         }
     }

--- a/hazelcast/src/hazelcast/client/mixedtype/ClientMapProxy.cpp
+++ b/hazelcast/src/hazelcast/client/mixedtype/ClientMapProxy.cpp
@@ -274,6 +274,19 @@ namespace hazelcast {
                 return proxy::IMapImpl::evict(keyData);
             }
 
+            EntryVector ClientMapProxy::getAllInternal(const PID_TO_KEY_MAP &partitionToKeyData) {
+                std::map<int, std::vector<serialization::pimpl::Data> > datas;
+                for (PID_TO_KEY_MAP::const_iterator it = partitionToKeyData.begin();
+                     it != partitionToKeyData.end(); ++it) {
+                    const std::vector<boost::shared_ptr<serialization::pimpl::Data> > &valueDatas = it->second;
+                    for (std::vector<boost::shared_ptr<serialization::pimpl::Data> >::const_iterator valueIt = valueDatas.begin();
+                         valueIt != valueDatas.end(); ++valueIt) {
+                        datas[it->first].push_back(*(*valueIt));
+                    }
+                }
+                return proxy::IMapImpl::getAllData(datas);
+            }
+
             std::auto_ptr<serialization::pimpl::Data>
             ClientMapProxy::executeOnKeyInternal(const serialization::pimpl::Data &keyData,
                                            const serialization::pimpl::Data &processor) {


### PR DESCRIPTION
Fix to the near cached mixed map getAll implementation. The previous implementation did not mark the base getAllInternal as virtual which caused the derived method call to go to the base implementation which works without near-cache.

Related to issue https://github.com/hazelcast/hazelcast-cpp-client/issues/379