### PR TITLE
Remove the SyncronizedMap usage from VectorClock

### DIFF
--- a/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
+++ b/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <stdint.h>
 #include <map>
+#include <vector>
 
 namespace hazelcast {
     namespace client {

--- a/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
+++ b/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
@@ -33,12 +33,14 @@ namespace hazelcast {
                  */
                 class VectorClock {
                 public:
+                    typedef std::vector<std::pair<std::string, int64_t> > TimestampVector;
+
                     VectorClock();
 
-                    VectorClock(const std::vector<std::pair<std::string, int64_t> > &replicaLogicalTimestamps);
+                    VectorClock(const TimestampVector &replicaLogicalTimestamps);
 
                     /** Returns a set of replica logical timestamps for this vector clock. */
-                    std::vector<std::pair<std::string, int64_t> > entrySet();
+                    TimestampVector entrySet();
 
                     /**
                      * Returns {@code true} if this vector clock is causally strictly after the

--- a/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
+++ b/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
@@ -19,8 +19,7 @@
 
 #include <string>
 #include <stdint.h>
-
-#include "hazelcast/util/SynchronizedMap.h"
+#include <map>
 
 namespace hazelcast {
     namespace client {
@@ -30,27 +29,13 @@ namespace hazelcast {
                  * Vector clock consisting of distinct replica logical clocks.
                  * <p>
                  * See https://en.wikipedia.org/wiki/Vector_clock
-                 * The vector clock may be read from different thread but concurrent
-                 * updates must be synchronized externally. There is no guarantee for
-                 * concurrent updates.
+                 * There is no guarantee for concurrent updates.
                  */
                 class VectorClock {
                 public:
                     VectorClock();
 
-                    /**
-                     * Returns logical timestamp for given {@code replicaId}.
-                     * This method may be called from different threads and the result reflects
-                     * the latest update on the vector clock.
-                     */
-                    boost::shared_ptr<int64_t> getTimestampForReplica(const std::string &replicaId);
-
-                    /**
-                     * Sets the logical timestamp for the given {@code replicaId}.
-                     * This method is not thread safe and concurrent access must be synchronized
-                     * externally.
-                     */
-                    void setReplicaTimestamp(const std::string &replicaId, int64_t timestamp);
+                    VectorClock(const std::vector<std::pair<std::string, int64_t> > &replicaLogicalTimestamps);
 
                     /** Returns a set of replica logical timestamps for this vector clock. */
                     std::vector<std::pair<std::string, int64_t> > entrySet();
@@ -59,13 +44,19 @@ namespace hazelcast {
                      * Returns {@code true} if this vector clock is causally strictly after the
                      * provided vector clock. This means that it the provided clock is neither
                      * equal to, greater than or concurrent to this vector clock.
-                     * This method may be called from different threads and the result reflects
-                     * the latest update on the vector clock.
                      */
                     bool isAfter(VectorClock &other);
 
                 private:
-                    util::SynchronizedMap<std::string, int64_t> replicaTimestamps;
+                    /**
+                     * Returns logical timestamp for given {@code replicaId}.
+                     * @return false for the pair.first if timestamp does not exist for replicaId,
+                     * otherwise returns true for pair.first and the timestamp of the replica as the pair.second.
+                     */
+                    std::pair<bool, int64_t> getTimestampForReplica(const std::string &replicaId);
+
+                    typedef std::map<std::string, int64_t> TimestampMap;
+                    TimestampMap replicaTimestamps;
                 };
             }
         }

--- a/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
+++ b/hazelcast/include/hazelcast/client/cluster/impl/VectorClock.h
@@ -60,6 +60,7 @@ namespace hazelcast {
 
                     typedef std::map<std::string, int64_t> TimestampMap;
                     TimestampMap replicaTimestamps;
+                    VectorClock::TimestampVector replicaTimestampEntries;
                 };
             }
         }

--- a/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
+++ b/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <utility>
 #include <boost/foreach.hpp>
-#include <set>
 
 #include "hazelcast/client/cluster/impl/VectorClock.h"
-#include "hazelcast/client/cluster/impl/ClusterDataSerializerHook.h"
-#include "hazelcast/client/serialization/ObjectDataInput.h"
 
 namespace hazelcast {
     namespace client {

--- a/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
+++ b/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
@@ -26,14 +26,15 @@ namespace hazelcast {
                 VectorClock::VectorClock() {}
 
                 VectorClock::VectorClock(const VectorClock::TimestampVector &replicaLogicalTimestamps) {
-                    BOOST_FOREACH(const TimestampVector::value_type &replicaTimestamp, replicaLogicalTimestamps) {
+                    BOOST_FOREACH(const VectorClock::TimestampVector::value_type &replicaTimestamp,
+                                  replicaLogicalTimestamps) {
                                     replicaTimestamps[replicaTimestamp.first] = replicaTimestamp.second;
                                 }
                 }
 
                 VectorClock::TimestampVector VectorClock::entrySet() {
-                    TimestampVector result;
-                    BOOST_FOREACH(const TimestampMap::value_type &entry, replicaTimestamps) {
+                    VectorClock::TimestampVector result;
+                    BOOST_FOREACH(const VectorClock::TimestampMap::value_type &entry, replicaTimestamps) {
                                     result.push_back(std::make_pair(entry.first, entry.second));
                     }
 
@@ -42,7 +43,7 @@ namespace hazelcast {
 
                 bool VectorClock::isAfter(VectorClock &other) {
                     bool anyTimestampGreater = false;
-                    BOOST_FOREACH(const TimestampMap::value_type &otherEntry, other.replicaTimestamps) {
+                    BOOST_FOREACH(const VectorClock::TimestampMap::value_type &otherEntry, other.replicaTimestamps) {
                         const std::string &replicaId = otherEntry.first;
                                     int64_t otherReplicaTimestamp = otherEntry.second;
                                     std::pair<bool, int64_t> localReplicaTimestamp = getTimestampForReplica(replicaId);

--- a/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
+++ b/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
@@ -25,7 +25,8 @@ namespace hazelcast {
 
                 VectorClock::VectorClock() {}
 
-                VectorClock::VectorClock(const VectorClock::TimestampVector &replicaLogicalTimestamps) {
+                VectorClock::VectorClock(const VectorClock::TimestampVector &replicaLogicalTimestamps)
+                        : replicaTimestampEntries(replicaLogicalTimestamps) {
                     BOOST_FOREACH(const VectorClock::TimestampVector::value_type &replicaTimestamp,
                                   replicaLogicalTimestamps) {
                                     replicaTimestamps[replicaTimestamp.first] = replicaTimestamp.second;
@@ -33,12 +34,7 @@ namespace hazelcast {
                 }
 
                 VectorClock::TimestampVector VectorClock::entrySet() {
-                    VectorClock::TimestampVector result;
-                    BOOST_FOREACH(const VectorClock::TimestampMap::value_type &entry, replicaTimestamps) {
-                                    result.push_back(std::make_pair(entry.first, entry.second));
-                    }
-
-                    return result;
+                    return replicaTimestampEntries;
                 }
 
                 bool VectorClock::isAfter(VectorClock &other) {
@@ -65,7 +61,6 @@ namespace hazelcast {
                     }
                     return std::make_pair(true, replicaTimestamps[replicaId]);
                 }
-
             }
         }
     }

--- a/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
+++ b/hazelcast/src/hazelcast/client/cluster/impl/VectorClock.cpp
@@ -24,19 +24,17 @@ namespace hazelcast {
     namespace client {
         namespace cluster {
             namespace impl {
-                typedef std::vector<std::pair<std::string, int64_t> > TimestampVector;
 
                 VectorClock::VectorClock() {}
 
-                VectorClock::VectorClock(
-                        const std::vector<std::pair<std::string, int64_t> > &replicaLogicalTimestamps) {
+                VectorClock::VectorClock(const VectorClock::TimestampVector &replicaLogicalTimestamps) {
                     BOOST_FOREACH(const TimestampVector::value_type &replicaTimestamp, replicaLogicalTimestamps) {
                                     replicaTimestamps[replicaTimestamp.first] = replicaTimestamp.second;
                                 }
                 }
 
-                std::vector<std::pair<std::string, int64_t> > VectorClock::entrySet() {
-                    std::vector<std::pair<std::string, int64_t> > result;
+                VectorClock::TimestampVector VectorClock::entrySet() {
+                    TimestampVector result;
                     BOOST_FOREACH(const TimestampMap::value_type &entry, replicaTimestamps) {
                                     result.push_back(std::make_pair(entry.first, entry.second));
                     }

--- a/hazelcast/src/hazelcast/client/proxy/ClientPNCounterProxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy/ClientPNCounterProxy.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <boost/foreach.hpp>
-
 #include "hazelcast/client/protocol/codec/PNCounterAddCodec.h"
 #include "hazelcast/client/protocol/codec/PNCounterGetConfiguredReplicaCountCodec.h"
 #include "hazelcast/client/cluster/memberselector/MemberSelectors.h"
@@ -331,13 +329,8 @@ namespace hazelcast {
 
             boost::shared_ptr<cluster::impl::VectorClock> ClientPNCounterProxy::toVectorClock(
                     const std::vector<std::pair<std::string, int64_t> > &replicaLogicalTimestamps) {
-                typedef std::vector<std::pair<std::string, int64_t> > TimestampVector;
-                boost::shared_ptr<cluster::impl::VectorClock> timestamps(new cluster::impl::VectorClock());
-                BOOST_FOREACH(const TimestampVector::value_type &replicaTimestamp, replicaLogicalTimestamps) {
-                                timestamps->setReplicaTimestamp(replicaTimestamp.first, replicaTimestamp.second);
-                            }
-
-                return timestamps;
+                return boost::shared_ptr<cluster::impl::VectorClock>(
+                        new cluster::impl::VectorClock(replicaLogicalTimestamps));
             }
 
             boost::shared_ptr<Address> ClientPNCounterProxy::getCurrentTargetReplicaAddress() {


### PR DESCRIPTION
Removed the SyncronizedMap usage from VectorClock.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/515