### PR TITLE
Reverted #558 for Windows - 64 bit debug test cmake fails to detect the python lib correctly

### DIFF
--- a/hazelcast/test/src/CMakeLists.txt
+++ b/hazelcast/test/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 project(HazelcastClientTest)
 
-find_package(PythonLibs 2 REQUIRED)
+IF (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    find_package(PythonLibs REQUIRED)
+else()
+    find_package(PythonLibs 2 REQUIRED)
+ENDIF (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
 message(STATUS "Using PYTHON_INCLUDE_DIRS: ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "Using PYTHON_LIBRARIES: ${PYTHON_LIBRARIES}")


### PR DESCRIPTION
Reverted #558 for Windows since the 64 bit debug test build fails on Windows with this option. At windows for this build type it detects the debug 64 bit python library at wrong location:

```
21:27:49 -- Found PythonLibs: optimized;C:/Python-2.7.14/PCbuild/amd64/python27_d.lib;debug;C:/Python27/libs/python27_d.lib (found suitable version "2.7.14", minimum required is "2")
21:27:49 -- Using PYTHON_INCLUDE_DIRS: C:/Python27/include
21:27:49 -- Using PYTHON_LIBRARIES: optimized;C:/Python-2.7.14/PCbuild/amd64/python27_d.lib;debug;C:/Python27/libs/python27_d.lib
21:27:49 -- Shall use the SHARED Hazelcast library for the tests.
21:27:49 -- Found PythonInterp: C:/Python27/python.exe (found version "2.7.14")
```

The working one prints:
```
14:48:31 -- Found PythonLibs: C:/Python-2.7.14/PCbuild/amd64/python27_d.lib (found version "2.7.14")
14:48:31 -- Using PYTHON_INCLUDE_DIRS: C:/Python27/include
14:48:31 -- Using PYTHON_LIBRARIES: C:/Python-2.7.14/PCbuild/amd64/python27_d.lib
14:48:31 -- Shall use the SHARED Hazelcast library for the tests.
14:48:31 -- Found PythonInterp: C:/Python27/python.exe (found version "2.7.14")
```