### PR TITLE
Thread termination passed argument memory leak fix

### DIFF
--- a/hazelcast/include/hazelcast/util/PosixThread.inl
+++ b/hazelcast/include/hazelcast/util/PosixThread.inl
@@ -74,13 +74,19 @@ namespace hazelcast {
                 } catch (...) {
                     logger.warning() << "Thread " << target->getName()
                                      << " is cancelled with an unexpected exception";
+
                     info->finishWaitLatch->countDown();
+
+                    delete info;
+
                     throw;
                 }
 
                 logger.finest() << "Thread " << target->getName() << " is finished.";
 
                 info->finishWaitLatch->countDown();
+
+                delete info;
 
                 return NULL;
             }

--- a/hazelcast/include/hazelcast/util/WindowsThread.inl
+++ b/hazelcast/include/hazelcast/util/WindowsThread.inl
@@ -72,12 +72,16 @@ namespace hazelcast {
 
                     info->finishWaitLatch->countDown();
 
+                    delete info;
+
                     return 1L;
                 }
 
                 logger.finest() << "Thread " << target->getName() << " is finished.";
 
                 info->finishWaitLatch->countDown();
+
+                delete info;
 
                 return 0;
             }

--- a/hazelcast/src/hazelcast/client/connection/ClientConnectionManagerImpl.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClientConnectionManagerImpl.cpp
@@ -607,6 +607,7 @@ namespace hazelcast {
             }
 
             ClientConnectionManagerImpl::~ClientConnectionManagerImpl() {
+                shutdown();
             }
 
             ClientConnectionManagerImpl::InitConnectionTask::InitConnectionTask(const Address &target,


### PR DESCRIPTION
Fix for leaking memory on thread close. The void pointer argument passed to the thread should be freed before thread exits. The leak was detected using valgrind.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/455

I tried using AbstractThread pointer instead of ThreadInfo struct when creating the thread but then it causes the following lifecycle problem: When the client is shutdown using the ShutdownTask, then when ShutdownTask::run finishes it is possible that HazelcastClientInstanceImpl is destructed and hence the Shutdown thread(AbstractThread type) should not touch any field of HazelcastInstanceImpl. But if we passed the thread pointer, then it will be destroyed and an illegal access will occur. 