### PR TITLE
TargetNotMemberException retry is not working

### DIFF
--- a/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
+++ b/hazelcast/include/hazelcast/client/exception/ProtocolExceptions.h
@@ -56,7 +56,7 @@ namespace hazelcast {
                 virtual std::auto_ptr<IException> clone() const {\
                     return std::auto_ptr<IException>(new ClassName(*this));\
                 } \
-                void raise() const { throw *this; } \
+                virtual void raise() const { throw *this; } \
             };\
 
             DEFINE_EXCEPTION_CLASS(ArrayIndexOutOfBoundsException, protocol::INDEX_OUT_OF_BOUNDS);
@@ -155,7 +155,7 @@ namespace hazelcast {
 
                 RetryableHazelcastException(const std::string &source, const std::string &message);
 
-
+                virtual void raise() const;
             };
 
             class HAZELCAST_API TargetNotMemberException : public RetryableHazelcastException {
@@ -167,7 +167,7 @@ namespace hazelcast {
 
                 TargetNotMemberException(const std::string &source, const std::string &message);
 
-
+                virtual void raise() const;
             };
 
             class HAZELCAST_API UndefinedErrorCodeException : public IException {
@@ -185,6 +185,8 @@ namespace hazelcast {
                 const std::string &getDetailedErrorMessage() const;
 
                 virtual std::auto_ptr<IException> clone() const;
+
+                virtual void raise() const;
 
             private:
                 int32_t error;

--- a/hazelcast/src/hazelcast/client/exception/ProtocolExceptions.cpp
+++ b/hazelcast/src/hazelcast/client/exception/ProtocolExceptions.cpp
@@ -47,6 +47,10 @@ namespace hazelcast {
                 return std::auto_ptr<IException>(new UndefinedErrorCodeException(*this));
             }
 
+            void UndefinedErrorCodeException::raise() const {
+                throw *this;
+            }
+
             RetryableHazelcastException::RetryableHazelcastException(const std::string &source, const std::string &message,
                                                                const std::string &details, int32_t causeCode)
                     : HazelcastException(source, message, details, causeCode) {
@@ -61,6 +65,10 @@ namespace hazelcast {
             RetryableHazelcastException::RetryableHazelcastException(const std::string &source, const std::string &message,
                                                                int32_t causeCode) : HazelcastException(source, message,
                                                                                                        causeCode) {}
+
+            void RetryableHazelcastException::raise() const {
+                throw *this;
+            }
 
             TargetNotMemberException::TargetNotMemberException(const std::string &source, const std::string &message,
                                                                const std::string &details, int32_t causeCode)
@@ -77,6 +85,10 @@ namespace hazelcast {
                                                                int32_t causeCode) : RetryableHazelcastException(source,
                                                                                                                 message,
                                                                                                                 causeCode) {}
+
+            void TargetNotMemberException::raise() const {
+                throw *this;
+            }
         }
     }
 }

--- a/hazelcast/src/hazelcast/util/impl/Executor.cpp
+++ b/hazelcast/src/hazelcast/util/impl/Executor.cpp
@@ -233,8 +233,12 @@ namespace hazelcast {
                     try {
                         command->run();
                     } catch (client::exception::IException &e) {
-                        util::ILogger::getLogger().warning() << "Repeated runnable " << getName()
-                                                             << " run method caused exception:" << e;
+                        ILogger &iLogger = util::ILogger::getLogger();
+                        if (isNotRepeating) {
+                            iLogger.warning() << "Runnable " << getName() << " run method caused exception:" << e;
+                        } else {
+                            iLogger.warning() << "Repeated runnable " << getName() << " run method caused exception:" << e;
+                        }
                     }
 
                     if (isNotRepeating) {


### PR DESCRIPTION
During compatibility testing of the 3.10.1 release, we found out that TargetNotMemberException retry may not work as expected since the raise method was not overridden correctly.

Fixed so that the TargetNotMemberException retryable exception is really retried.