### PR TITLE
Disable test MixedMapAPITest.testGetAllPutAll until the related issue is resolved

### DIFF
--- a/hazelcast/test/src/map/MixedMapAPITest.cpp
+++ b/hazelcast/test/src/map/MixedMapAPITest.cpp
@@ -645,7 +645,11 @@ namespace hazelcast {
                 }
 
 
-                TEST_P(MixedMapAPITest, testGetAllPutAll) {
+                /**
+                 * This failure with this test is reported at https://github.com/hazelcast/hazelcast-cpp-client/issues/379
+                 * Do not forget to enable this test once the issue is resolved!!!
+                 */
+                TEST_P(MixedMapAPITest, DISABLED_testGetAllPutAll) {
                     std::map<std::string, std::string> mapTemp;
 
                     for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Disabled test MixedMapAPITest.testGetAllPutAll until the issue https://github.com/hazelcast/hazelcast-cpp-client/issues/379 is resolved.