### PR TITLE
Missing Data class move constructor symbol problem for C++ language level C++11 and later problem

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
@@ -57,7 +57,12 @@ namespace hazelcast {
 
                     Data(std::auto_ptr<std::vector<byte> > buffer);
 
-                    virtual ~Data();
+                    /**
+                     * We need to define the destructor so that for C++11 and later compiler users, no implicit move
+                     * constructor is generated. It can not also be virtual.
+                     * See https://github.com/hazelcast/hazelcast-cpp-client/issues/563
+                     */
+                    ~Data();
 
                     size_t dataSize() const;
 

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/Data.h
@@ -55,11 +55,9 @@ namespace hazelcast {
 
                     Data();
 
-/*
-                    Data(const boost::shared_ptr<std::vector<byte> > &data);
-*/
-
                     Data(std::auto_ptr<std::vector<byte> > buffer);
+
+                    virtual ~Data();
 
                     size_t dataSize() const;
 

--- a/hazelcast/src/hazelcast/client/serialization/pimpl/Data.cpp
+++ b/hazelcast/src/hazelcast/client/serialization/pimpl/Data.cpp
@@ -61,6 +61,8 @@ namespace hazelcast {
                     }
                 }
 
+                Data::~Data() {}
+
                 size_t Data::dataSize() const {
                     return (size_t) std::max<int>((int) totalSize() - (int) Data::DATA_OVERHEAD, 0);
                 }


### PR DESCRIPTION
Added the destructor to the Data class to prevent the generation of the move constructor, when the C++11 and later compiler is used by the users. Adding the destructor avoid implicit move constructor generation (see https://en.cppreference.com/w/cpp/language/move_constructor).

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/563