### PR TITLE
Enable easylogger debug output when build type is "Release"

### DIFF
--- a/external/include/easylogging++/easylogging++.h
+++ b/external/include/easylogging++/easylogging++.h
@@ -195,7 +195,7 @@
 #else
 #   define _ELPP_ENABLE_MUTEX 0
 #endif // (!defined(_DISABLE_MUTEX) && (_ENABLE_EASYLOGGING))
-#if (!defined(_DISABLE_DEBUG_LOGS) && (_ENABLE_EASYLOGGING) && ((defined(_DEBUG)) || (!defined(NDEBUG))))
+#if (!defined(_DISABLE_DEBUG_LOGS) && (_ENABLE_EASYLOGGING)) // && ((defined(_DEBUG)) || (!defined(NDEBUG)))) CHANGED FROM ORIGINAL SOURCE CODE SO THAT DEBUG LOG WORKS WITH RELEASE BUILDS
 #   define _ELPP_DEBUG_LOG 1
 #else
 #   define _ELPP_DEBUG_LOG 0
@@ -2411,10 +2411,9 @@ public:
             username_(internal::utilities::OSUtils::currentUser()),
             hostname_(internal::utilities::OSUtils::currentHost()),
             counters_(new internal::RegisteredCounters()) {
-/*
- *      COMMENTED OUT FROM ORIGINAL SOURCE CODE to disable built-in loggers
- *
         defaultConfigurations_.setToDefault();
+/*
+ *  COMMENTED OUT FROM ORIGINAL SOURCE CODE to disable built-in loggers
         Configurations conf;
         conf.setToDefault();
         conf.parseFromText(constants_->DEFAULT_LOGGER_CONFIGURATION);

--- a/external/include/easylogging++/easylogging++.h
+++ b/external/include/easylogging++/easylogging++.h
@@ -1494,6 +1494,8 @@ public:
     //!
     void setToDefault(void) {
         setAll(ConfigurationType::Enabled, "true");
+
+/* CHANGED FROM ORIGINAL SOURCE CODE. Disabled file logging by default. This causes unneeded file operations
 #if _ELPP_OS_UNIX
 #   if _ELPP_NDK
         setAll(ConfigurationType::Filename, "/data/local/tmp/myeasylog.txt");
@@ -1503,7 +1505,9 @@ public:
 #elif _ELPP_OS_WINDOWS
         setAll(ConfigurationType::Filename, "logs\\myeasylog.log");
 #endif // _ELPP_OS_UNIX
-        setAll(ConfigurationType::ToFile, "true");
+*/
+        /* CHANGED FROM ORIGINAL SOURCE CODE. Disabled file writing by default. */
+        setAll(ConfigurationType::ToFile, "false");
         setAll(ConfigurationType::ToStandardOutput, "true");
         setAll(ConfigurationType::MillisecondsWidth, "3");
         setAll(ConfigurationType::PerformanceTracking, "false");
@@ -2413,7 +2417,7 @@ public:
             counters_(new internal::RegisteredCounters()) {
         defaultConfigurations_.setToDefault();
 /*
- *  COMMENTED OUT FROM ORIGINAL SOURCE CODE to disable built-in loggers
+ *  CHANGED FROM ORIGINAL CODE. COMMENTED OUT FROM ORIGINAL SOURCE CODE to disable built-in loggers
         Configurations conf;
         conf.setToDefault();
         conf.parseFromText(constants_->DEFAULT_LOGGER_CONFIGURATION);

--- a/external/release_include/easylogging++/easylogging++.h
+++ b/external/release_include/easylogging++/easylogging++.h
@@ -195,7 +195,7 @@
 #else
 #   define _ELPP_ENABLE_MUTEX 0
 #endif // (!defined(_DISABLE_MUTEX) && (_ENABLE_EASYLOGGING))
-#if (!defined(_DISABLE_DEBUG_LOGS) && (_ENABLE_EASYLOGGING) && ((defined(_DEBUG)) || (!defined(NDEBUG))))
+#if (!defined(_DISABLE_DEBUG_LOGS) && (_ENABLE_EASYLOGGING)) // && ((defined(_DEBUG)) || (!defined(NDEBUG)))) CHANGED FROM ORIGINAL SOURCE CODE SO THAT DEBUG LOG WORKS WITH RELEASE BUILDS
 #   define _ELPP_DEBUG_LOG 1
 #else
 #   define _ELPP_DEBUG_LOG 0
@@ -1494,6 +1494,8 @@ public:
     //!
     void setToDefault(void) {
         setAll(ConfigurationType::Enabled, "true");
+
+/* CHANGED FROM ORIGINAL SOURCE CODE. Disabled file logging by default. This causes unneeded file operations
 #if _ELPP_OS_UNIX
 #   if _ELPP_NDK
         setAll(ConfigurationType::Filename, "/data/local/tmp/myeasylog.txt");
@@ -1503,7 +1505,9 @@ public:
 #elif _ELPP_OS_WINDOWS
         setAll(ConfigurationType::Filename, "logs\\myeasylog.log");
 #endif // _ELPP_OS_UNIX
-        setAll(ConfigurationType::ToFile, "true");
+*/
+        /* CHANGED FROM ORIGINAL SOURCE CODE. Disabled file writing by default. */
+        setAll(ConfigurationType::ToFile, "false");
         setAll(ConfigurationType::ToStandardOutput, "true");
         setAll(ConfigurationType::MillisecondsWidth, "3");
         setAll(ConfigurationType::PerformanceTracking, "false");
@@ -2411,10 +2415,9 @@ public:
             username_(internal::utilities::OSUtils::currentUser()),
             hostname_(internal::utilities::OSUtils::currentHost()),
             counters_(new internal::RegisteredCounters()) {
-/*
- *      COMMENTED OUT FROM ORIGINAL SOURCE CODE to disable built-in loggers
- *
         defaultConfigurations_.setToDefault();
+/*
+ *  CHANGED FROM ORIGINAL CODE. COMMENTED OUT FROM ORIGINAL SOURCE CODE to disable built-in loggers
         Configurations conf;
         conf.setToDefault();
         conf.parseFromText(constants_->DEFAULT_LOGGER_CONFIGURATION);

--- a/hazelcast/test/resources/logger-config.txt
+++ b/hazelcast/test/resources/logger-config.txt
@@ -6,7 +6,7 @@
     TO_STANDARD_OUTPUT		=	false
     MILLISECONDS_WIDTH		=	3
     PERFORMANCE_TRACKING	=	false
-    ROLL_OUT_SIZE           =  17 // Throw log files away after 17 bytes
+    ROLL_OUT_SIZE           =  2097152 // Throw log files away after 2MB
 
 // Following configuration only defines FORMAT for INFO, rest of the configurations are used from ALL configurations above
 * INFO:

--- a/hazelcast/test/src/ClientTestSupport.h
+++ b/hazelcast/test/src/ClientTestSupport.h
@@ -50,6 +50,7 @@ namespace hazelcast {
             protected:
                 util::ILogger &getLogger();
 
+            private:
                 boost::shared_ptr<hazelcast::util::ILogger> logger;
             };
         }

--- a/hazelcast/test/src/util/ClientUtilTest.cpp
+++ b/hazelcast/test/src/util/ClientUtilTest.cpp
@@ -225,7 +225,7 @@ namespace hazelcast {
                 util::Future<int> future(getLogger());
                 util::CountDownLatch successLatch(1);
                 util::CountDownLatch failLatch(1);
-                util::impl::SimpleExecutorService executorService(*logger, "testFutureAndThen", 3);
+                util::impl::SimpleExecutorService executorService(getLogger(), "testFutureAndThen", 3);
                 future.andThen(boost::shared_ptr<impl::ExecutionCallback<int> >(
                         new LatchExecutionCallback(successLatch, failLatch)), executorService);
 
@@ -240,7 +240,7 @@ namespace hazelcast {
                 util::Future<int> future(getLogger());
                 util::CountDownLatch successLatch(1);
                 util::CountDownLatch failLatch(1);
-                util::impl::SimpleExecutorService executorService(*logger, "testFutureAndThen", 3);
+                util::impl::SimpleExecutorService executorService(getLogger(), "testFutureAndThen", 3);
 
                 int value = 5;
                 future.set_value(value);
@@ -254,7 +254,7 @@ namespace hazelcast {
                 util::Future<int> future(getLogger());
                 util::CountDownLatch successLatch(1);
                 util::CountDownLatch failLatch(1);
-                util::impl::SimpleExecutorService executorService(*logger, "testFutureAndThen", 3);
+                util::impl::SimpleExecutorService executorService(getLogger(), "testFutureAndThen", 3);
                 future.andThen(boost::shared_ptr<impl::ExecutionCallback<int> >(
                         new LatchExecutionCallback(successLatch, failLatch)), executorService);
 
@@ -269,7 +269,7 @@ namespace hazelcast {
                 util::Future<int> future(getLogger());
                 util::CountDownLatch successLatch(1);
                 util::CountDownLatch failLatch(1);
-                util::impl::SimpleExecutorService executorService(*logger, "testFutureAndThen", 3);
+                util::impl::SimpleExecutorService executorService(getLogger(), "testFutureAndThen", 3);
 
                 future.set_exception(std::auto_ptr<client::exception::IException>(
                         new exception::IOException("exceptionName", "details")));


### PR DESCRIPTION
Corrected the _ELPP_DEBUG_LOG macro setting when the build type is "Release". This flag was being defined to 0 when Release builds are compiled which caused the LoggerConfigFromFileTest.testFinest to fail. By defining this flag to 1 even when "Release" builds are compiled, the test passes now.

Modified LoggerConfigFromFileTest so that the log output file is truncated (contents cleared) at every test case start.

Changed the ClientTestSupport logger from protected to private and only let derived test classes use getLogger() API instead.

Also increased the ROLL_OUT_SIZE parameter for the LoggerConfigFromFileTest to 2MB from 17 bytes. The roll-out does not work as expected in environments, and hence i am not testing for roll-out, this is a bug of the library, it usually rolls out when size is a lot greater than 17 bytes.
