### PR TITLE
Adding missing virtual destructors to abstract base classes

### DIFF
--- a/hazelcast/include/hazelcast/client/cluster/memberselector/MemberSelectors.h
+++ b/hazelcast/include/hazelcast/client/cluster/memberselector/MemberSelectors.h
@@ -51,6 +51,8 @@ namespace hazelcast {
                      * @return true if the member should take part in the operation, false otherwise
                      */
                     virtual bool select(const Member &member) const = 0;
+
+                    virtual ~MemberSelector(){};
                 };
 
                 /**

--- a/hazelcast/include/hazelcast/client/connection/AddressProvider.h
+++ b/hazelcast/include/hazelcast/client/connection/AddressProvider.h
@@ -34,6 +34,8 @@ namespace hazelcast {
                  * @return The possible member addresses to connect to.
                  */
                 virtual std::vector<Address> loadAddresses() = 0;
+
+                virtual ~AddressProvider(){};
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/flakeidgen/impl/AutoBatcher.h
+++ b/hazelcast/include/hazelcast/client/flakeidgen/impl/AutoBatcher.h
@@ -35,6 +35,8 @@ namespace hazelcast {
                     class IdBatchSupplier {
                     public:
                         virtual IdBatch newIdBatch(int32_t batchSize) = 0;
+
+                        virtual ~IdBatchSupplier(){};
                     };
 
                     AutoBatcher(int32_t batchSize, int64_t validity,

--- a/hazelcast/include/hazelcast/client/impl/Partition.h
+++ b/hazelcast/include/hazelcast/client/impl/Partition.h
@@ -51,6 +51,8 @@ namespace hazelcast {
                  * @return the owner member of the partition
                  */
                 virtual boost::shared_ptr<Member> getOwner() const = 0;
+
+                virtual ~Partition(){};
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/spi/EventHandler.h
+++ b/hazelcast/include/hazelcast/client/spi/EventHandler.h
@@ -53,6 +53,8 @@ namespace hazelcast {
                  *  and re-registering to a second node.
                  */
                 virtual void onListenerRegister() = 0;
+
+                virtual ~EventHandler(){};
             };
         }
     }


### PR DESCRIPTION
Following version compilers gave compile errors for these:

The C compiler identification is AppleClang 10.0.0.10001145
The CXX compiler identification is AppleClang 10.0.0.10001145