### PR TITLE
The ASSERT_EQ_EVENTUALLY macro expression may not compile with complex expressions

### DIFF
--- a/hazelcast/test/src/TestHelperFunctions.h
+++ b/hazelcast/test/src/TestHelperFunctions.h
@@ -23,7 +23,7 @@
 #define ASSERT_EQ_EVENTUALLY(expected, actual) do{              \
             bool result = false;                                \
             for(int i = 0 ; i < 120 * 5 && !result ; i++ ) {    \
-                if (expected == actual) {                       \
+                if ((expected) == actual) {                       \
                     result = true;                              \
                 } else {                                        \
                     util::sleepmillis(200);                     \
@@ -47,19 +47,6 @@
 
 #define WAIT_EQ_EVENTUALLY(expected, expression) WAIT_TRUE_EVENTUALLY(expected == expression)
 #define WAIT_NE_EVENTUALLY(expected, expression) WAIT_NE_EVENTUALLY(expected != expression)
-
-#define ASSERT_NE_EVENTUALLY(expected, actual) do{              \
-            bool result = false;                                \
-            for(int i = 0 ; i < 120 * 5 && !result ; i++ ) {    \
-                if (expected != actual) {                       \
-                    result = true;                              \
-                } else {                                        \
-                    util::sleepmillis(200);                     \
-                }                                               \
-            }                                                   \
-            ASSERT_TRUE(result);                                \
-      }while(0)                                                 \
-
 
 #define ASSERT_NULL(msg, value, type) ASSERT_EQ((type *) NULL, value) << msg
 #define ASSERT_NOTNULL(value, type) ASSERT_NE((type *) NULL, value)

--- a/hazelcast/test/src/TestHelperFunctions.h
+++ b/hazelcast/test/src/TestHelperFunctions.h
@@ -23,7 +23,7 @@
 #define ASSERT_EQ_EVENTUALLY(expected, actual) do{              \
             bool result = false;                                \
             for(int i = 0 ; i < 120 * 5 && !result ; i++ ) {    \
-                if ((expected) == actual) {                       \
+                if ((expected) == (actual)) {                       \
                     result = true;                              \
                 } else {                                        \
                     util::sleepmillis(200);                     \
@@ -45,8 +45,8 @@
             }                                                   \
       } while(0)                                                \
 
-#define WAIT_EQ_EVENTUALLY(expected, expression) WAIT_TRUE_EVENTUALLY(expected == expression)
-#define WAIT_NE_EVENTUALLY(expected, expression) WAIT_NE_EVENTUALLY(expected != expression)
+#define WAIT_EQ_EVENTUALLY(expected, expression) WAIT_TRUE_EVENTUALLY((expected) == (expression))
+#define WAIT_NE_EVENTUALLY(expected, expression) WAIT_NE_EVENTUALLY((expected) != (expression))
 
 #define ASSERT_NULL(msg, value, type) ASSERT_EQ((type *) NULL, value) << msg
 #define ASSERT_NOTNULL(value, type) ASSERT_NE((type *) NULL, value)


### PR DESCRIPTION
The ASSERT_EQ_EVENTUALLY macro expression evaluation works better if expression is evaluated using parenthesis since it is checked for equality with the == operand and without the extra parenthesis the equality may not work correctly depending on the expression.

Centos 7 Builds failed due to the following warning:

`ClientReplicatedMapListenerTest.cpp:161:125:[m[K [01;31m[Kerror: [m[Ksuggest parentheses around comparison in operand of ‘[01m[K==[m[K’ [-Werror=parentheses]
02:20:04                  ASSERT_TRUE_EVENTUALLY(listener->keys.size() == 1U && listener->keys.pop() == 1 && listener->addCount.get() == 1);`

Also removed the unused code ASSERT_NE_EVENTUALLY.