### PR TITLE
Add test for verifying that extended ascii utf-8 representation

### DIFF
--- a/hazelcast/test/src/map/ClientMapTest.cpp
+++ b/hazelcast/test/src/map/ClientMapTest.cpp
@@ -3397,6 +3397,16 @@ namespace hazelcast {
                 ASSERT_EQ(1U, result.size());
                 ASSERT_EQ(young, result[0]);
             }
+
+            TYPED_TEST(ClientMapTest, testExtendedAsciiString) {
+                std::string key = "Num\xc3\xa9ro key";
+                std::string value = "Num\xc3\xa9ro value";
+                ClientMapTest<TypeParam>::imap->put(key, value);
+
+                boost::shared_ptr<std::string> actualValue = ClientMapTest<TypeParam>::imap->get(key);
+
+                ASSERT_EQ_PTR(value, actualValue.get(), std::string);
+            }
         }
     }
 }

--- a/hazelcast/test/src/serialization/ClientSerializationTest.cpp
+++ b/hazelcast/test/src/serialization/ClientSerializationTest.cpp
@@ -741,11 +741,21 @@ namespace hazelcast {
                 serialization::pimpl::DataOutput dataOutput;
                 serialization::ObjectDataOutput out(dataOutput, &serializationService.getSerializerHolder());
 
-
                 out.writeUTF(&utfStr);
                 std::auto_ptr<std::vector<byte> > byteArray = out.toByteArray();
                 int strLen = util::Bits::readIntB(*byteArray, 0);
                 ASSERT_EQ(7, strLen);
+            }
+
+            TEST_F(ClientSerializationTest, testExtendedAscii) {
+                std::string utfStr = "Num\xc3\xa9ro";
+
+                SerializationConfig serializationConfig;
+                serialization::pimpl::SerializationService serializationService(serializationConfig);
+
+                serialization::pimpl::Data data = serializationService.toData<std::string>(&utfStr);
+                std::auto_ptr<std::string> deserializedString = serializationService.toObject<std::string>(data);
+                ASSERT_EQ_PTR(utfStr, deserializedString.get(), std::string);
             }
 
             TEST_F(ClientSerializationTest, testGlobalSerializer) {


### PR DESCRIPTION
Added test for verifying that extended ascii utf-8 representation works as expected.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/539