### PR TITLE
Fix for failing to sync the proxy creation and destroy

### DIFF
--- a/hazelcast/src/hazelcast/client/proxy/ClientIdGeneratorProxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy/ClientIdGeneratorProxy.cpp
@@ -18,7 +18,7 @@
 namespace hazelcast {
     namespace client {
         namespace proxy {
-            const std::string ClientIdGeneratorProxy::SERVICE_NAME = "hz:impl:IdGeneratorService";
+            const std::string ClientIdGeneratorProxy::SERVICE_NAME = "hz:impl:idGeneratorService";
 
             ClientIdGeneratorProxy::ClientIdGeneratorProxy(const std::string &instanceName, spi::ClientContext *context)
                     : proxy::ProxyImpl(ClientIdGeneratorProxy::SERVICE_NAME, instanceName, context),

--- a/hazelcast/src/hazelcast/client/spi/ClientProxy.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ClientProxy.cpp
@@ -72,7 +72,7 @@ namespace hazelcast {
             void ClientProxy::destroyRemotely() {
                 std::auto_ptr<protocol::ClientMessage> clientMessage = protocol::codec::ClientDestroyProxyCodec::encodeRequest(
                         getName(), getServiceName());
-                spi::impl::ClientInvocation::create(getContext(), clientMessage, getName())->invoke().get();
+                spi::impl::ClientInvocation::create(getContext(), clientMessage, getName())->invoke()->get();
             }
 
             ClientProxy::EventHandlerDelegator::EventHandlerDelegator(client::impl::BaseEventHandler *handler) : handler(

--- a/hazelcast/src/hazelcast/client/spi/ProxyManager.cpp
+++ b/hazelcast/src/hazelcast/client/spi/ProxyManager.cpp
@@ -104,7 +104,7 @@ namespace hazelcast {
                         clientProxy->getName(),
                         clientProxy->getServiceName(), *initializationTarget);
                 spi::impl::ClientInvocation::create(client, clientMessage, clientProxy->getServiceName(),
-                                                    *initializationTarget)->invoke().get();
+                                                    *initializationTarget)->invoke()->get();
                 clientProxy->onInitialize();
             }
 


### PR DESCRIPTION
Fix for failing to sync the proxy creation and destroy. We called the wrong method and this was causing the tests that use proxy->destroy on test tear down which caused the cleanup incomplete and the following tests which depends on the destroyed proxy to fail.

Fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/379