### PR TITLE
The authentication failure could not throw the expected IllegalStateException 

### DIFF
--- a/hazelcast/src/hazelcast/client/connection/ClientConnectionManagerImpl.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClientConnectionManagerImpl.cpp
@@ -708,9 +708,17 @@ namespace hazelcast {
                     }
                     case protocol::CREDENTIALS_FAILED: {
                         boost::shared_ptr<protocol::Principal> p = connectionManager.principal;
-                        onFailure((exception::ExceptionBuilder<exception::AuthenticationException>(
-                                "ConnectionManager::AuthCallback::onResponse") << "Invalid credentials! Principal: "
-                                                                               << *p).buildShared());
+                        boost::shared_ptr<exception::AuthenticationException> exception;
+                        if (p.get()) {
+                            exception = (exception::ExceptionBuilder<exception::AuthenticationException>(
+                                    "ConnectionManager::AuthCallback::onResponse") << "Invalid credentials! Principal: "
+                                                                                   << *p).buildShared();
+                        } else {
+                            exception.reset(new exception::AuthenticationException(
+                                    "ConnectionManager::AuthCallback::onResponse",
+                                    "Invalid credentials! No principal."));
+                        }
+                        onFailure(exception);
                         break;
                     }
                     default: {

--- a/hazelcast/test/src/cluster/ClientAuthenticationTest.cpp
+++ b/hazelcast/test/src/cluster/ClientAuthenticationTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This has to be the first include, so that Python.h is the first include. Otherwise, compilation warning such as
+ * "_POSIX_C_SOURCE" redefined occurs.
+ */
+#include "HazelcastServerFactory.h"
+
+#include "ClientTestSupport.h"
+#include "HazelcastServer.h"
+#include "hazelcast/client/HazelcastClient.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class ClientAuthenticationTest : public ClientTestSupport {
+            };
+
+            TEST_F(ClientAuthenticationTest, testIncorrectGroupName) {
+                HazelcastServer instance(*g_srvFactory);
+                ClientConfig config;
+                config.getGroupConfig().setName("invalid cluster");
+
+                ASSERT_THROW((HazelcastClient(config)), exception::IllegalStateException);
+            }
+        }
+    }
+}

--- a/hazelcast/test/src/cluster/ClientAuthenticationTest.cpp
+++ b/hazelcast/test/src/cluster/ClientAuthenticationTest.cpp
@@ -29,6 +29,14 @@ namespace hazelcast {
             class ClientAuthenticationTest : public ClientTestSupport {
             };
 
+            TEST_F(ClientAuthenticationTest, testSetGroupConfig) {
+                HazelcastServer instance(*g_srvFactory);
+                ClientConfig config;
+                config.setGroupConfig(GroupConfig("dev", "dev-pass"));
+
+                HazelcastClient client(config);
+            }
+
             TEST_F(ClientAuthenticationTest, testIncorrectGroupName) {
                 HazelcastServer instance(*g_srvFactory);
                 ClientConfig config;

--- a/hazelcast/test/src/cluster/ClusterTest.cpp
+++ b/hazelcast/test/src/cluster/ClusterTest.cpp
@@ -206,15 +206,6 @@ namespace hazelcast {
                 ASSERT_OPEN_EVENTUALLY(shutdownLatch);
             }
 
-            TEST_P(ClusterTest, testGroupConfig) {
-                ClientConfig &clientConfig = *const_cast<ParamType &>(GetParam());
-
-                std::auto_ptr<HazelcastServer> instance = startServer(clientConfig);
-
-                clientConfig.setGroupConfig(GroupConfig("dev", "dev-pass"));
-                HazelcastClient client(clientConfig);
-            }
-
             #ifdef HZ_BUILD_WITH_SSL
 
             INSTANTIATE_TEST_CASE_P(All,


### PR DESCRIPTION
Added a test and fix when the authentication fails we can compose the exceptıon properly when no credentials exist. Without the fix the log was trying to print a null object which causes shared_ptr dereference assertion.