### PR TITLE
Make HazelcastClientInstanceImpl accept const ClientConfig

### DIFF
--- a/hazelcast/include/hazelcast/client/ClientProperties.h
+++ b/hazelcast/include/hazelcast/client/ClientProperties.h
@@ -41,28 +41,21 @@ namespace hazelcast {
         */
         class HAZELCAST_API ClientProperty {
         public:
-            ClientProperty(ClientConfig& config, const std::string& name, const std::string& defaultValue);
+            ClientProperty(const std::string &name, const std::string &defaultValue);
 
-            std::string getName() const;
-
-            std::string getValue() const;
-
-            template <typename T>
-            T get() const {
-                return util::IOUtil::to_value<T>(value);
-            }
-
-            int getInteger() const;
-
-            bool getBoolean() const;
-
-            int64_t getLong() const;
+            const std::string &getName() const;
 
             const std::string &getDefaultValue() const;
 
+            /**
+             * Gets the system environment property value of the property.
+             *
+             * @return the value of the property. NULL if no such environment property exist.
+             */
+            const char *getSystemProperty() const;
+
         private:
             std::string name;
-            std::string value;
             std::string defaultValue;
         };
 
@@ -74,7 +67,7 @@ namespace hazelcast {
         */
         class HAZELCAST_API ClientProperties {
         public:
-            ClientProperties(ClientConfig& clientConfig);
+            ClientProperties(const std::map<std::string, std::string> &properties);
 
             const ClientProperty& getHeartbeatTimeout() const;
 
@@ -244,6 +237,37 @@ namespace hazelcast {
             static const std::string STATISTICS_PERIOD_SECONDS;
             static const std::string STATISTICS_PERIOD_SECONDS_DEFAULT;
 
+            /**
+             * Returns the configured boolean value of a {@link ClientProperty}.
+             *
+             * @param property the {@link ClientProperty} to get the value from
+             * @return the value as bool
+             */
+            bool getBoolean(const ClientProperty &property) const;
+
+            /**
+             * Returns the configured int32_t value of a {@link ClientProperty}.
+             *
+             * @param property the {@link ClientProperty} to get the value from
+             * @return the value as int32_t
+             */
+            int32_t getInteger(const ClientProperty &property) const;
+
+            /**
+             * Returns the configured int64_t value of a {@link ClientProperty}.
+             *
+             * @param property the {@link ClientProperty} to get the value from
+             * @return the value as int64_t
+             */
+            int64_t getLong(const ClientProperty &property) const;
+
+            /**
+             * Returns the configured value of a {@link ClientProperty} as std::string.
+             *
+             * @param property the {@link ClientProperty} to get the value from
+             * @return the value
+             */
+            std::string getString(const ClientProperty &property) const;
 
         private:
             ClientProperty heartbeatTimeout;
@@ -262,6 +286,8 @@ namespace hazelcast {
             ClientProperty backpressureBackoffTimeoutMillis;
             ClientProperty statisticsEnabled;
             ClientProperty statisticsPeriodSeconds;
+
+            std::map<std::string, std::string> propertiesMap;
         };
 
     }

--- a/hazelcast/include/hazelcast/client/HazelcastClient.h
+++ b/hazelcast/include/hazelcast/client/HazelcastClient.h
@@ -399,7 +399,7 @@ namespace hazelcast {
             * Note: ClientConfig will be copied.
             * @param config client configuration to start the client with
             */
-            HazelcastClient(ClientConfig &config);
+            HazelcastClient(const ClientConfig &config);
 
             /**
              * Returns the name of this Hazelcast instance.

--- a/hazelcast/include/hazelcast/client/impl/AbstractLoadBalancer.h
+++ b/hazelcast/include/hazelcast/client/impl/AbstractLoadBalancer.h
@@ -40,7 +40,9 @@ namespace hazelcast {
             public:
                 AbstractLoadBalancer();
 
-                AbstractLoadBalancer(AbstractLoadBalancer &rhs);
+                AbstractLoadBalancer(const AbstractLoadBalancer &rhs);
+
+                void operator=(const AbstractLoadBalancer &rhs);
 
                 void setMembersRef();
 

--- a/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
+++ b/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
@@ -122,7 +122,7 @@ namespace hazelcast {
                 * Note: ClientConfig will be copied.
                 * @param config client configuration to start the client with
                 */
-                HazelcastClientInstanceImpl(ClientConfig &config);
+                HazelcastClientInstanceImpl(const ClientConfig &config);
 
                 /**
                 * Destructor

--- a/hazelcast/include/hazelcast/client/impl/RoundRobinLB.h
+++ b/hazelcast/include/hazelcast/client/impl/RoundRobinLB.h
@@ -40,6 +40,8 @@ namespace hazelcast {
             public:
                 RoundRobinLB();
 
+                void operator=(const RoundRobinLB &rhs);
+
                 RoundRobinLB(const RoundRobinLB &rhs);
 
                 void init(Cluster &cluster);

--- a/hazelcast/include/hazelcast/util/SynchronizedMap.h
+++ b/hazelcast/include/hazelcast/util/SynchronizedMap.h
@@ -46,6 +46,10 @@ namespace hazelcast {
             }
 
             SynchronizedMap(const SynchronizedMap<K, V, Comparator> &rhs) {
+                *this = rhs;
+            }
+
+            void operator=(const SynchronizedMap<K, V, Comparator> &rhs) {
                 util::LockGuard lg(mapLock);
                 util::LockGuard lgRhs(rhs.mapLock);
                 internalMap = rhs.internalMap;

--- a/hazelcast/src/hazelcast/client/HazelcastClient.cpp
+++ b/hazelcast/src/hazelcast/client/HazelcastClient.cpp
@@ -31,7 +31,7 @@
 
 namespace hazelcast {
     namespace client {
-        HazelcastClient::HazelcastClient(ClientConfig &config) : clientImpl(
+        HazelcastClient::HazelcastClient(const ClientConfig &config) : clientImpl(
                 new impl::HazelcastClientInstanceImpl(config)) {
         }
 

--- a/hazelcast/src/hazelcast/client/connection/ClientConnectionManagerImpl.cpp
+++ b/hazelcast/src/hazelcast/client/connection/ClientConnectionManagerImpl.cpp
@@ -84,7 +84,8 @@ namespace hazelcast {
 
                 clusterConnectionExecutor = createSingleThreadExecutorService(client);
 
-                shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+                ClientProperties &clientProperties = client.getClientProperties();
+                shuffleMemberList = clientProperties.getBoolean(clientProperties.getShuffleMemberList());
 
                 ClientConnectionManagerImpl::addressProviders = addressProviders;
 

--- a/hazelcast/src/hazelcast/client/connection/HeartbeatManager.cpp
+++ b/hazelcast/src/hazelcast/client/connection/HeartbeatManager.cpp
@@ -29,11 +29,11 @@ namespace hazelcast {
             HeartbeatManager::HeartbeatManager(spi::ClientContext &client) : client(client), clientConnectionManager(
                     client.getConnectionManager()), logger(client.getLogger()) {
                 ClientProperties &clientProperties = client.getClientProperties();
-                int timeoutSeconds = clientProperties.getHeartbeatTimeout().getInteger();
+                int timeoutSeconds = clientProperties.getInteger(clientProperties.getHeartbeatTimeout());
                 heartbeatTimeout = timeoutSeconds > 0 ? timeoutSeconds * 1000 : util::IOUtil::to_value<int>(
                         (std::string) ClientProperties::PROP_HEARTBEAT_TIMEOUT_DEFAULT) * 1000;
 
-                int intervalSeconds = clientProperties.getHeartbeatInterval().getInteger();
+                int intervalSeconds = clientProperties.getInteger(clientProperties.getHeartbeatInterval());
                 heartbeatInterval = intervalSeconds > 0 ? intervalSeconds * 1000 : util::IOUtil::to_value<int>(
                         (std::string) ClientProperties::PROP_HEARTBEAT_INTERVAL_DEFAULT) * 1000;
             }

--- a/hazelcast/src/hazelcast/client/impl/AbstractLoadBalancer.cpp
+++ b/hazelcast/src/hazelcast/client/impl/AbstractLoadBalancer.cpp
@@ -24,8 +24,13 @@
 namespace hazelcast {
     namespace client {
         namespace impl {
-            AbstractLoadBalancer::AbstractLoadBalancer(AbstractLoadBalancer &rhs) {
-                util::LockGuard lg(rhs.membersLock);
+            AbstractLoadBalancer::AbstractLoadBalancer(const AbstractLoadBalancer &rhs) {
+                *this = rhs;
+            }
+
+            void AbstractLoadBalancer::operator=(const AbstractLoadBalancer &rhs) {
+                util::LockGuard lg(const_cast<util::Mutex &>(rhs.membersLock));
+                util::LockGuard lg2(membersLock);
                 membersRef = rhs.membersRef;
                 cluster = rhs.cluster;
             }

--- a/hazelcast/src/hazelcast/client/impl/RoundRobinLB.cpp
+++ b/hazelcast/src/hazelcast/client/impl/RoundRobinLB.cpp
@@ -40,6 +40,10 @@ namespace hazelcast {
             RoundRobinLB::RoundRobinLB(const RoundRobinLB &rhs) : index(const_cast<RoundRobinLB &>(rhs).index.get()) {
             }
 
+            void RoundRobinLB::operator=(const RoundRobinLB &rhs) {
+                index.set(const_cast<RoundRobinLB &>(rhs).index.get());
+            }
+
         }
     }
 }

--- a/hazelcast/src/hazelcast/client/impl/statistics/Statistics.cpp
+++ b/hazelcast/src/hazelcast/client/impl/statistics/Statistics.cpp
@@ -42,7 +42,7 @@ namespace hazelcast {
                                                                                     clientContext.getClientProperties()),
                                                                             logger(clientContext.getLogger()),
                                                                             periodicStats(*this) {
-                    this->enabled = clientProperties.getStatisticsEnabled().getBoolean();
+                    this->enabled = clientProperties.getBoolean(clientProperties.getStatisticsEnabled());
                 }
 
                 void Statistics::start() {
@@ -50,7 +50,7 @@ namespace hazelcast {
                         return;
                     }
 
-                    int64_t periodSeconds = clientProperties.getStatisticsPeriodSeconds().getLong();
+                    int64_t periodSeconds = clientProperties.getLong(clientProperties.getStatisticsPeriodSeconds());
                     if (periodSeconds <= 0) {
 
                         int64_t defaultValue = util::IOUtil::to_value<int64_t>(

--- a/hazelcast/src/hazelcast/client/spi/impl/AbstractClientInvocationService.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/AbstractClientInvocationService.cpp
@@ -32,10 +32,10 @@ namespace hazelcast {
                           connectionManager(NULL),
                           partitionService(client.getPartitionService()),
                           clientListenerService(NULL),
-                          invocationTimeoutMillis(
-                                  client.getClientProperties().getInvocationTimeoutSeconds().getInteger() * 1000),
-                          invocationRetryPauseMillis(
-                                  client.getClientProperties().getInvocationRetryPauseMillis().getLong()),
+                          invocationTimeoutMillis(client.getClientProperties().getInteger(
+                                  client.getClientProperties().getInvocationTimeoutSeconds()) * 1000),
+                          invocationRetryPauseMillis(client.getClientProperties().getLong(
+                                  client.getClientProperties().getInvocationRetryPauseMillis())),
                           responseThread(client.getName() + ".response-", invocationLogger, *this, client) {
                 }
 
@@ -45,7 +45,7 @@ namespace hazelcast {
 
                     responseThread.start();
 
-                    int64_t cleanResourcesMillis = CLEAN_RESOURCES_MILLIS.getLong();
+                    int64_t cleanResourcesMillis = client.getClientProperties().getLong(CLEAN_RESOURCES_MILLIS);
                     if (cleanResourcesMillis <= 0) {
                         cleanResourcesMillis = util::IOUtil::to_value<int64_t>(
                                 CLEAN_RESOURCES_MILLIS.getDefaultValue());

--- a/hazelcast/src/hazelcast/client/spi/impl/ClientExecutionServiceImpl.cpp
+++ b/hazelcast/src/hazelcast/client/spi/impl/ClientExecutionServiceImpl.cpp
@@ -35,7 +35,7 @@ namespace hazelcast {
                                                                        int32_t poolSize, util::ILogger &logger)
                         : logger(logger) {
 
-                    int internalPoolSize = clientProperties.getInternalExecutorPoolSize().getInteger();
+                    int internalPoolSize = clientProperties.getInteger(clientProperties.getInternalExecutorPoolSize());
                     if (internalPoolSize <= 0) {
                         internalPoolSize = util::IOUtil::to_value<int>(
                                 ClientProperties::INTERNAL_EXECUTOR_POOL_SIZE_DEFAULT);

--- a/hazelcast/test/src/ClientTestSupportBase.cpp
+++ b/hazelcast/test/src/ClientTestSupportBase.cpp
@@ -29,14 +29,12 @@ namespace hazelcast {
                 return "hazelcast/test/resources/cpp_client.crt";
             }
 
-            std::auto_ptr<hazelcast::client::ClientConfig> ClientTestSupportBase::getConfig() {
-                std::auto_ptr<hazelcast::client::ClientConfig> clientConfig(new ClientConfig());
-                return clientConfig;
+            hazelcast::client::ClientConfig ClientTestSupportBase::getConfig() {
+                return ClientConfig();
             }
 
-            std::auto_ptr<HazelcastClient> ClientTestSupportBase::getNewClient() {
-                std::auto_ptr<HazelcastClient> result(new HazelcastClient(*getConfig()));
-                return result;
+            HazelcastClient ClientTestSupportBase::getNewClient() {
+                return HazelcastClient(getConfig());
             }
 
             const std::string ClientTestSupportBase::getSslFilePath() {

--- a/hazelcast/test/src/ClientTestSupportBase.h
+++ b/hazelcast/test/src/ClientTestSupportBase.h
@@ -56,9 +56,9 @@ namespace hazelcast {
                 static std::string generateKeyOwnedBy(spi::ClientContext &context, const Member &member);
             protected:
 
-                static std::auto_ptr<hazelcast::client::ClientConfig> getConfig();
+                static hazelcast::client::ClientConfig getConfig();
 
-                static std::auto_ptr<HazelcastClient> getNewClient();
+                static HazelcastClient getNewClient();
 
                 static const std::string getSslFilePath();
 

--- a/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
+++ b/hazelcast/test/src/adaptor/RawPointerMapTest.cpp
@@ -132,13 +132,13 @@ namespace hazelcast {
                         instance2 = new HazelcastServer(*g_srvFactory);
                         #endif
 
-                        clientConfig = getConfig().release();
+                        ClientConfig clientConfig = getConfig();
                         #ifdef HZ_BUILD_WITH_SSL
                         config::SSLConfig sslConfig;
                         sslConfig.setEnabled(true).setProtocol(config::tlsv1).addVerifyFile(getCAFilePath());
-                        clientConfig->getNetworkConfig().setSSLConfig(sslConfig);
+                        clientConfig.getNetworkConfig().setSSLConfig(sslConfig);
                         #endif // HZ_BUILD_WITH_SSL
-                        client = new HazelcastClient(*clientConfig);
+                        client = new HazelcastClient(clientConfig);
                     }
 
                     static void TearDownTestCase() {
@@ -149,7 +149,6 @@ namespace hazelcast {
                         delete imap;
                         delete legacyMap;
                         delete client;
-                        delete clientConfig;
                         delete instance2;
                         delete instance;
                         delete sslFactory;
@@ -161,7 +160,6 @@ namespace hazelcast {
                         imap = NULL;
                         legacyMap = NULL;
                         client = NULL;
-                        clientConfig = NULL;
                         instance2 = NULL;
                         instance = NULL;
                     }
@@ -178,7 +176,6 @@ namespace hazelcast {
 
                     static HazelcastServer *instance;
                     static HazelcastServer *instance2;
-                    static ClientConfig *clientConfig;
                     static HazelcastClient *client;
                     static client::adaptor::RawPointerMap<std::string, std::string> *imap;
                     static IMap<std::string, std::string> *legacyMap;
@@ -191,7 +188,6 @@ namespace hazelcast {
 
                 HazelcastServer *RawPointerMapTest::instance = NULL;
                 HazelcastServer *RawPointerMapTest::instance2 = NULL;
-                ClientConfig *RawPointerMapTest::clientConfig = NULL;
                 HazelcastClient *RawPointerMapTest::client = NULL;
                 IMap<std::string, std::string> *RawPointerMapTest::legacyMap = NULL;
                 client::adaptor::RawPointerMap<std::string, std::string> *RawPointerMapTest::imap = NULL;

--- a/hazelcast/test/src/atomiclong/IAtomicLongTest.cpp
+++ b/hazelcast/test/src/atomiclong/IAtomicLongTest.cpp
@@ -48,7 +48,7 @@ namespace hazelcast {
                 }
 
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
                 std::auto_ptr<IAtomicLong> l;
 
                 static HazelcastServer *instance;
@@ -57,7 +57,7 @@ namespace hazelcast {
             HazelcastServer *IAtomicLongTest::instance = NULL;
 
             IAtomicLongTest::IAtomicLongTest() : client(getNewClient()),
-                                                 l(new IAtomicLong(client->getIAtomicLong(getTestName()))) {
+                                                 l(new IAtomicLong(client.getIAtomicLong(getTestName()))) {
                 l->set(0);
             }
 

--- a/hazelcast/test/src/cluster/ClientConnectionTest.cpp
+++ b/hazelcast/test/src/cluster/ClientConnectionTest.cpp
@@ -68,26 +68,26 @@ namespace hazelcast {
             TEST_F(ClientConnectionTest, testSSLWrongCAFilePath) {
                 HazelcastServerFactory sslFactory(getSslFilePath());
                 HazelcastServer instance(sslFactory);
-                std::auto_ptr<ClientConfig> config = getConfig();
-                config->getNetworkConfig().getSSLConfig().setEnabled(true).addVerifyFile("abc");
-                ASSERT_THROW(HazelcastClient client(*config), exception::IllegalStateException);
+                ClientConfig config = getConfig();
+                config.getNetworkConfig().getSSLConfig().setEnabled(true).addVerifyFile("abc");
+                ASSERT_THROW(HazelcastClient client(config), exception::IllegalStateException);
             }
 
             TEST_F(ClientConnectionTest, testExcludedCipher) {
                 HazelcastServerFactory sslFactory(getSslFilePath());
                 HazelcastServer instance(sslFactory);
 
-                std::auto_ptr<ClientConfig> config = getConfig();
-                config->getNetworkConfig().getSSLConfig().setEnabled(true).addVerifyFile(getCAFilePath()).setCipherList(
+                ClientConfig config = getConfig();
+                config.getNetworkConfig().getSSLConfig().setEnabled(true).addVerifyFile(getCAFilePath()).setCipherList(
                         "HIGH");
-                std::vector<internal::socket::SSLSocket::CipherInfo> supportedCiphers = getCiphers(*config);
+                std::vector<internal::socket::SSLSocket::CipherInfo> supportedCiphers = getCiphers(config);
 
                 std::string unsupportedCipher = supportedCiphers[0].name;
                 config = getConfig();
-                config->getNetworkConfig().getSSLConfig().setEnabled(true).addVerifyFile(getCAFilePath()).
+                config.getNetworkConfig().getSSLConfig().setEnabled(true).addVerifyFile(getCAFilePath()).
                         setCipherList(std::string("HIGH:!") + unsupportedCipher);
 
-                std::vector<internal::socket::SSLSocket::CipherInfo> newCiphers = getCiphers(*config);
+                std::vector<internal::socket::SSLSocket::CipherInfo> newCiphers = getCiphers(config);
 
                 ASSERT_EQ(supportedCiphers.size() - 1, newCiphers.size());
 

--- a/hazelcast/test/src/cluster/HeartbeatTest.cpp
+++ b/hazelcast/test/src/cluster/HeartbeatTest.cpp
@@ -31,10 +31,10 @@ namespace hazelcast {
 
             TEST_F(HeartbeatTest, testPing) {
                 HazelcastServer instance(*g_srvFactory);
-                std::auto_ptr<ClientConfig> config = getConfig();
-                config->setProperty("hazelcast_client_heartbeat_interval", "1");
+                ClientConfig config = getConfig();
+                config.setProperty("hazelcast_client_heartbeat_interval", "1");
 
-                HazelcastClient client(*config);
+                HazelcastClient client(config);
 
                 // sleep enough time so that the client ping is sent to the server
                 util::sleep(3);

--- a/hazelcast/test/src/cluster/MemberAttributeTest.cpp
+++ b/hazelcast/test/src/cluster/MemberAttributeTest.cpp
@@ -46,8 +46,8 @@ namespace hazelcast {
             TEST_F(MemberAttributeTest, testInitialValues) {
                 HazelcastServer instance(*g_srvFactory);
                 ASSERT_TRUE(instance.setAttributes(0));
-                std::auto_ptr<HazelcastClient> hazelcastClient(getNewClient());
-                Cluster cluster = hazelcastClient->getCluster();
+                HazelcastClient hazelcastClient(getNewClient());
+                Cluster cluster = hazelcastClient.getCluster();
                 std::vector<Member> members = cluster.getMembers();
                 ASSERT_EQ(1U,members.size());
                 Member &member = members[0];
@@ -139,11 +139,11 @@ namespace hazelcast {
                 util::CountDownLatch attributeLatch(7);
                 AttributeListener sampleListener(attributeLatch);
 
-                std::auto_ptr<ClientConfig> clientConfig(getConfig());
-                clientConfig->addListener(&sampleListener);
+                ClientConfig clientConfig(getConfig());
+                clientConfig.addListener(&sampleListener);
 
                 HazelcastServer instance(*g_srvFactory);
-                HazelcastClient hazelcastClient(*clientConfig);
+                HazelcastClient hazelcastClient(clientConfig);
 
                 HazelcastServer instance2(*g_srvFactory);
                 ASSERT_TRUE(instance2.setAttributes(1));

--- a/hazelcast/test/src/cluster/SocketInterceptorTest.cpp
+++ b/hazelcast/test/src/cluster/SocketInterceptorTest.cpp
@@ -51,25 +51,25 @@ namespace hazelcast {
             TEST_F(SocketInterceptorTest, interceptSSLBasic) {
                 HazelcastServerFactory sslFactory(getSslFilePath());
                 HazelcastServer instance(sslFactory);
-                std::auto_ptr<ClientConfig> config = getConfig();
+                ClientConfig config = getConfig();
                 util::CountDownLatch interceptorLatch(1);
                 MySocketInterceptor interceptor(interceptorLatch);
-                config->setSocketInterceptor(&interceptor);
+                config.setSocketInterceptor(&interceptor);
                 config::SSLConfig sslConfig;
                 sslConfig.setEnabled(true).addVerifyFile(getCAFilePath());
-                config->getNetworkConfig().setSSLConfig(sslConfig);
-                HazelcastClient client(*config);
+                config.getNetworkConfig().setSSLConfig(sslConfig);
+                HazelcastClient client(config);
                 interceptorLatch.await(2);
             }
             #endif
 
             TEST_F(SocketInterceptorTest, interceptBasic) {
                 HazelcastServer instance(*g_srvFactory);
-                std::auto_ptr<ClientConfig> config = getConfig();
+                ClientConfig config = getConfig();
                 util::CountDownLatch interceptorLatch(1);
                 MySocketInterceptor interceptor(interceptorLatch);
-                config->setSocketInterceptor(&interceptor);
-                HazelcastClient client(*config);
+                config.setSocketInterceptor(&interceptor);
+                HazelcastClient client(config);
                 interceptorLatch.await(2);
             }
         }

--- a/hazelcast/test/src/countdownlatch/ICountDownLatchTest.cpp
+++ b/hazelcast/test/src/countdownlatch/ICountDownLatchTest.cpp
@@ -36,14 +36,13 @@ namespace hazelcast {
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
                 std::auto_ptr<ICountDownLatch> l;
             };
 
             ICountDownLatchTest::ICountDownLatchTest()
             : instance(*g_srvFactory)
-            , client(getNewClient())
-            , l(new ICountDownLatch(client->getICountDownLatch("ICountDownLatchTest"))) {
+            , client(getNewClient()), l(new ICountDownLatch(client.getICountDownLatch("ICountDownLatchTest"))) {
             }
 
             ICountDownLatchTest::~ICountDownLatchTest() {

--- a/hazelcast/test/src/faulttolerance/LoadTest.cpp
+++ b/hazelcast/test/src/faulttolerance/LoadTest.cpp
@@ -40,10 +40,10 @@ namespace hazelcast {
             namespace faulttolerance {
                 class LoadTest : public ClientTestSupport {
                 public:
-                    std::auto_ptr<hazelcast::client::ClientConfig> getLoadTestConfig() {
-                        std::auto_ptr<ClientConfig> config = ClientTestSupport::getConfig();
-                        config->setRedoOperation(true);
-                        config->setLogLevel(FINEST);
+                    hazelcast::client::ClientConfig getLoadTestConfig() {
+                        ClientConfig config = ClientTestSupport::getConfig();
+                        config.setRedoOperation(true);
+                        config.setLogLevel(FINEST);
                         return config;
                     }
 
@@ -147,17 +147,17 @@ namespace hazelcast {
                 }
 
                 TEST_F(LoadTest, DISABLED_testIntMapSmartClientServerRestart) {
-                    std::auto_ptr<ClientConfig> config = getLoadTestConfig();
-                    config->setSmart(true);
+                    ClientConfig config = getLoadTestConfig();
+                    config.setSmart(true);
 
-                    loadIntMapTestWithConfig(*config, *this);
+                    loadIntMapTestWithConfig(config, *this);
                 }
 
                 TEST_F(LoadTest, DISABLED_testIntMapDummyClientServerRestart) {
-                    std::auto_ptr<ClientConfig> config = getLoadTestConfig();
-                    config->setSmart(false);
+                    ClientConfig config = getLoadTestConfig();
+                    config.setSmart(false);
 
-                    loadIntMapTestWithConfig(*config, *this);
+                    loadIntMapTestWithConfig(config, *this);
                 }
             }
         }

--- a/hazelcast/test/src/flakeidgen/FlakeIdGeneratorApiTest.cpp
+++ b/hazelcast/test/src/flakeidgen/FlakeIdGeneratorApiTest.cpp
@@ -40,21 +40,19 @@ namespace hazelcast {
 
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
-                    clientConfig = getConfig().release();
+                    ClientConfig clientConfig = getConfig();
                     boost::shared_ptr<config::ClientFlakeIdGeneratorConfig> flakeIdConfig(
                             new config::ClientFlakeIdGeneratorConfig("test*"));
                     flakeIdConfig->setPrefetchCount(10).setPrefetchValidityMillis(20000);
-                    clientConfig->addFlakeIdGeneratorConfig(flakeIdConfig);
-                    client = new HazelcastClient(*clientConfig);
+                    clientConfig.addFlakeIdGeneratorConfig(flakeIdConfig);
+                    client = new HazelcastClient(clientConfig);
                 }
 
                 static void TearDownTestCase() {
                     delete client;
-                    delete clientConfig;
                     delete instance;
 
                     client = NULL;
-                    clientConfig = NULL;
                     instance = NULL;
                 }
 
@@ -86,14 +84,12 @@ namespace hazelcast {
                 };
 
                 static HazelcastServer *instance;
-                static ClientConfig *clientConfig;
                 static HazelcastClient *client;
 
                 FlakeIdGenerator flakeIdGenerator;
             };
 
             HazelcastServer *FlakeIdGeneratorApiTest::instance = NULL;
-            ClientConfig *FlakeIdGeneratorApiTest::clientConfig = NULL;
             HazelcastClient *FlakeIdGeneratorApiTest::client = NULL;
 
             TEST_F (FlakeIdGeneratorApiTest, testStartingValue) {

--- a/hazelcast/test/src/idgenerator/IdGeneratorTest.cpp
+++ b/hazelcast/test/src/idgenerator/IdGeneratorTest.cpp
@@ -37,15 +37,14 @@ namespace hazelcast {
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
                 std::auto_ptr<IdGenerator> generator;
 
             };
 
             IdGeneratorTest::IdGeneratorTest()
             : instance(*g_srvFactory)
-            , client(getNewClient())
-            , generator(new IdGenerator(client->getIdGenerator("clientIdGenerator"))) {
+            , client(getNewClient()), generator(new IdGenerator(client.getIdGenerator("clientIdGenerator"))) {
             }
 
             TEST_F (IdGeneratorTest, testGenerator) {

--- a/hazelcast/test/src/issues/IssueTest.cpp
+++ b/hazelcast/test/src/issues/IssueTest.cpp
@@ -87,11 +87,11 @@ namespace hazelcast {
                 HazelcastServer hz1(*g_srvFactory);
                 HazelcastServer hz2(*g_srvFactory);
 
-                std::auto_ptr<ClientConfig> clientConfig(getConfig());
-                clientConfig->setRedoOperation(true);
-                clientConfig->setSmart(false);
+                ClientConfig clientConfig(getConfig());
+                clientConfig.setRedoOperation(true);
+                clientConfig.setSmart(false);
 
-                HazelcastClient client(*clientConfig);
+                HazelcastClient client(clientConfig);
 
                 client::IMap<int, int> map = client.getMap<int, int>("m");
                 util::StartedThread *thread = NULL;
@@ -111,10 +111,10 @@ namespace hazelcast {
                 HazelcastServer server(*g_srvFactory);
 
                 // 2. Start a client
-                std::auto_ptr<ClientConfig> clientConfig(getConfig());
-                clientConfig->setConnectionAttemptLimit(10);
+                ClientConfig clientConfig(getConfig());
+                clientConfig.setConnectionAttemptLimit(10);
 
-                HazelcastClient client(*clientConfig);
+                HazelcastClient client(clientConfig);
 
                 // 3. Get a map
                 IMap<int, int> map = client.getMap<int, int>("IssueTest_map");
@@ -152,8 +152,8 @@ namespace hazelcast {
                 HazelcastServer server(*g_srvFactory);
 
                 // start a client
-                std::auto_ptr<ClientConfig> config = getConfig();
-                HazelcastClient client(*config);
+                ClientConfig config = getConfig();
+                HazelcastClient client(config);
 
                 IMap<int, int> map = client.getMap<int, int>("Issue221_test_map");
 

--- a/hazelcast/test/src/list/ClientListTest.cpp
+++ b/hazelcast/test/src/list/ClientListTest.cpp
@@ -71,42 +71,38 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     #endif
 
-                    clientConfig = getConfig().release();
+                    ClientConfig clientConfig = getConfig();
 
                     #ifdef HZ_BUILD_WITH_SSL
                     config::ClientNetworkConfig networkConfig;
                     config::SSLConfig sslConfig;
                     sslConfig.setEnabled(true).addVerifyFile(getCAFilePath()).setCipherList("HIGH");
                     networkConfig.setSSLConfig(sslConfig);
-                    clientConfig->setNetworkConfig(networkConfig);
+                    clientConfig.setNetworkConfig(networkConfig);
                     #endif // HZ_BUILD_WITH_SSL
 
-                    client = new HazelcastClient(*clientConfig);
+                    client = new HazelcastClient(clientConfig);
                     list = new IList<std::string>(client->getList<std::string>("MyList"));
                 }
 
                 static void TearDownTestCase() {
                     delete list;
                     delete client;
-                    delete clientConfig;
                     delete instance;
                     delete sslFactory;
 
                     list = NULL;
                     client = NULL;
-                    clientConfig = NULL;
                     instance = NULL;
                 }
 
                 static HazelcastServer *instance;
-                static ClientConfig *clientConfig;
                 static HazelcastClient *client;
                 static IList<std::string> *list;
                 static HazelcastServerFactory *sslFactory;
             };
 
             HazelcastServer *ClientListTest::instance = NULL;
-            ClientConfig *ClientListTest::clientConfig = NULL;
             HazelcastClient *ClientListTest::client = NULL;
             IList<std::string> *ClientListTest::list = NULL;
             HazelcastServerFactory *ClientListTest::sslFactory = NULL;

--- a/hazelcast/test/src/list/MixedListTest.cpp
+++ b/hazelcast/test/src/list/MixedListTest.cpp
@@ -66,42 +66,38 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     #endif
 
-                    clientConfig = getConfig().release();
+                    ClientConfig clientConfig = getConfig();
 
                     #ifdef HZ_BUILD_WITH_SSL
                     config::ClientNetworkConfig networkConfig;
                     config::SSLConfig sslConfig;
                     sslConfig.setEnabled(true).addVerifyFile(getCAFilePath()).setCipherList("HIGH");
                     networkConfig.setSSLConfig(sslConfig);
-                    clientConfig->setNetworkConfig(networkConfig);
+                    clientConfig.setNetworkConfig(networkConfig);
                     #endif // HZ_BUILD_WITH_SSL
 
-                    client = new HazelcastClient(*clientConfig);
+                    client = new HazelcastClient(clientConfig);
                     list = new mixedtype::IList(client->toMixedType().getList("MyMixedList"));
                 }
 
                 static void TearDownTestCase() {
                     delete list;
                     delete client;
-                    delete clientConfig;
                     delete instance;
                     delete sslFactory;
 
                     list = NULL;
                     client = NULL;
-                    clientConfig = NULL;
                     instance = NULL;
                 }
 
                 static HazelcastServer *instance;
-                static ClientConfig *clientConfig;
                 static HazelcastClient *client;
                 static mixedtype::IList *list;
                 static HazelcastServerFactory *sslFactory;
             };
 
             HazelcastServer *MixedListTest::instance = NULL;
-            ClientConfig *MixedListTest::clientConfig = NULL;
             HazelcastClient *MixedListTest::client = NULL;
             mixedtype::IList *MixedListTest::list = NULL;
             HazelcastServerFactory *MixedListTest::sslFactory = NULL;

--- a/hazelcast/test/src/nearcache/BasicClientNearCacheTest.cpp
+++ b/hazelcast/test/src/nearcache/BasicClientNearCacheTest.cpp
@@ -171,15 +171,15 @@ namespace hazelcast {
 
                 void createNoNearCacheContext() {
                     clientConfig = getConfig();
-                    client = std::auto_ptr<HazelcastClient>(new HazelcastClient(*clientConfig));
+                    client = std::auto_ptr<HazelcastClient>(new HazelcastClient(clientConfig));
                     noNearCacheMap = std::auto_ptr<IMap<int, std::string> >(
                             new IMap<int, std::string>(client->getMap<int, std::string>(getTestName())));
                 }
 
                 void createNearCacheContext() {
                     nearCachedClientConfig = getConfig();
-                    nearCachedClientConfig->addNearCacheConfig(nearCacheConfig);
-                    nearCachedClient = std::auto_ptr<HazelcastClient>(new HazelcastClient(*nearCachedClientConfig));
+                    nearCachedClientConfig.addNearCacheConfig(nearCacheConfig);
+                    nearCachedClient = std::auto_ptr<HazelcastClient>(new HazelcastClient(nearCachedClientConfig));
                     nearCachedMap = std::auto_ptr<IMap<int, std::string> >(new IMap<int, std::string>(
                             nearCachedClient->getMap<int, std::string>(getTestName())));
                     spi::ClientContext clientContext(*nearCachedClient);
@@ -320,8 +320,8 @@ namespace hazelcast {
                     ASSERT_EQ(0, nearCache->size()) << "Invalidation is not working on putAll()";
                 }
 
-                std::auto_ptr<ClientConfig> clientConfig;
-                std::auto_ptr<ClientConfig> nearCachedClientConfig;
+                ClientConfig clientConfig;
+                ClientConfig nearCachedClientConfig;
                 boost::shared_ptr<config::NearCacheConfig<int, std::string> > nearCacheConfig;
                 std::auto_ptr<HazelcastClient> client;
                 std::auto_ptr<HazelcastClient> nearCachedClient;

--- a/hazelcast/test/src/replicatedmap/nearcache/BasicClientReplicatedMapNearCacheTest.cpp
+++ b/hazelcast/test/src/replicatedmap/nearcache/BasicClientReplicatedMapNearCacheTest.cpp
@@ -171,14 +171,14 @@ namespace hazelcast {
 
                 void createNoNearCacheContext() {
                     clientConfig = getConfig();
-                    client = std::auto_ptr<HazelcastClient>(new HazelcastClient(*clientConfig));
+                    client = std::auto_ptr<HazelcastClient>(new HazelcastClient(clientConfig));
                     noNearCacheMap = client->getReplicatedMap<int, std::string>(getTestName());
                 }
 
                 void createNearCacheContext() {
                     nearCachedClientConfig = getConfig();
-                    nearCachedClientConfig->addNearCacheConfig(nearCacheConfig);
-                    nearCachedClient = std::auto_ptr<HazelcastClient>(new HazelcastClient(*nearCachedClientConfig));
+                    nearCachedClientConfig.addNearCacheConfig(nearCacheConfig);
+                    nearCachedClient = std::auto_ptr<HazelcastClient>(new HazelcastClient(nearCachedClientConfig));
                     nearCachedMap = nearCachedClient->getReplicatedMap<int, std::string>(getTestName());
                     spi::ClientContext clientContext(*nearCachedClient);
                     nearCacheManager = &clientContext.getNearCacheManager();
@@ -319,8 +319,8 @@ namespace hazelcast {
                     ASSERT_EQ(0, nearCache->size()) << "Invalidation is not working on putAll()";
                 }
 
-                std::auto_ptr<ClientConfig> clientConfig;
-                std::auto_ptr<ClientConfig> nearCachedClientConfig;
+                ClientConfig clientConfig;
+                ClientConfig nearCachedClientConfig;
                 boost::shared_ptr<config::NearCacheConfig<int, std::string> > nearCacheConfig;
                 std::auto_ptr<HazelcastClient> client;
                 std::auto_ptr<HazelcastClient> nearCachedClient;

--- a/hazelcast/test/src/topic/ClientTopicTest.cpp
+++ b/hazelcast/test/src/topic/ClientTopicTest.cpp
@@ -37,14 +37,12 @@ namespace hazelcast {
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
                 ITopic<std::string> topic;
             };
 
-            ClientTopicTest::ClientTopicTest()
-            : instance(*g_srvFactory)
-            , client(getNewClient())
-            , topic(client->getTopic<std::string>("ClientTopicTest")) {
+            ClientTopicTest::ClientTopicTest() : instance(*g_srvFactory), client(getNewClient()),
+                                                 topic(client.getTopic<std::string>("ClientTopicTest")) {
             }
 
             class MyMessageListener : public topic::MessageListener<std::string> {

--- a/hazelcast/test/src/topic/MixedTopicTest.cpp
+++ b/hazelcast/test/src/topic/MixedTopicTest.cpp
@@ -37,14 +37,14 @@ namespace hazelcast {
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
                 mixedtype::ITopic topic;
             };
 
 
             MixedTopicTest::MixedTopicTest()
                     : instance(*g_srvFactory), client(getNewClient()),
-                      topic(client->toMixedType().getTopic("MixedTopicTest")) {
+                      topic(client.toMixedType().getTopic("MixedTopicTest")) {
             }
 
             class MyMessageListener : public mixedtype::topic::MessageListener {

--- a/hazelcast/test/src/txn/ClientTxnListTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnListTest.cpp
@@ -42,22 +42,20 @@ namespace hazelcast {
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
             };
 
-            ClientTxnListTest::ClientTxnListTest()
-            : instance(*g_srvFactory)
-            , client(getNewClient()) {
+            ClientTxnListTest::ClientTxnListTest() : instance(*g_srvFactory), client(getNewClient()) {
             }
 
             ClientTxnListTest::~ClientTxnListTest() {
             }
 
             TEST_F(ClientTxnListTest, testAddRemove) {
-                IList<std::string> l = client->getList<std::string>("testAddRemove");
+                IList<std::string> l = client.getList<std::string>("testAddRemove");
                 l.add("item1");
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalList<std::string> list = context.getList<std::string>("testAddRemove");
                 ASSERT_TRUE(list.add("item2"));

--- a/hazelcast/test/src/txn/ClientTxnMapTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnMapTest.cpp
@@ -40,12 +40,10 @@ namespace hazelcast {
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
             };
 
-            ClientTxnMapTest::ClientTxnMapTest()
-            : instance(*g_srvFactory)
-            , client(getNewClient()) {
+            ClientTxnMapTest::ClientTxnMapTest() : instance(*g_srvFactory), client(getNewClient()) {
             }
             
             ClientTxnMapTest::~ClientTxnMapTest() {
@@ -54,32 +52,32 @@ namespace hazelcast {
             TEST_F(ClientTxnMapTest, testPutGet) {
                 std::string name = "testPutGet";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
 
                 ASSERT_EQ(map.put("key1", "value1").get(), (std::string *)NULL);
                 ASSERT_EQ("value1", *(map.get("key1")));
-                boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
+                boost::shared_ptr<std::string> val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 context.commitTransaction();
 
-                ASSERT_EQ("value1", *(client->getMap<std::string, std::string>(name).get("key1")));
+                ASSERT_EQ("value1", *(client.getMap<std::string, std::string>(name).get("key1")));
             }
 
             TEST_F(ClientTxnMapTest, testRemove) {
                 std::string name = "testRemove";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
 
                 ASSERT_EQ(map.put("key1", "value1").get(), (std::string *)NULL);
                 ASSERT_EQ("value1", *(map.get("key1")));
-                boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
+                boost::shared_ptr<std::string> val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_EQ((std::string *)NULL, map.remove("key2").get());
@@ -89,21 +87,21 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                IMap <std::string, std::string> regularMap = client->getMap<std::string, std::string>(name);
+                IMap<std::string, std::string> regularMap = client.getMap<std::string, std::string>(name);
                 ASSERT_TRUE(regularMap.isEmpty());
             }
 
             TEST_F(ClientTxnMapTest, testRemoveIfSame) {
                 std::string name = "testRemoveIfSame";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
 
                 ASSERT_EQ(map.put("key1", "value1").get(), (std::string *)NULL);
                 ASSERT_EQ("value1", *(map.get("key1")));
-                boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
+                boost::shared_ptr<std::string> val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_EQ((std::string *)NULL, map.remove("key2").get());
@@ -111,14 +109,14 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                IMap <std::string, std::string> regularMap = client->getMap<std::string, std::string>(name);
+                IMap<std::string, std::string> regularMap = client.getMap<std::string, std::string>(name);
                 ASSERT_TRUE(regularMap.isEmpty());
             }
 
             TEST_F(ClientTxnMapTest, testDeleteEntry) {
                 std::string name = "testDeleteEntry";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
@@ -127,7 +125,7 @@ namespace hazelcast {
 
                 ASSERT_EQ(map.put("key1", "value1").get(), (std::string *)NULL);
                 ASSERT_EQ("value1", *(map.get("key1")));
-                boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
+                boost::shared_ptr<std::string> val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_NO_THROW(map.deleteEntry("key1"));
@@ -136,34 +134,34 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                IMap <std::string, std::string> regularMap = client->getMap<std::string, std::string>(name);
+                IMap<std::string, std::string> regularMap = client.getMap<std::string, std::string>(name);
                 ASSERT_TRUE(regularMap.isEmpty());
             }
 
             TEST_F(ClientTxnMapTest, testReplace) {
                 std::string name = "testReplace";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
 
                 ASSERT_EQ(map.put("key1", "value1").get(), (std::string *)NULL);
                 ASSERT_EQ("value1", *(map.get("key1")));
-                boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
+                boost::shared_ptr<std::string> val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_EQ("value1", *map.replace("key1", "myNewValue"));
 
                 context.commitTransaction();
 
-                ASSERT_EQ("myNewValue", *(client->getMap<std::string, std::string>(name).get("key1")));
+                ASSERT_EQ("myNewValue", *(client.getMap<std::string, std::string>(name).get("key1")));
             }
 
             TEST_F(ClientTxnMapTest, testSet) {
                 std::string name = "testSet";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
@@ -174,7 +172,7 @@ namespace hazelcast {
                 ASSERT_NE((std::string *)NULL, val.get());
                 ASSERT_EQ("value1", *val);
 
-                val = client->getMap<std::string, std::string>(name).get("key1");
+                val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_NO_THROW(map.set("key1", "myNewValue"));
@@ -185,7 +183,7 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                val = client->getMap<std::string, std::string>(name).get("key1");
+                val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_NE((std::string *)NULL, val.get());
                 ASSERT_EQ("myNewValue", *val);
             }
@@ -193,7 +191,7 @@ namespace hazelcast {
             TEST_F(ClientTxnMapTest, testContains) {
                 std::string name = "testContains";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
@@ -210,21 +208,21 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                IMap <std::string, std::string> regularMap = client->getMap<std::string, std::string>(name);
+                IMap<std::string, std::string> regularMap = client.getMap<std::string, std::string>(name);
                 ASSERT_TRUE(regularMap.containsKey("key1"));
             }
 
             TEST_F(ClientTxnMapTest, testReplaceIfSame) {
                 std::string name = "testReplaceIfSame";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
 
                 ASSERT_EQ(map.put("key1", "value1").get(), (std::string *)NULL);
                 ASSERT_EQ("value1", *(map.get("key1")));
-                boost::shared_ptr<std::string> val = client->getMap<std::string, std::string>(name).get("key1");
+                boost::shared_ptr<std::string> val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 ASSERT_FALSE(map.replace("key1", "valueNonExistent", "myNewValue"));
@@ -232,13 +230,13 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                ASSERT_EQ("myNewValue", *(client->getMap<std::string, std::string>(name).get("key1")));
+                ASSERT_EQ("myNewValue", *(client.getMap<std::string, std::string>(name).get("key1")));
             }
 
             TEST_F(ClientTxnMapTest, testPutIfSame) {
                 std::string name = "testPutIfSame";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
@@ -248,7 +246,7 @@ namespace hazelcast {
                 val = map.get("key1");
                 ASSERT_NE((std::string *)NULL, val.get());
                 ASSERT_EQ("value1", *val);
-                val = client->getMap<std::string, std::string>(name).get("key1");
+                val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_EQ(val.get(), (std::string *)NULL);
 
                 val = map.putIfAbsent("key1", "value1");
@@ -257,7 +255,7 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                val = client->getMap<std::string, std::string>(name).get("key1");
+                val = client.getMap<std::string, std::string>(name).get("key1");
                 ASSERT_NE((std::string *)NULL, val.get());
                 ASSERT_EQ("value1", *val);
             }
@@ -301,11 +299,11 @@ namespace hazelcast {
 
             TEST_F(ClientTxnMapTest, testKeySetValues) {
                 std::string name = "testKeySetValues";
-                IMap<std::string, std::string> map = client->getMap<std::string, std::string>(name);
+                IMap<std::string, std::string> map = client.getMap<std::string, std::string>(name);
                 map.put("key1", "value1");
                 map.put("key2", "value2");
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalMap<std::string, std::string> txMap = context.getMap<std::string, std::string>(name);
                 ASSERT_EQ(txMap.put("key3", "value3").get(), (std::string *)NULL);
@@ -324,14 +322,14 @@ namespace hazelcast {
 
             TEST_F(ClientTxnMapTest, testKeySetAndValuesWithPredicates) {
                 std::string name = "testKeysetAndValuesWithPredicates";
-                IMap<Employee, Employee> map = client->getMap<Employee, Employee>(name);
+                IMap<Employee, Employee> map = client.getMap<Employee, Employee>(name);
 
                 Employee emp1("abc-123-xvz", 34);
                 Employee emp2("abc-123-xvz", 20);
 
                 map.put(emp1, emp1);
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<Employee, Employee> txMap = context.getMap<Employee, Employee>(name);
@@ -355,7 +353,7 @@ namespace hazelcast {
             TEST_F(ClientTxnMapTest, testIsEmpty) {
                 std::string name = "testIsEmpty";
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
 
                 TransactionalMap<std::string, std::string> map = context.getMap<std::string, std::string>(name);
@@ -369,7 +367,7 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                IMap <std::string, std::string> regularMap = client->getMap<std::string, std::string>(name);
+                IMap<std::string, std::string> regularMap = client.getMap<std::string, std::string>(name);
                 ASSERT_FALSE(regularMap.isEmpty());
             }
 

--- a/hazelcast/test/src/txn/ClientTxnMultiMapTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnMultiMapTest.cpp
@@ -24,7 +24,6 @@
 #include "ClientTestSupport.h"
 #include "HazelcastServer.h"
 
-#include "hazelcast/client/ClientConfig.h"
 #include "hazelcast/client/HazelcastClient.h"
 
 namespace hazelcast {
@@ -79,8 +78,7 @@ namespace hazelcast {
                 };
 
                 HazelcastServer instance;
-                ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
             };
 
             ClientTxnMultiMapTest::ClientTxnMultiMapTest()
@@ -91,7 +89,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientTxnMultiMapTest, testRemoveIfExists) {
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalMultiMap<std::string, std::string> multiMap = context.getMultiMap<std::string, std::string>(
                         "testRemoveIfExists");
@@ -109,13 +107,13 @@ namespace hazelcast {
 
                 context.commitTransaction();
 
-                MultiMap<std::string, std::string> mm = client->getMultiMap<std::string, std::string>(
+                MultiMap<std::string, std::string> mm = client.getMultiMap<std::string, std::string>(
                         "testRemoveIfExists");
                 ASSERT_EQ(2, (int) mm.get(key).size());
             }
 
             TEST_F(ClientTxnMultiMapTest, testPutGetRemove) {
-                MultiMap<std::string, std::string> mm = client->getMultiMap<std::string, std::string>(
+                MultiMap<std::string, std::string> mm = client.getMultiMap<std::string, std::string>(
                         "testPutGetRemove");
                 int n = 10;
                 util::CountDownLatch latch(n);
@@ -124,8 +122,8 @@ namespace hazelcast {
                 for (int i = 0; i < n; i++) {
                     boost::shared_ptr<util::Thread> t(
                             new util::Thread(
-                                    boost::shared_ptr<util::Runnable>(new PutGetRemoveTestTask(*client, mm, latch)),
-                                            getLogger()));
+                                    boost::shared_ptr<util::Runnable>(new PutGetRemoveTestTask(client, mm, latch)),
+                                    getLogger()));
                     t->start();
                     allThreads.push_back(t);
                 }

--- a/hazelcast/test/src/txn/ClientTxnQueueTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnQueueTest.cpp
@@ -38,13 +38,10 @@ namespace hazelcast {
                     ~ClientTxnQueueTest();
                 protected:
                     HazelcastServer instance;
-                    ClientConfig clientConfig;
-                    std::auto_ptr<HazelcastClient> client;
+                    HazelcastClient client;
                 };
 
-            ClientTxnQueueTest::ClientTxnQueueTest()
-            : instance(*g_srvFactory)
-            , client(getNewClient()) {
+                ClientTxnQueueTest::ClientTxnQueueTest() : instance(*g_srvFactory), client(getNewClient()) {
             }
             
             ClientTxnQueueTest::~ClientTxnQueueTest() {
@@ -53,7 +50,7 @@ namespace hazelcast {
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPoll1) {
                 std::string name = "defQueue";
 
-                TransactionContext context = client->newTransactionContext();
+                    TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalQueue<std::string> q = context.getQueue<std::string>(name);
                 ASSERT_TRUE(q.offer("ali"));
@@ -61,13 +58,13 @@ namespace hazelcast {
                 ASSERT_EQ("ali", *(q.poll()));
                 ASSERT_EQ(0, q.size());
                 context.commitTransaction();
-                ASSERT_EQ(0, client->getQueue<std::string>(name).size());
+                    ASSERT_EQ(0, client.getQueue<std::string>(name).size());
             }
 
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPollByteVector) {
                 std::string name = "defQueue";
 
-                TransactionContext context = client->newTransactionContext();
+                    TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalQueue<std::vector<byte> > q = context.getQueue<std::vector<byte> >(name);
                 std::vector<byte> value(3);
@@ -76,7 +73,7 @@ namespace hazelcast {
                 ASSERT_EQ(value, *(q.poll()));
                 ASSERT_EQ(0, q.size());
                 context.commitTransaction();
-                ASSERT_EQ(0, client->getQueue<std::vector<byte> >(name).size());
+                    ASSERT_EQ(0, client.getQueue<std::vector<byte> >(name).size());
             }
 
             void testTransactionalOfferPoll2Thread(util::ThreadArgs& args) {
@@ -88,8 +85,8 @@ namespace hazelcast {
 
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPoll2) {
                 util::CountDownLatch latch(1);
-                util::StartedThread t(testTransactionalOfferPoll2Thread, &latch, client.get());
-                TransactionContext context = client->newTransactionContext();
+                    util::StartedThread t(testTransactionalOfferPoll2Thread, &latch, &client);
+                    TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalQueue<std::string> q0 = context.getQueue<std::string>("defQueue0");
                 TransactionalQueue<std::string> q1 = context.getQueue<std::string>("defQueue1");
@@ -101,8 +98,8 @@ namespace hazelcast {
 
                 ASSERT_NO_THROW(context.commitTransaction());
 
-                ASSERT_EQ(0, client->getQueue<std::string>("defQueue0").size());
-                ASSERT_EQ("item0", *(client->getQueue<std::string>("defQueue1").poll()));
+                    ASSERT_EQ(0, client.getQueue<std::string>("defQueue0").size());
+                    ASSERT_EQ("item0", *(client.getQueue<std::string>("defQueue1").poll()));
             }
         }
     }

--- a/hazelcast/test/src/txn/ClientTxnSetTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnSetTest.cpp
@@ -25,7 +25,6 @@
 #include "ClientTestSupport.h"
 #include "HazelcastServer.h"
 
-#include "hazelcast/client/ClientConfig.h"
 #include "hazelcast/client/HazelcastClient.h"
 
 namespace hazelcast {
@@ -39,23 +38,20 @@ namespace hazelcast {
 
             protected:
                 HazelcastServer instance;
-                ClientConfig clientConfig;
-                std::auto_ptr<HazelcastClient> client;
+                HazelcastClient client;
             };
 
-            ClientTxnSetTest::ClientTxnSetTest()
-            : instance(*g_srvFactory)
-            , client(getNewClient()) {
+            ClientTxnSetTest::ClientTxnSetTest() : instance(*g_srvFactory), client(getNewClient()) {
             }
             
             ClientTxnSetTest::~ClientTxnSetTest() {
             }
 
             TEST_F(ClientTxnSetTest, testAddRemove) {
-                ISet<std::string> s = client->getSet<std::string>("testAddRemove");
+                ISet<std::string> s = client.getSet<std::string>("testAddRemove");
                 s.add("item1");
 
-                TransactionContext context = client->newTransactionContext();
+                TransactionContext context = client.newTransactionContext();
                 context.beginTransaction();
                 TransactionalSet<std::string> set = context.getSet<std::string>("testAddRemove");
                 ASSERT_TRUE(set.add("item2"));

--- a/hazelcast/test/src/txn/ClientTxnTest.cpp
+++ b/hazelcast/test/src/txn/ClientTxnTest.cpp
@@ -88,12 +88,12 @@ namespace hazelcast {
             ClientTxnTest::ClientTxnTest()
             : hazelcastInstanceFactory(*g_srvFactory) {
                 server.reset(new HazelcastServer(hazelcastInstanceFactory));
-                std::auto_ptr<ClientConfig> clientConfig = getConfig();
-                clientConfig->setRedoOperation(true);
+                ClientConfig clientConfig = getConfig();
+                clientConfig.setRedoOperation(true);
                 //always start the txn on first member
                 loadBalancer.reset(new MyLoadBalancer());
-                clientConfig->setLoadBalancer(loadBalancer.get());
-                client.reset(new HazelcastClient(*clientConfig));
+                clientConfig.setLoadBalancer(loadBalancer.get());
+                client.reset(new HazelcastClient(clientConfig));
                 second.reset(new HazelcastServer(hazelcastInstanceFactory));
             }
 


### PR DESCRIPTION
Changed the constructor of HazelcastClientInstanceImpl to copy the provided config so that no change to the user provided ClientConfig during the client operation does not effect the client. Also updated the ClientProperties usage similar to the Java client HazelcastProperties.