### PR TITLE
LoggerConfigFromFileTest.testFinest may fail at Windows builds

### DIFF
--- a/hazelcast/test/src/util/LoggerConfigFromFileTest.cpp
+++ b/hazelcast/test/src/util/LoggerConfigFromFileTest.cpp
@@ -45,8 +45,22 @@ namespace hazelcast {
                     std::cout.rdbuf(originalStdout);
                 }
 
+                void forceSyncToFileSystem(const std::string &filename) {
+                    FILE *fhandle = fopen(filename.c_str(), "r");
+                    #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+                    FlushFileBuffers(fhandle);
+                    #else
+                        fsync(fileno(fhandle));
+                    #endif
+                    fclose(fhandle);
+                }
+
                 std::vector<std::string> getLogLines() {
-                    std::ifstream logFile("testLog.txt");
+                    std::string logFileName("testLog.txt");
+
+                    forceSyncToFileSystem(logFileName);
+
+                    std::ifstream logFile(logFileName);
                     std::vector<std::string> lines;
                     std::string line;
                     while (std::getline(logFile, line)) {

--- a/hazelcast/test/src/util/LoggerConfigFromFileTest.cpp
+++ b/hazelcast/test/src/util/LoggerConfigFromFileTest.cpp
@@ -60,7 +60,7 @@ namespace hazelcast {
 
                     forceSyncToFileSystem(logFileName);
 
-                    std::ifstream logFile(logFileName);
+                    std::ifstream logFile(logFileName.c_str());
                     std::vector<std::string> lines;
                     std::string line;
                     while (std::getline(logFile, line)) {


### PR DESCRIPTION
I believe the cause of the problem is non-sync filesystem. The easylogging++ library by default flushes the context but it does not sync since it more expensive. Hence, i believe this may have been the reason for some windows test failures.

Adding a step to sync log file content to filesystem. Failure to do this most probably caused some test failure at windows.  The failures at windows were:

[  FAILED  ] LoggerConfigFromFileTest.testFinest
[  FAILED  ] LoggerConfigFromFileTest.testMultipleLinesLog
LoggerConfigFromFIleTest.cpp(69): error: Value of: lines.size()
   Actual: 0
  Expected: 1U
  Which is: 1