### PR TITLE
Implement HazelcastClient::getLocalEndpoint() API

### DIFF
--- a/hazelcast/include/hazelcast/client/Client.h
+++ b/hazelcast/include/hazelcast/client/Client.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZElCAST_CLIENT_CLIENT_H_
+#define HAZElCAST_CLIENT_CLIENT_H_
+
+#include "hazelcast/client/Endpoint.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
+namespace hazelcast {
+    namespace client {
+        /**
+         * The Client interface allows to get information about
+         * a connected client's socket address, type and UUID.
+         *
+         */
+        class HAZELCAST_API Client : public Endpoint {
+        public:
+            Client(const boost::shared_ptr<std::string> &uuid, const boost::shared_ptr<Address> &socketAddress,
+                   const std::string &name);
+
+            const std::string &getName() const;
+
+        private:
+            std::string name;
+        };
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+#endif //HAZElCAST_CLIENT_CLIENT_H_
+

--- a/hazelcast/include/hazelcast/client/Endpoint.h
+++ b/hazelcast/include/hazelcast/client/Endpoint.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HAZElCAST_CLIENT_ENDPOINT_H_
+#define HAZElCAST_CLIENT_ENDPOINT_H_
+
+#include <string>
+#include <boost/shared_ptr.hpp>
+
+#include "hazelcast/client/Address.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
+
+namespace hazelcast {
+    namespace client {
+        /**
+         * Endpoint represents a peer in the cluster.
+         * It is the client.
+         */
+        class HAZELCAST_API Endpoint {
+        public:
+            Endpoint(boost::shared_ptr<std::string> uuid, boost::shared_ptr<Address> socketAddress);
+
+            /**
+             * Returns the UUID of this endpoint
+             *
+             * @return the UUID of this endpoint
+             */
+            const boost::shared_ptr<std::string> &getUuid() const;
+
+            /**
+             * Returns the socket address for this endpoint.
+             *
+             * @return the socket address for this endpoint
+             */
+            const boost::shared_ptr<Address> &getSocketAddress() const;
+
+        private:
+            boost::shared_ptr<std::string> uuid;
+            boost::shared_ptr<Address> socketAddress;
+        };
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+#endif //HAZElCAST_CLIENT_ENDPOINT_H_
+

--- a/hazelcast/include/hazelcast/client/HazelcastClient.h
+++ b/hazelcast/include/hazelcast/client/HazelcastClient.h
@@ -665,6 +665,15 @@ namespace hazelcast {
             Cluster& getCluster();
 
             /**
+             * Returns the local endpoint which this HazelcastInstance belongs to.
+             * <p>
+             *
+             * @return the local enpoint which this client belongs to
+             * @see Client
+             */
+            Client getLocalEndpoint() const;
+
+            /**
             * Add listener to listen lifecycle events.
             *
             * Warning 1: If listener should do a time consuming operation, off-load the operation to another thread.

--- a/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
+++ b/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
@@ -52,6 +52,7 @@
 #include "hazelcast/client/impl/statistics/Statistics.h"
 #include "hazelcast/client/FlakeIdGenerator.h"
 #include "hazelcast/client/IExecutorService.h"
+#include "hazelcast/client/Client.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -384,6 +385,8 @@ namespace hazelcast {
                 * @return cluster
                 */
                 Cluster& getCluster();
+
+                Client getLocalEndpoint() const;
 
                 /**
                 * Add listener to listen lifecycle events.

--- a/hazelcast/include/hazelcast/client/spi/ClientClusterService.h
+++ b/hazelcast/include/hazelcast/client/spi/ClientClusterService.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
-#include "hazelcast/util/HazelcastDll.h"
+#include "hazelcast/client/Client.h"
 #include "hazelcast/client/Member.h"
 #include "hazelcast/client/MembershipListener.h"
 
@@ -36,6 +36,11 @@ namespace hazelcast {
             }
         }
         namespace spi {
+            /**
+             * @return The client interface representing the local client.
+             */
+            Client getLocalClient();
+
             /**
              * Cluster service for Hazelcast clients.
              *

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
@@ -27,6 +27,7 @@
 #include "hazelcast/client/Member.h"
 #include "hazelcast/util/Atomic.h"
 #include "hazelcast/util/SynchronizedMap.h"
+#include "hazelcast/client/Client.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -77,6 +78,8 @@ namespace hazelcast {
                     void fireMemberAttributeEvent(const MemberAttributeEvent &event);
 
                     virtual int getSize();
+
+                    Client getLocalClient() const;
 
                 private:
                     ClientContext &client;

--- a/hazelcast/src/hazelcast/client/Client.cpp
+++ b/hazelcast/src/hazelcast/client/Client.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hazelcast/client/Client.h"
+
+namespace hazelcast {
+    namespace client {
+        Client::Client(const boost::shared_ptr<std::string> &uuid, const boost::shared_ptr<Address> &socketAddress,
+                       const std::string &name) : Endpoint(uuid, socketAddress), name(name) {}
+
+        const std::string &Client::getName() const {
+            return name;
+        }
+    }
+}

--- a/hazelcast/src/hazelcast/client/Endpoint.cpp
+++ b/hazelcast/src/hazelcast/client/Endpoint.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hazelcast/client/Endpoint.h"
+
+namespace hazelcast {
+    namespace client {
+        Endpoint::Endpoint(boost::shared_ptr<std::string> uuid, boost::shared_ptr<Address> socketAddress) : uuid(uuid),
+                                                                                                            socketAddress(
+                                                                                                                    socketAddress) {}
+
+        const boost::shared_ptr<std::string> &Endpoint::getUuid() const {
+            return uuid;
+        }
+
+        const boost::shared_ptr<Address> &Endpoint::getSocketAddress() const {
+            return socketAddress;
+        }
+    }
+}

--- a/hazelcast/src/hazelcast/client/HazelcastClient.cpp
+++ b/hazelcast/src/hazelcast/client/HazelcastClient.cpp
@@ -110,6 +110,10 @@ namespace hazelcast {
         boost::shared_ptr<IExecutorService> HazelcastClient::getExecutorService(const std::string &name) {
             return clientImpl->getExecutorService(name);
         }
+
+        Client HazelcastClient::getLocalEndpoint() const {
+            return clientImpl->getLocalEndpoint();
+        }
     }
 }
 

--- a/hazelcast/src/hazelcast/client/impl/HazelcastClientInstanceImpl.cpp
+++ b/hazelcast/src/hazelcast/client/impl/HazelcastClientInstanceImpl.cpp
@@ -359,6 +359,10 @@ namespace hazelcast {
 
                 return boost::static_pointer_cast<IExecutorService>(proxy);
             }
+
+            Client HazelcastClientInstanceImpl::getLocalEndpoint() const {
+                return clusterService.getLocalClient();
+            }
         }
     }
 }

--- a/hazelcast/test/src/cluster/ClientEndpointTest.cpp
+++ b/hazelcast/test/src/cluster/ClientEndpointTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This has to be the first include, so that Python.h is the first include. Otherwise, compilation warning such as
+ * "_POSIX_C_SOURCE" redefined occurs.
+ */
+#include "HazelcastServerFactory.h"
+#include "ClientTestSupport.h"
+#include "HazelcastServer.h"
+
+#include <hazelcast/client/HazelcastClient.h>
+#include <hazelcast/client/spi/ClientContext.h>
+#include <hazelcast/client/connection/ClientConnectionManagerImpl.h>
+#include <hazelcast/client/protocol/Principal.h>
+#include <hazelcast/client/connection/Connection.h>
+
+namespace hazelcast {
+    namespace client {
+        namespace test {
+            class ClientEnpointTest : public ClientTestSupport {
+            };
+
+            TEST_F(ClientEnpointTest, testConnectedClientEnpoint) {
+                HazelcastServer instance(*g_srvFactory);
+
+                HazelcastClient client;
+                const Client endpoint = client.getLocalEndpoint();
+                spi::ClientContext context(client);
+                ASSERT_EQ(context.getName(), endpoint.getName());
+
+                boost::shared_ptr<Address> endpointAddress = endpoint.getSocketAddress();
+                ASSERT_NOTNULL(endpointAddress.get(), Address);
+                connection::ClientConnectionManagerImpl &connectionManager = context.getConnectionManager();
+                boost::shared_ptr<connection::Connection> connection = connectionManager.getOwnerConnection();
+                ASSERT_NOTNULL(connection.get(), connection::Connection);
+                std::auto_ptr<Address> localAddress = connection->getLocalSocketAddress();
+                ASSERT_NOTNULL(localAddress.get(), Address);
+                ASSERT_EQ(*localAddress, *endpointAddress);
+
+                boost::shared_ptr<protocol::Principal> principal = connectionManager.getPrincipal();
+                ASSERT_NOTNULL(principal.get(), protocol::Principal);
+                ASSERT_NOTNULL(principal->getUuid(), std::string);
+                ASSERT_EQ_PTR((*principal->getUuid()), endpoint.getUuid().get(), std::string);
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
Implemented HazelcastClient::getLocalEndpoint().

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/524