### PR TITLE
Add more tests for executor service `execute` methods for coverage

### DIFF
--- a/hazelcast/include/hazelcast/client/IExecutorService.h
+++ b/hazelcast/include/hazelcast/client/IExecutorService.h
@@ -77,7 +77,7 @@ namespace hazelcast {
              */
             template<typename HazelcastSerializable>
             void execute(const HazelcastSerializable &command) {
-                submit<HazelcastSerializable, void>(command);
+                submit<HazelcastSerializable, bool>(command);
             }
 
             /**
@@ -126,7 +126,7 @@ namespace hazelcast {
             template<typename HazelcastSerializable>
             void executeOnMembers(const HazelcastSerializable &command, const std::vector<Member> &members) {
                 for (std::vector<Member>::const_iterator it = members.begin(); it != members.end(); ++it) {
-                    submitToMember<HazelcastSerializable, void>(command, *it);
+                    submitToMember<HazelcastSerializable, bool>(command, *it);
                 }
             }
 
@@ -153,7 +153,7 @@ namespace hazelcast {
             void executeOnAllMembers(const HazelcastSerializable &command) {
                 std::vector<Member> memberList = getContext().getClientClusterService().getMemberList();
                 for (std::vector<Member>::const_iterator it = memberList.begin(); it != memberList.end(); ++it) {
-                    submitToMember<HazelcastSerializable, void>(command, *it);
+                    submitToMember<HazelcastSerializable, bool>(command, *it);
                 }
             }
 

--- a/hazelcast/test/src/TestHelperFunctions.h
+++ b/hazelcast/test/src/TestHelperFunctions.h
@@ -20,8 +20,7 @@
 #ifndef HAZELCAST_TestHelperFunctions
 #define HAZELCAST_TestHelperFunctions
 
-#define ASSERT_EQ_EVENTUALLY(expected, actual) ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT(expected, actual, 120)
-#define ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT(expected, actual, timeoutSeconds) do{              \
+#define ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT_MSG(message, expected, actual, timeoutSeconds) do{              \
             bool result = false;                                \
             for(int i = 0 ; i < timeoutSeconds * 5 && !result ; i++ ) {    \
                 if ((expected) == (actual)) {                       \
@@ -30,7 +29,7 @@
                     util::sleepmillis(200);                     \
                 }                                               \
             }                                                   \
-            ASSERT_TRUE(result);                                \
+            ASSERT_TRUE(result) << message;                     \
       }while(0)                                                 \
 
 #define WAIT_TRUE_EVENTUALLY(expression) do{                    \
@@ -38,6 +37,9 @@
                 util::sleepmillis(200);                         \
             }                                                   \
       }while(0)                                                 \
+
+#define ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT(expected, actual, timeoutSeconds) ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT_MSG("", expected, actual, timeoutSeconds)
+#define ASSERT_EQ_EVENTUALLY(expected, actual) ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT(expected, actual, 120)
 
 #define ASSERT_TRUE_ALL_THE_TIME(expression, seconds) do{       \
             for(int i = 0; i < seconds ; i++ ) {                \
@@ -55,5 +57,10 @@
 #define ASSERT_TRUE_EVENTUALLY_WITH_TIMEOUT(value, timeout) ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT(value, true, timeout)
 #define ASSERT_NULL_EVENTUALLY(value, type) ASSERT_EQ_EVENTUALLY((type *) NULL, value)
 #define ASSERT_OPEN_EVENTUALLY(latch) ASSERT_TRUE((latch).await(120))
+
+#define assertSizeEventually(expectedSize, container) assertSizeEventuallyWithTimeout(expectedSize, container, 120)
+#define assertSizeEventuallyWithTimeout(expectedSize, container, timeoutSeconds) do{  \
+    ASSERT_EQ_EVENTUALLY_WITH_TIMEOUT_MSG("the size of the map is not correct", expectedSize, (container).size(), timeoutSeconds);  \
+    } while(0)                                                                                                                      \
 
 #endif //HAZELCAST_TestHelperFunctions


### PR DESCRIPTION
Added more tests for executor service `execute` methods. Also, minor fix for not using void which is not serializable for the dummy template parameter.

Tests are adopted from Java ClientExecutorServiceExecuteTest.