### PR TITLE
Fix for Portable Serialization incompatible class definition when nested portables used

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/ClassDefinition.h
+++ b/hazelcast/include/hazelcast/client/serialization/ClassDefinition.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <memory>
 #include <boost/shared_ptr.hpp>
+#include <ostream>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -133,6 +134,12 @@ namespace hazelcast {
                 */
                 void readData(pimpl::DataInput& dataInput);
 
+                bool operator==(const ClassDefinition &rhs) const;
+
+                bool operator!=(const ClassDefinition &rhs) const;
+
+                friend std::ostream &operator<<(std::ostream &os, const ClassDefinition &definition);
+
             private:
                 int factoryId;
                 int classId;
@@ -142,7 +149,6 @@ namespace hazelcast {
 
                 ClassDefinition& operator=(const ClassDefinition& rhs);
 
-                std::vector<FieldDefinition> fieldDefinitions;
                 std::map<std::string, FieldDefinition> fieldDefinitionsMap;
 
                 std::auto_ptr<std::vector<byte> > binary;

--- a/hazelcast/include/hazelcast/client/serialization/ClassDefinitionBuilder.h
+++ b/hazelcast/include/hazelcast/client/serialization/ClassDefinitionBuilder.h
@@ -46,8 +46,6 @@ namespace hazelcast {
             public:
                 ClassDefinitionBuilder(int factoryId, int classId, int version);
 
-                ClassDefinitionBuilder(int factoryId, int classId);
-
                 ClassDefinitionBuilder& addIntField(const std::string& fieldName);
 
                 ClassDefinitionBuilder& addLongField(const std::string& fieldName);

--- a/hazelcast/include/hazelcast/client/serialization/FieldDefinition.h
+++ b/hazelcast/include/hazelcast/client/serialization/FieldDefinition.h
@@ -56,7 +56,7 @@ namespace hazelcast {
                 /**
                 * Constructor
                 */
-                FieldDefinition(int, const std::string&, FieldType const&);
+                FieldDefinition(int, const std::string&, FieldType const&type, int version);
 
                 /**
                 * Constructor

--- a/hazelcast/include/hazelcast/client/serialization/FieldDefinition.h
+++ b/hazelcast/include/hazelcast/client/serialization/FieldDefinition.h
@@ -26,6 +26,7 @@
 
 #include "hazelcast/client/serialization/FieldType.h"
 #include <string>
+#include <ostream>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -60,7 +61,8 @@ namespace hazelcast {
                 /**
                 * Constructor
                 */
-                FieldDefinition(int index, const std::string& fieldName, FieldType const& type, int factoryId, int classId);
+                FieldDefinition(int index, const std::string &fieldName, FieldType const &type, int factoryId,
+                                int classId, int version);
 
                 /**
                 * @return field type
@@ -98,12 +100,19 @@ namespace hazelcast {
                 */
                 void readData(pimpl::DataInput& dataInput);
 
+                bool operator==(const FieldDefinition &rhs) const;
+
+                bool operator!=(const FieldDefinition &rhs) const;
+
+                friend std::ostream &operator<<(std::ostream &os, const FieldDefinition &definition);
+
             private:
                 int index;
                 std::string fieldName;
                 FieldType type;
                 int classId;
                 int factoryId;
+                int version;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/serialization/FieldType.h
+++ b/hazelcast/include/hazelcast/client/serialization/FieldType.h
@@ -16,6 +16,7 @@
 #ifndef HAZELCAST_FIELD_TYPE
 #define HAZELCAST_FIELD_TYPE
 
+#include <ostream>
 #include "hazelcast/util/HazelcastDll.h"
 
 namespace hazelcast {
@@ -36,6 +37,8 @@ namespace hazelcast {
                 bool operator==(FieldType const& rhs) const;
 
                 bool operator!=(FieldType const& rhs) const;
+
+                friend std::ostream &operator<<(std::ostream &os, const FieldType &type);
 
                 byte id;
             };

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/ClassDefinitionContext.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/ClassDefinitionContext.h
@@ -19,8 +19,9 @@
 #ifndef HAZELCAST_PORTABLE_CONTEXT
 #define HAZELCAST_PORTABLE_CONTEXT
 
-#include "hazelcast/util/SynchronizedMap.h"
+#include <stdint.h>
 
+#include "hazelcast/util/SynchronizedMap.h"
 
 namespace hazelcast {
     namespace client {
@@ -35,7 +36,7 @@ namespace hazelcast {
                 class ClassDefinitionContext {
                 public:
 
-                    ClassDefinitionContext(PortableContext *portableContext);
+                    ClassDefinitionContext(int portableContext, PortableContext *pContext);
 
                     int getClassVersion(int classId);
 
@@ -46,8 +47,9 @@ namespace hazelcast {
                     boost::shared_ptr<ClassDefinition> registerClassDefinition(boost::shared_ptr<ClassDefinition>);
 
                 private:
-                    long long combineToLong(int x, int y) const;
+                    int64_t combineToLong(int x, int y) const;
 
+                    const int factoryId;
                     util::SynchronizedMap<long long, ClassDefinition> versionedDefinitions;
                     util::SynchronizedMap<int, int> currentClassVersions;
                     PortableContext *portableContext;

--- a/hazelcast/src/hazelcast/client/serialization/ClassDefinition.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/ClassDefinition.cpp
@@ -26,7 +26,6 @@
 #include "hazelcast/client/serialization/pimpl/DataInput.h"
 #include "hazelcast/client/serialization/pimpl/DataOutput.h"
 
-
 namespace hazelcast {
     namespace client {
         namespace serialization {
@@ -41,7 +40,6 @@ namespace hazelcast {
             }
 
             void ClassDefinition::addFieldDef(FieldDefinition& fd) {
-                fieldDefinitions.push_back(fd);
                 fieldDefinitionsMap[fd.getName()] = fd;
             }
 
@@ -66,7 +64,7 @@ namespace hazelcast {
             }
 
             int ClassDefinition::getFieldCount() const {
-                return (int)fieldDefinitions.size();
+                return (int)fieldDefinitionsMap.size();
             }
 
 
@@ -92,10 +90,10 @@ namespace hazelcast {
                 dataOutput.writeInt(factoryId);
                 dataOutput.writeInt(classId);
                 dataOutput.writeInt(version);
-                dataOutput.writeShort(fieldDefinitions.size());
-                std::vector<FieldDefinition>::iterator it;
-                for (it = fieldDefinitions.begin(); it != fieldDefinitions.end(); ++it) {
-                    it->writeData(dataOutput);
+                dataOutput.writeShort(fieldDefinitionsMap.size());
+                for (std::map<std::string, FieldDefinition>::iterator it = fieldDefinitionsMap.begin();
+                     it != fieldDefinitionsMap.end(); ++it) {
+                    it->second.writeData(dataOutput);
                 }
             }
 
@@ -109,6 +107,28 @@ namespace hazelcast {
                     fieldDefinition.readData(dataInput);
                     addFieldDef(fieldDefinition);
                 }
+            }
+
+            bool ClassDefinition::operator==(const ClassDefinition &rhs) const {
+                return factoryId == rhs.factoryId &&
+                       classId == rhs.classId &&
+                       version == rhs.version &&
+                       fieldDefinitionsMap == rhs.fieldDefinitionsMap;
+            }
+
+            bool ClassDefinition::operator!=(const ClassDefinition &rhs) const {
+                return !(rhs == *this);
+            }
+
+            std::ostream &operator<<(std::ostream &os, const ClassDefinition &definition) {
+                os << "ClassDefinition{" << "factoryId: " << definition.factoryId << " classId: " << definition.classId << " version: "
+                   << definition.version << " fieldDefinitions: {";
+
+                for (std::map<std::string, FieldDefinition>::const_iterator it = definition.fieldDefinitionsMap.begin(); it != definition.fieldDefinitionsMap.end(); ++it) {
+                    os << it->second;
+                }
+                os << "} }";
+                return os;
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/serialization/ClassDefinitionBuilder.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/ClassDefinitionBuilder.cpp
@@ -22,7 +22,6 @@
 #include "hazelcast/client/serialization/pimpl/Data.h"
 #include "hazelcast/client/serialization/ClassDefinitionBuilder.h"
 #include "hazelcast/client/exception/IllegalArgumentException.h"
-#include "hazelcast/client/exception/HazelcastSerializationException.h"
 
 namespace hazelcast {
     namespace client {
@@ -134,9 +133,11 @@ namespace hazelcast {
             ClassDefinitionBuilder& ClassDefinitionBuilder::addPortableField(const std::string& fieldName, boost::shared_ptr<ClassDefinition> def) {
                 check();
                 if (def->getClassId() == 0) {
-                    throw exception::IllegalArgumentException("ClassDefinitionBuilder::addPortableField", "Portable class id cannot be zero!");
+                    throw exception::IllegalArgumentException("ClassDefinitionBuilder::addPortableField",
+                                                              "Portable class id cannot be zero!");
                 }
-                FieldDefinition fieldDefinition(index++, fieldName, FieldTypes::TYPE_PORTABLE, def->getFactoryId(), def->getClassId());
+                FieldDefinition fieldDefinition(index++, fieldName, FieldTypes::TYPE_PORTABLE, def->getFactoryId(),
+                                                def->getClassId(), def->getVersion());
                 fieldDefinitions.push_back(fieldDefinition);
                 return *this;
             }
@@ -144,9 +145,11 @@ namespace hazelcast {
             ClassDefinitionBuilder& ClassDefinitionBuilder::addPortableArrayField(const std::string& fieldName, boost::shared_ptr<ClassDefinition> def) {
                 check();
                 if (def->getClassId() == 0) {
-                    throw exception::IllegalArgumentException("ClassDefinitionBuilder::addPortableField", "Portable class id cannot be zero!");
+                    throw exception::IllegalArgumentException("ClassDefinitionBuilder::addPortableField",
+                                                              "Portable class id cannot be zero!");
                 }
-                FieldDefinition fieldDefinition(index++, fieldName, FieldTypes::TYPE_PORTABLE_ARRAY, def->getFactoryId(), def->getClassId());
+                FieldDefinition fieldDefinition(index++, fieldName, FieldTypes::TYPE_PORTABLE_ARRAY,
+                                                def->getFactoryId(), def->getClassId(), def->getVersion());
                 fieldDefinitions.push_back(fieldDefinition);
                 return *this;
             }

--- a/hazelcast/src/hazelcast/client/serialization/ClassDefinitionBuilder.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/ClassDefinitionBuilder.cpp
@@ -35,16 +35,6 @@ namespace hazelcast {
 
             }
 
-            ClassDefinitionBuilder::ClassDefinitionBuilder(int factoryId, int classId)
-            : factoryId(factoryId)
-            , classId(classId)
-            , version(-1)
-            , index(0)
-            , done(false) {
-
-
-            }
-
             ClassDefinitionBuilder& ClassDefinitionBuilder::addIntField(const std::string& fieldName) {
                 addField(fieldName, FieldTypes::TYPE_INT);
                 return *this;
@@ -187,7 +177,7 @@ namespace hazelcast {
 
             void ClassDefinitionBuilder::addField(const std::string& fieldName, FieldType const& fieldType) {
                 check();
-                FieldDefinition fieldDefinition(index++, fieldName, fieldType);
+                FieldDefinition fieldDefinition(index++, fieldName, fieldType, version);
                 fieldDefinitions.push_back(fieldDefinition);
             }
 

--- a/hazelcast/src/hazelcast/client/serialization/FieldDefinition.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/FieldDefinition.cpp
@@ -44,12 +44,13 @@ namespace hazelcast {
             , factoryId(0) {
             }
 
-            FieldDefinition::FieldDefinition(int index, const std::string& fieldName, FieldType const& type, int factoryId, int classId)
+            FieldDefinition::FieldDefinition(int index, const std::string& fieldName, FieldType const& type, int factoryId, int classId, int version)
             : index(index)
             , fieldName(fieldName)
             , type(type)
             , classId(classId)
-            , factoryId(factoryId) {
+            , factoryId(factoryId)
+            , version(version) {
             }
 
             const FieldType &FieldDefinition::getType() const {
@@ -72,7 +73,6 @@ namespace hazelcast {
                 return classId;
             }
 
-
             void FieldDefinition::writeData(pimpl::DataOutput& dataOutput) {
                 dataOutput.writeInt(index);
                 dataOutput.writeUTF(&fieldName);
@@ -87,6 +87,25 @@ namespace hazelcast {
                 type.id = dataInput.readByte();
                 factoryId = dataInput.readInt();
                 classId = dataInput.readInt();
+            }
+
+            bool FieldDefinition::operator==(const FieldDefinition &rhs) const {
+                return fieldName == rhs.fieldName &&
+                       type == rhs.type &&
+                       classId == rhs.classId &&
+                       factoryId == rhs.factoryId &&
+                       version == rhs.version;
+            }
+
+            bool FieldDefinition::operator!=(const FieldDefinition &rhs) const {
+                return !(rhs == *this);
+            }
+
+            std::ostream &operator<<(std::ostream &os, const FieldDefinition &definition) {
+                os << "FieldDefinition{" << "index: " << definition.index << " fieldName: " << definition.fieldName
+                   << " type: " << definition.type << " classId: " << definition.classId << " factoryId: "
+                   << definition.factoryId << " version: " << definition.version;
+                return os;
             }
 
         }

--- a/hazelcast/src/hazelcast/client/serialization/FieldDefinition.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/FieldDefinition.cpp
@@ -32,19 +32,21 @@ namespace hazelcast {
             FieldDefinition::FieldDefinition()
             : index(0)
             , classId(0)
-            , factoryId(0) {
-
+            , factoryId(0)
+            , version(-1) {
             }
 
-            FieldDefinition::FieldDefinition(int index, const std::string& fieldName, FieldType const& type)
+            FieldDefinition::FieldDefinition(int index, const std::string& fieldName, FieldType const& type, int version)
             : index(index)
             , fieldName(fieldName)
             , type(type)
             , classId(0)
-            , factoryId(0) {
+            , factoryId(0)
+            , version(version) {
             }
 
-            FieldDefinition::FieldDefinition(int index, const std::string& fieldName, FieldType const& type, int factoryId, int classId, int version)
+            FieldDefinition::FieldDefinition(int index, const std::string &fieldName, FieldType const &type,
+                                             int factoryId, int classId, int version)
             : index(index)
             , fieldName(fieldName)
             , type(type)

--- a/hazelcast/src/hazelcast/client/serialization/FieldType.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/FieldType.cpp
@@ -50,6 +50,11 @@ namespace hazelcast {
                 if (id == rhs.id) return false;
                 return true;
             }
+
+            std::ostream &operator<<(std::ostream &os, const FieldType &type) {
+                os << "FieldType{id: " << type.id << "}";
+                return os;
+            }
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/ClassDefinitionContext.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/ClassDefinitionContext.cpp
@@ -18,16 +18,14 @@
 
 #include "hazelcast/client/serialization/pimpl/ClassDefinitionContext.h"
 #include "hazelcast/client/serialization/pimpl/SerializationService.h"
-#include "hazelcast/client/exception/IllegalArgumentException.h"
 
 namespace hazelcast {
     namespace client {
         namespace serialization {
             namespace pimpl {
 
-                ClassDefinitionContext::ClassDefinitionContext(PortableContext *portableContext)
-                : portableContext(portableContext) {
-
+                ClassDefinitionContext::ClassDefinitionContext(int factoryId, PortableContext *portableContext)
+                : factoryId(factoryId), portableContext(portableContext) {
                 }
 
                 int ClassDefinitionContext::getClassVersion(int classId) {
@@ -50,21 +48,37 @@ namespace hazelcast {
 
                 }
 
-                boost::shared_ptr<ClassDefinition>  ClassDefinitionContext::registerClassDefinition(boost::shared_ptr<ClassDefinition> cd) {
+                boost::shared_ptr<ClassDefinition> ClassDefinitionContext::registerClassDefinition(boost::shared_ptr<ClassDefinition> cd) {
+                    if (cd.get() == NULL) {
+                        return boost::shared_ptr<ClassDefinition>();
+                    }
+                    if (cd->getFactoryId() != factoryId) {
+                        throw (exception::ExceptionBuilder<exception::HazelcastSerializationException>(
+                                "ClassDefinitionContext::registerClassDefinition") << "Invalid factory-id! "
+                                                                                   << factoryId << " -> "
+                                                                                   << cd).build();
+                    }
+
                     cd->setVersionIfNotSet(portableContext->getVersion());
 
                     long long versionedClassId = combineToLong(cd->getClassId(), cd->getVersion());
-                    boost::shared_ptr<ClassDefinition> currentCD = versionedDefinitions.putIfAbsent(versionedClassId, cd);
-                    if (currentCD == NULL) {
+                    boost::shared_ptr<ClassDefinition> currentCd = versionedDefinitions.putIfAbsent(versionedClassId, cd);
+                    if (currentCd.get() == NULL) {
                         return cd;
                     }
 
-                    versionedDefinitions.put(versionedClassId, cd);
-                    return cd;
+                    if (currentCd.get() != cd.get() && *currentCd != *cd) {
+                        throw (exception::ExceptionBuilder<exception::HazelcastSerializationException>(
+                                "ClassDefinitionContext::registerClassDefinition")
+                                << "Incompatible class-definitions with same class-id: " << *cd << " VS "
+                                << *currentCd).build();
+                    }
+
+                    return currentCd;
                 }
 
-                long long ClassDefinitionContext::combineToLong(int x, int y) const {
-                    return ((long long)x) << 32 | (((long long)y) & 0xFFFFFFFL);
+                int64_t ClassDefinitionContext::combineToLong(int x, int y) const {
+                    return ((int64_t)x) << 32 | (((int64_t)y) & 0xFFFFFFFL);
                 }
 
             }

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/PortableContext.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/PortableContext.cpp
@@ -80,6 +80,7 @@ namespace hazelcast {
                         std::string name((char *)&(chars[0]));
                         int fieldFactoryId = 0;
                         int fieldClassId = 0;
+                        int fieldVersion = version;
                         if (type == FieldTypes::TYPE_PORTABLE) {
                             // is null
                             if (in.readBoolean()) {
@@ -90,7 +91,7 @@ namespace hazelcast {
 
                             // TODO: what if there's a null inner Portable field
                             if (shouldRegister) {
-                                int fieldVersion = in.readInt();
+                                fieldVersion = in.readInt();
                                 readClassDefinition(in, fieldFactoryId, fieldClassId, fieldVersion);
                             }
                         } else if (type == FieldTypes::TYPE_PORTABLE_ARRAY) {
@@ -103,14 +104,14 @@ namespace hazelcast {
                                 in.position(p);
 
                                 // TODO: what if there's a null inner Portable field
-                                int fieldVersion = in.readInt();
+                                fieldVersion = in.readInt();
                                 readClassDefinition(in, fieldFactoryId, fieldClassId, fieldVersion);
                             } else {
                                 shouldRegister = false;
                             }
 
                         }
-                        FieldDefinition fieldDef(i, name, type, fieldFactoryId, fieldClassId);
+                        FieldDefinition fieldDef(i, name, type, fieldFactoryId, fieldClassId, fieldVersion);
                         builder.addField(fieldDef);
                     }
                     boost::shared_ptr<ClassDefinition> classDefinition = builder.build();
@@ -148,7 +149,7 @@ namespace hazelcast {
                 ClassDefinitionContext& PortableContext::getClassDefinitionContext(int factoryId) {
                     boost::shared_ptr<ClassDefinitionContext> value = classDefContextMap.get(factoryId);
                     if (value == NULL) {
-                        value = boost::shared_ptr<ClassDefinitionContext>(new ClassDefinitionContext(this));
+                        value = boost::shared_ptr<ClassDefinitionContext>(new ClassDefinitionContext(factoryId, this));
                         boost::shared_ptr<ClassDefinitionContext> current = classDefContextMap.putIfAbsent(factoryId, value);
                         if (current != NULL) {
                             value = current;

--- a/hazelcast/test/src/serialization/PortableVersionTest.cpp
+++ b/hazelcast/test/src/serialization/PortableVersionTest.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <TestHelperFunctions.h>
+#include <ClientTestSupport.h>
+
+#include "hazelcast/client/serialization/pimpl/SerializationService.h"
+#include "hazelcast/client/serialization/PortableWriter.h"
+#include "hazelcast/client/serialization/PortableReader.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class PortableVersionTest : public ::testing::Test {
+            protected:
+                class Child : public serialization::Portable {
+                public:
+                    Child() {
+                    }
+
+                    Child(const std::string &name) : name (name) {
+                    }
+
+                    virtual int getFactoryId() const {
+                        return 1;
+                    }
+
+                    virtual int getClassId() const {
+                        return 2;
+                    }
+
+                    virtual void writePortable(serialization::PortableWriter &writer) const {
+                        writer.writeUTF("name", &name);
+                    }
+
+                    virtual void readPortable(serialization::PortableReader &reader) {
+                        name = *reader.readUTF("name");
+                    }
+
+                    bool operator==(const Child &rhs) const {
+                        return name == rhs.name;
+                    }
+
+                private:
+                    std::string name;
+
+                };
+
+                class Parent : public serialization::Portable {
+                public:
+                    Parent() {}
+
+                    Parent(const Child &child) : child(child) {}
+
+                    virtual int getFactoryId() const {
+                        return 1;
+                    }
+
+                    virtual int getClassId() const {
+                        return 1;
+                    }
+
+                    virtual void writePortable(serialization::PortableWriter &writer) const {
+                        writer.writePortable<Child>("child", &child);
+                    }
+
+                    virtual void readPortable(serialization::PortableReader &reader) {
+                        child = *reader.readPortable<Child>("child");
+                    }
+
+                    bool operator==(const Parent &rhs) const {
+                        return child == rhs.child;
+                    }
+
+                    bool operator!=(const Parent &rhs) const {
+                        return !(rhs == *this);
+                    }
+
+                private:
+                    Child child;
+                };
+
+                class MyPortableFactory : public serialization::PortableFactory {
+                public:
+                    virtual std::auto_ptr<serialization::Portable> create(int32_t classId) const {
+                        if (classId == 1) {
+                            return std::auto_ptr<serialization::Portable>(new Parent());
+                        } else if (classId == 2) {
+                            return std::auto_ptr<serialization::Portable>(new Child());
+                        }
+
+                        return std::auto_ptr<serialization::Portable>();
+                    }
+                };
+            };
+
+            // Test for issue https://github.com/hazelcast/hazelcast/issues/12733
+            TEST_F(PortableVersionTest, test_nestedPortable_versionedSerializer) {
+                SerializationConfig serializationConfig;
+                serializationConfig.addPortableFactory(1, boost::shared_ptr<serialization::PortableFactory>(new MyPortableFactory));
+                serialization::pimpl::SerializationService ss1(serializationConfig);
+
+                SerializationConfig serializationConfig2;
+                serializationConfig2.setPortableVersion(6).addPortableFactory(1, boost::shared_ptr<serialization::PortableFactory>(new MyPortableFactory));
+                serialization::pimpl::SerializationService ss2(serializationConfig2);
+
+                //make sure ss2 cached class definition of Child
+                ss2.toData<Child>(new Child("sancar"));
+
+                //serialized parent from ss1
+                Parent parent(Child("sancar"));
+                serialization::pimpl::Data data = ss1.toData<Parent>(&parent);
+
+                // cached class definition of Child and the class definition from data coming from ss1 should be compatible
+                assertEquals(parent, *ss2.toObject<Parent>(data));
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes registration of incompatible portable class definitions when nested portables used.

fixes #391