### PR TITLE
Requiring the specific version of python (python2) for testing

### DIFF
--- a/hazelcast/test/src/CMakeLists.txt
+++ b/hazelcast/test/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(HazelcastClientTest)
 
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs 2.7 EXACT REQUIRED)
 
 message(STATUS "Using PYTHON_INCLUDE_DIRS: ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "Using PYTHON_LIBRARIES: ${PYTHON_LIBRARIES}")

--- a/hazelcast/test/src/CMakeLists.txt
+++ b/hazelcast/test/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(HazelcastClientTest)
 
-find_package(PythonLibs 2.7 EXACT REQUIRED)
+find_package(PythonLibs 2 REQUIRED)
 
 message(STATUS "Using PYTHON_INCLUDE_DIRS: ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "Using PYTHON_LIBRARIES: ${PYTHON_LIBRARIES}")


### PR DESCRIPTION
Fix for requiring the specific version of python (python2) for testing.