### PR TITLE
Add UTF-8 format validation for serialized and deserialized strings

### DIFF
--- a/hazelcast/include/hazelcast/client/proxy/ClientReplicatedMapProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/ClientReplicatedMapProxy.h
@@ -51,6 +51,11 @@
 #include "hazelcast/client/protocol/codec/ReplicatedMapEntrySetCodec.h"
 #include "hazelcast/client/protocol/codec/ReplicatedMapAddNearCacheEntryListenerCodec.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4250) //for warning class1' : inherits 'class2::member' via dominance
+#endif
+
 namespace hazelcast {
     namespace client {
         namespace proxy {
@@ -706,5 +711,9 @@ namespace hazelcast {
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_CLIENT_PROXY_CLIENTREPLICATEDMAPPROXY_H_

--- a/hazelcast/include/hazelcast/client/proxy/ClientRingbufferProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/ClientRingbufferProxy.h
@@ -35,6 +35,11 @@
 #include "hazelcast/util/Atomic.h"
 #include "hazelcast/client/Ringbuffer.h"
 
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4250) //for warning class1' : inherits 'class2::member' via dominance
+#endif
+
 namespace hazelcast {
     namespace client {
         class HazelcastClient;
@@ -315,6 +320,10 @@ namespace hazelcast {
         }
     }
 }
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
 
 #endif //HAZELCAST_CLIENT_PROXY_CLIENTRINGBUFFERPROXY_H_
 

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
@@ -41,13 +41,15 @@ namespace hazelcast {
     namespace client {
         namespace serialization {
             namespace pimpl {
-                class DataInput : public util::UTFUtil::ByteReadable {
+                class HAZELCAST_API DataInput : public util::UTFUtil::ByteReadable {
                 public:
                     static const int MAX_UTF_CHAR_SIZE = 4;
 
                     DataInput(const std::vector<byte> &buffer);
 
                     DataInput(const std::vector<byte> &buffer, int offset);
+
+                    virtual ~DataInput();
 
                     void readFully(std::vector<byte> &);
 

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/DataInput.h
@@ -18,12 +18,10 @@
 #ifndef HAZELCAST_DataInput
 #define HAZELCAST_DataInput
 
-#include "hazelcast/util/HazelcastDll.h"
 #include "hazelcast/util/ByteBuffer.h"
 #include "hazelcast/util/Bits.h"
 #include "hazelcast/client/exception/HazelcastSerializationException.h"
-
-#include <boost/smart_ptr/shared_ptr.hpp>
+#include "hazelcast/util/UTFUtil.h"
 
 #include <vector>
 #include <string>
@@ -43,8 +41,10 @@ namespace hazelcast {
     namespace client {
         namespace serialization {
             namespace pimpl {
-                class HAZELCAST_API DataInput {
+                class DataInput : public util::UTFUtil::ByteReadable {
                 public:
+                    static const int MAX_UTF_CHAR_SIZE = 4;
+
                     DataInput(const std::vector<byte> &buffer);
 
                     DataInput(const std::vector<byte> &buffer, int offset);
@@ -98,6 +98,7 @@ namespace hazelcast {
 
                 private:
                     const std::vector<byte> &buffer;
+                    std::vector<char> utfBuffer;
 
                     int pos;
 
@@ -134,8 +135,6 @@ namespace hazelcast {
                         }
                         return values;
                     }
-
-                    int getNumBytesForUtf8Char(const byte *start) const;
 
                     DataInput(const DataInput &);
 

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -27,7 +27,7 @@ namespace hazelcast {
     namespace util {
         class HAZELCAST_API UTFUtil {
         public:
-            class ByteReadable {
+            class HAZELCAST_API ByteReadable {
             public:
                 virtual ~ByteReadable();
 

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -52,7 +52,7 @@ namespace hazelcast {
              */
             static int32_t isValidUTF8(const std::string &str);
 
-            static void readUTF8Char(ByteReadable &in, byte c, std::vector<char> &utfBuffer);
+            static void readUTF8Char(ByteReadable &in, byte firstByte, std::vector<char> &utfBuffer);
 
         private:
             UTFUtil();

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -52,7 +52,7 @@ namespace hazelcast {
              */
             static int32_t isValidUTF8(const std::string &str);
 
-            static void readUTF8Char(ByteReadable &in, byte c, std::vector<char> &utfBuffer, size_t &index);
+            static void readUTF8Char(ByteReadable &in, byte c, std::vector<char> &utfBuffer);
 
         private:
             UTFUtil();

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -25,7 +25,7 @@
 
 namespace hazelcast {
     namespace util {
-        class UTFUtil {
+        class HAZELCAST_API UTFUtil {
         public:
             class ByteReadable {
             public:

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAZELCAST_UTIL_UTFUTIL_H_
+#define HAZELCAST_UTIL_UTFUTIL_H_
+
+#include <string>
+#include <vector>
+#include <stdint.h>
+
+#include "hazelcast/util/HazelcastDll.h"
+
+namespace hazelcast {
+    namespace util {
+        class UTFUtil {
+        public:
+            class ByteReadable {
+            public:
+                virtual byte readByte() = 0;
+            };
+
+            /**  UTF-8 Encoding
+            Number      Bits for        First           Last        Byte 1	    Byte 2	    Byte 3	    Byte 4
+            of bytes	code point      code point      code point
+
+            1	            7	        U+0000	        U+007F	    0xxxxxxx
+            2	            11	        U+0080	        U+07FF	    110xxxxx	10xxxxxx
+            3	            16	        U+0800	        U+FFFF	    1110xxxx	10xxxxxx	10xxxxxx
+            4	            21	        U+10000	        U+10FFFF	11110xxx	10xxxxxx	10xxxxxx	10xxxxxx
+            */
+
+            /**
+             *
+             *
+             * @param str The string whose UTF-8 byte format will be validated.
+             * @return The number of UTF-8 encoded bytes. Returns -1 if the format is incorrect.
+             */
+            static int32_t isValidUTF8(const std::string &str);
+
+            static void readUTF8Char(ByteReadable &in, byte c, std::vector<char> &utfBuffer, size_t &index);
+
+        private:
+            UTFUtil();
+
+            UTFUtil(const UTFUtil &);
+        };
+    }
+}
+#endif //HAZELCAST_UTIL_UTFUTIL_H_

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -29,6 +29,8 @@ namespace hazelcast {
         public:
             class ByteReadable {
             public:
+                virtual ~ByteReadable();
+
                 virtual byte readByte() = 0;
             };
 

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
@@ -152,14 +152,12 @@ namespace hazelcast {
                     } else {
                         utfBuffer.reserve((size_t) MAX_UTF_CHAR_SIZE * charCount);
                         byte b;
-                        size_t index = 0;
                         for (int i = 0; i < charCount; ++i) {
                             b = readByte();
-                            util::UTFUtil::readUTF8Char(*this, b, utfBuffer, index);
+                            util::UTFUtil::readUTF8Char(*this, b, utfBuffer);
                         }
 
-                        return std::auto_ptr<std::string>(
-                                new std::string(utfBuffer.begin(), utfBuffer.begin() + index));
+                        return std::auto_ptr<std::string>(new std::string(utfBuffer.begin(), utfBuffer.end()));
                     }
                 }
 

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
@@ -30,9 +30,7 @@ namespace hazelcast {
         namespace serialization {
             namespace pimpl {
 
-                DataInput::DataInput(const std::vector<byte> &buf)
-                :buffer(buf)
-                , pos(0) {
+                DataInput::DataInput(const std::vector<byte> &buf) : buffer(buf), pos(0) {
                 }
 
                 DataInput::DataInput(const std::vector<byte> &buf, int offset)
@@ -150,6 +148,7 @@ namespace hazelcast {
                     if (util::Bits::NULL_ARRAY == charCount) {
                         return std::auto_ptr<std::string>();
                     } else {
+                        utfBuffer.clear();
                         utfBuffer.reserve((size_t) MAX_UTF_CHAR_SIZE * charCount);
                         byte b;
                         for (int i = 0; i < charCount; ++i) {

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
@@ -39,6 +39,9 @@ namespace hazelcast {
                         : buffer(buf), pos(offset) {
                 }
 
+                DataInput::~DataInput() {
+                }
+
                 void DataInput::readFully(std::vector<byte> &bytes) {
                     size_t length = bytes.size();
                     checkAvailable(length);
@@ -152,11 +155,7 @@ namespace hazelcast {
                         size_t index = 0;
                         for (int i = 0; i < charCount; ++i) {
                             b = readByte();
-                            if (b < 0) {
-                                util::UTFUtil::readUTF8Char(*this, b, utfBuffer, index);
-                            } else {
-                                utfBuffer[index++] = (char) b;
-                            }
+                            util::UTFUtil::readUTF8Char(*this, b, utfBuffer, index);
                         }
 
                         return std::auto_ptr<std::string>(

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/DataInput.cpp
@@ -143,22 +143,24 @@ namespace hazelcast {
                 }
 
                 std::auto_ptr<std::string> DataInput::readUTF() {
-                    int32_t len = readInt();
-                    if (util::Bits::NULL_ARRAY == len) {
-                        return std::auto_ptr<std::string>(NULL);
+                    int32_t charCount = readInt();
+                    if (util::Bits::NULL_ARRAY == charCount) {
+                        return std::auto_ptr<std::string>();
                     } else {
-                        int numBytesToRead = 0;
-                        for (int i = 0; i < len ; ++i) {
-                            checkAvailable(1);
-                            int numBytesForChar = getNumBytesForUtf8Char(&buffer[pos] + numBytesToRead);
-                            numBytesToRead += numBytesForChar;
-                            checkAvailable(numBytesToRead);
+                        utfBuffer.reserve((size_t) MAX_UTF_CHAR_SIZE * charCount);
+                        byte b;
+                        size_t index = 0;
+                        for (int i = 0; i < charCount; ++i) {
+                            b = readByte();
+                            if (b < 0) {
+                                util::UTFUtil::readUTF8Char(*this, b, utfBuffer, index);
+                            } else {
+                                utfBuffer[index++] = (char) b;
+                            }
                         }
 
-                        const std::vector<unsigned char>::const_iterator start = buffer.begin() + pos;
-                        std::auto_ptr<std::string> result(new std::string(start, start + numBytesToRead));
-                        pos += numBytesToRead;
-                        return result;
+                        return std::auto_ptr<std::string>(
+                                new std::string(utfBuffer.begin(), utfBuffer.begin() + index));
                     }
                 }
 
@@ -299,32 +301,6 @@ namespace hazelcast {
                 template <>
                 double DataInput::read() {
                     return readDoubleUnchecked();
-                }
-
-                int DataInput::getNumBytesForUtf8Char(const byte *start) const {
-                    char first = *start;
-                    int b = first & 0xFF;
-                    switch (b >> 4) {
-                        case 0:
-                        case 1:
-                        case 2:
-                        case 3:
-                        case 4:
-                        case 5:
-                        case 6:
-                        case 7:
-                            return 1;
-                        case 12:
-                        case 13: {
-                            return 2;
-                        }
-                        case 14: {
-                            return 3;
-                        }
-                        default:
-                            throw exception::UTFDataFormatException("DataInput::getNumBytesForUtf8Char",
-                                                                    "Malformed byte sequence");
-                    }
                 }
             }
         }

--- a/hazelcast/src/hazelcast/util/UTFUtil.cpp
+++ b/hazelcast/src/hazelcast/util/UTFUtil.cpp
@@ -51,7 +51,7 @@ namespace hazelcast {
             return numberOfUtf8Chars;
         }
 
-        void UTFUtil::readUTF8Char(UTFUtil::ByteReadable &in, byte c, std::vector<char> &utfBuffer, size_t &index) {
+        void UTFUtil::readUTF8Char(UTFUtil::ByteReadable &in, byte c, std::vector<char> &utfBuffer) {
             size_t n = 0;
             //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
             if (c <= 0x7f) {
@@ -66,7 +66,7 @@ namespace hazelcast {
                 throw client::exception::UTFDataFormatException("Bits::readUTF8Char", "Malformed byte sequence");
             }
 
-            utfBuffer[index++] = (char) c;
+            utfBuffer.push_back((char) c);
             for (size_t j = 0; j < n; j++) {
                 byte b = in.readByte();
                 if (c == 0xed && (b & 0xa0) == 0xa0) {
@@ -77,7 +77,7 @@ namespace hazelcast {
                 if ((b & 0xC0) != 0x80) { // n bytes matching 10bbbbbb follow ?
                     throw client::exception::UTFDataFormatException("Bits::readUTF8Char", "Malformed byte sequence");
                 }
-                utfBuffer[index++] = (char) b;
+                utfBuffer.push_back((char) b);
             }
         }
 

--- a/hazelcast/src/hazelcast/util/UTFUtil.cpp
+++ b/hazelcast/src/hazelcast/util/UTFUtil.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hazelcast/util/UTFUtil.h"
+#include "hazelcast/client/exception/UTFDataFormatException.h"
+
+namespace hazelcast {
+    namespace util {
+        int32_t UTFUtil::isValidUTF8(const std::string &str) {
+            int32_t numberOfUtf8Chars = 0;
+            for (size_t i = 0, len = str.length(); i < len; ++i) {
+                unsigned char c = (unsigned char) str[i];
+                int32_t n = 0;
+                //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
+                if (0x00 <= c && c <= 0x7f) {
+                    n = 0; // 0bbbbbbb
+                } else if ((c & 0xE0) == 0xC0) {
+                    n = 1; // 110bbbbb
+                } else if (c == 0xed && i < (len - 1) && ((unsigned char) str[i + 1] & 0xa0) == 0xa0) {
+                    return -1; //U+d800 to U+dfff
+                } else if ((c & 0xF0) == 0xE0) {
+                    n = 2; // 1110bbbb
+                } else if ((c & 0xF8) == 0xF0) {
+                    n = 3; // 11110bbb
+                } else {
+                    return -1;
+                }
+
+                for (size_t j = 0; j < n && i < len; j++) { // n bytes matching 10bbbbbb follow ?
+                    if ((++i == len) || (((unsigned char) str[i] & 0xC0) != 0x80)) {
+                        return -1;
+                    }
+                }
+
+                ++numberOfUtf8Chars;
+            }
+
+            return numberOfUtf8Chars;
+        }
+
+        void UTFUtil::readUTF8Char(UTFUtil::ByteReadable &in, byte c, std::vector<char> &utfBuffer, size_t &index) {
+            int32_t n = 0;
+            //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
+            if (0x00 <= c && c <= 0x7f) {
+                n = 0; // 0bbbbbbb
+            } else if ((c & 0xE0) == 0xC0) {
+                n = 1; // 110bbbbb
+            } else if ((c & 0xF0) == 0xE0) {
+                n = 2; // 1110bbbb
+            } else if ((c & 0xF8) == 0xF0) {
+                n = 3; // 11110bbb
+            } else {
+                throw client::exception::UTFDataFormatException("Bits::readUTF8Char", "Malformed byte sequence");
+            }
+
+            utfBuffer[index++] = (char) c;
+            for (size_t j = 0; j < n; j++) {
+                byte b = in.readByte();
+                if (c == 0xed && (b & 0xa0) == 0xa0) {
+                    throw client::exception::UTFDataFormatException("Bits::readUTF8Char",
+                                                                    "Malformed byte sequence U+d800 to U+dfff"); //U+d800 to U+dfff
+                }
+
+                if ((b & 0xC0) != 0x80) { // n bytes matching 10bbbbbb follow ?
+                    throw client::exception::UTFDataFormatException("Bits::readUTF8Char", "Malformed byte sequence");
+                }
+                utfBuffer[index++] = (char) b;
+            }
+        }
+    }
+}

--- a/hazelcast/src/hazelcast/util/UTFUtil.cpp
+++ b/hazelcast/src/hazelcast/util/UTFUtil.cpp
@@ -23,9 +23,9 @@ namespace hazelcast {
             int32_t numberOfUtf8Chars = 0;
             for (size_t i = 0, len = str.length(); i < len; ++i) {
                 unsigned char c = (unsigned char) str[i];
-                int32_t n = 0;
+                size_t n = 0;
                 //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
-                if (0x00 <= c && c <= 0x7f) {
+                if (c <= 0x7f) {
                     n = 0; // 0bbbbbbb
                 } else if ((c & 0xE0) == 0xC0) {
                     n = 1; // 110bbbbb
@@ -52,9 +52,9 @@ namespace hazelcast {
         }
 
         void UTFUtil::readUTF8Char(UTFUtil::ByteReadable &in, byte c, std::vector<char> &utfBuffer, size_t &index) {
-            int32_t n = 0;
+            size_t n = 0;
             //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
-            if (0x00 <= c && c <= 0x7f) {
+            if (c <= 0x7f) {
                 n = 0; // 0bbbbbbb
             } else if ((c & 0xE0) == 0xC0) {
                 n = 1; // 110bbbbb

--- a/hazelcast/src/hazelcast/util/UTFUtil.cpp
+++ b/hazelcast/src/hazelcast/util/UTFUtil.cpp
@@ -80,5 +80,8 @@ namespace hazelcast {
                 utfBuffer[index++] = (char) b;
             }
         }
+
+        UTFUtil::ByteReadable::~ByteReadable() {
+        }
     }
 }

--- a/hazelcast/src/hazelcast/util/UTFUtil.cpp
+++ b/hazelcast/src/hazelcast/util/UTFUtil.cpp
@@ -24,7 +24,7 @@ namespace hazelcast {
             for (size_t i = 0, len = str.length(); i < len; ++i) {
                 unsigned char c = (unsigned char) str[i];
                 size_t n = 0;
-                //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
+                // is ascii
                 if (c <= 0x7f) {
                     n = 0; // 0bbbbbbb
                 } else if ((c & 0xE0) == 0xC0) {
@@ -51,25 +51,25 @@ namespace hazelcast {
             return numberOfUtf8Chars;
         }
 
-        void UTFUtil::readUTF8Char(UTFUtil::ByteReadable &in, byte c, std::vector<char> &utfBuffer) {
+        void UTFUtil::readUTF8Char(UTFUtil::ByteReadable &in, byte firstByte, std::vector<char> &utfBuffer) {
             size_t n = 0;
-            //if (c==0x09 || c==0x0a || c==0x0d || (0x20 <= c && c <= 0x7e) ) n = 0; // is_printable_ascii
-            if (c <= 0x7f) {
+            // ascii
+            if (firstByte <= 0x7f) {
                 n = 0; // 0bbbbbbb
-            } else if ((c & 0xE0) == 0xC0) {
+            } else if ((firstByte & 0xE0) == 0xC0) {
                 n = 1; // 110bbbbb
-            } else if ((c & 0xF0) == 0xE0) {
+            } else if ((firstByte & 0xF0) == 0xE0) {
                 n = 2; // 1110bbbb
-            } else if ((c & 0xF8) == 0xF0) {
+            } else if ((firstByte & 0xF8) == 0xF0) {
                 n = 3; // 11110bbb
             } else {
                 throw client::exception::UTFDataFormatException("Bits::readUTF8Char", "Malformed byte sequence");
             }
 
-            utfBuffer.push_back((char) c);
+            utfBuffer.push_back((char) firstByte);
             for (size_t j = 0; j < n; j++) {
                 byte b = in.readByte();
-                if (c == 0xed && (b & 0xa0) == 0xa0) {
+                if (firstByte == 0xed && (b & 0xa0) == 0xa0) {
                     throw client::exception::UTFDataFormatException("Bits::readUTF8Char",
                                                                     "Malformed byte sequence U+d800 to U+dfff"); //U+d800 to U+dfff
                 }

--- a/hazelcast/test/src/serialization/ClientSerializationTest.cpp
+++ b/hazelcast/test/src/serialization/ClientSerializationTest.cpp
@@ -758,6 +758,15 @@ namespace hazelcast {
                 ASSERT_EQ_PTR(utfStr, deserializedString.get(), std::string);
             }
 
+            TEST_F(ClientSerializationTest, testExtendedAsciiIncorrectUtf8Write) {
+                std::string utfStr = "Num\351ro";
+
+                SerializationConfig serializationConfig;
+                serialization::pimpl::SerializationService serializationService(serializationConfig);
+
+                ASSERT_THROW(serializationService.toData<std::string>(&utfStr), exception::UTFDataFormatException);
+            }
+
             TEST_F(ClientSerializationTest, testGlobalSerializer) {
                 SerializationConfig serializationConfig;
 

--- a/hazelcast/test/src/util/UTFUtilTest.cpp
+++ b/hazelcast/test/src/util/UTFUtilTest.cpp
@@ -87,8 +87,8 @@ namespace hazelcast {
                     size_t index = 0;
                     for (int i = 0; i < 5; ++i) {
                         byte c = in.readByte();
-                        if (i ==
-                            4) {  // The 4th utf character is missing one byte intentionally in the invalid utf string
+                        // The 4th utf character is missing one byte intentionally in the invalid utf string
+                        if (i == 4) {
                             ASSERT_THROW(hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index),
                                          exception::UTFDataFormatException);
                         } else {

--- a/hazelcast/test/src/util/UTFUtilTest.cpp
+++ b/hazelcast/test/src/util/UTFUtilTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <hazelcast/client/exception/IOException.h>
+#include <hazelcast/client/serialization/pimpl/DataInput.h>
+#include "hazelcast/util/UTFUtil.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            namespace util {
+                class UTFUtilTest : public ::testing::Test {
+                protected:
+                    // includes one, two three and 4 byte code points
+                    static const std::string VALID_UTF_STRING;
+
+                    static const std::string INVALID_UTF_STRING_INSUFFICIENT_BYTES;
+
+                    class ByteReader : public hazelcast::util::UTFUtil::ByteReadable {
+                    public:
+                        ByteReader(const std::string &value) : internalString(value) {
+                            it = internalString.begin();
+                        }
+
+                        virtual byte readByte() {
+                            if (it == internalString.end()) {
+                                throw exception::IOException("ByteReader::readByte", "End of string is reached!");
+                            }
+                            byte b = *it;
+                            ++it;
+                            return b;
+                        }
+
+                    private:
+                        std::string internalString;
+                        std::string::const_iterator it;
+                    };
+                };
+
+                const std::string UTFUtilTest::VALID_UTF_STRING = "a \xc3\xa9 \xe5\x92\xa7 \xf6\xa7\x93\xb5";
+                const std::string UTFUtilTest::INVALID_UTF_STRING_INSUFFICIENT_BYTES = "a \xc3\xa9 \xe5\x92 \xf6\xa7\x93\xb5";
+
+                TEST_F(UTFUtilTest, validUTF8) {
+                    ASSERT_GT(hazelcast::util::UTFUtil::isValidUTF8(VALID_UTF_STRING), 0);
+                }
+
+                TEST_F(UTFUtilTest, invalidUTF8) {
+                    ASSERT_EQ(-1, hazelcast::util::UTFUtil::isValidUTF8(INVALID_UTF_STRING_INSUFFICIENT_BYTES));
+                }
+
+                TEST_F(UTFUtilTest, readValidUTF8) {
+                    ByteReader in(VALID_UTF_STRING);
+                    std::vector<char> utfBuffer;
+                    utfBuffer.reserve(
+                            client::serialization::pimpl::DataInput::MAX_UTF_CHAR_SIZE * VALID_UTF_STRING.size());
+                    int numberOfUtfChars = hazelcast::util::UTFUtil::isValidUTF8(VALID_UTF_STRING);
+                    size_t index = 0;
+                    for (int i = 0; i < numberOfUtfChars; ++i) {
+                        byte c = in.readByte();
+                        hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index);
+                    }
+
+                    std::string result(utfBuffer.begin(), utfBuffer.begin() + index);
+                    ASSERT_EQ(VALID_UTF_STRING, result);
+                }
+
+                TEST_F(UTFUtilTest, readInvalidUTF8) {
+                    ByteReader in(INVALID_UTF_STRING_INSUFFICIENT_BYTES);
+                    std::vector<char> utfBuffer;
+                    utfBuffer.reserve(
+                            client::serialization::pimpl::DataInput::MAX_UTF_CHAR_SIZE * VALID_UTF_STRING.size());
+                    size_t index = 0;
+                    for (int i = 0; i < 5; ++i) {
+                        byte c = in.readByte();
+                        if (i ==
+                            4) {  // The 4th utf character is missing one byte intentionally in the invalid utf string
+                            ASSERT_THROW(hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index),
+                                         exception::UTFDataFormatException);
+                        } else {
+                            hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/test/src/util/UTFUtilTest.cpp
+++ b/hazelcast/test/src/util/UTFUtilTest.cpp
@@ -69,13 +69,12 @@ namespace hazelcast {
                     utfBuffer.reserve(
                             client::serialization::pimpl::DataInput::MAX_UTF_CHAR_SIZE * VALID_UTF_STRING.size());
                     int numberOfUtfChars = hazelcast::util::UTFUtil::isValidUTF8(VALID_UTF_STRING);
-                    size_t index = 0;
                     for (int i = 0; i < numberOfUtfChars; ++i) {
                         byte c = in.readByte();
-                        hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index);
+                        hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer);
                     }
 
-                    std::string result(utfBuffer.begin(), utfBuffer.begin() + index);
+                    std::string result(utfBuffer.begin(), utfBuffer.end());
                     ASSERT_EQ(VALID_UTF_STRING, result);
                 }
 
@@ -84,15 +83,14 @@ namespace hazelcast {
                     std::vector<char> utfBuffer;
                     utfBuffer.reserve(
                             client::serialization::pimpl::DataInput::MAX_UTF_CHAR_SIZE * VALID_UTF_STRING.size());
-                    size_t index = 0;
                     for (int i = 0; i < 5; ++i) {
                         byte c = in.readByte();
                         // The 4th utf character is missing one byte intentionally in the invalid utf string
                         if (i == 4) {
-                            ASSERT_THROW(hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index),
+                            ASSERT_THROW(hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer),
                                          exception::UTFDataFormatException);
                         } else {
-                            hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer, index);
+                            hazelcast::util::UTFUtil::readUTF8Char(in, c, utfBuffer);
                         }
                     }
                 }


### PR DESCRIPTION
Added UTF-8 format validation for serialized and deserialized strings We now provide exception to the user if the user supplies invalid utf-8 string.

related to https://github.com/hazelcast/hazelcast-cpp-client/issues/539