### PR TITLE
Fix concurrent access to message decoding

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/ClientDelegatingFuture.h
+++ b/hazelcast/include/hazelcast/client/internal/ClientDelegatingFuture.h
@@ -153,15 +153,16 @@ namespace hazelcast {
                     if (decodedResponse != boost::static_pointer_cast<V>(VOIDOBJ)) {
                         return decodedResponse;
                     }
-                    // TODO: Java uses a message wrapper here --> ClientMessage message = ClientMessage.createForDecode(clientMessage.buffer(), 0);
-                    boost::shared_ptr<V> newDecodedResponse = clientMessageDecoder->decodeClientMessage(clientMessage,
+
+                    boost::shared_ptr<protocol::ClientMessage> message(
+                            protocol::ClientMessage::createForDecode(*clientMessage));
+                    boost::shared_ptr<V> newDecodedResponse = clientMessageDecoder->decodeClientMessage(message,
                                                                                                         serializationService);
 
                     decodedResponse.compareAndSet(boost::static_pointer_cast<V>(VOIDOBJ), newDecodedResponse);
                     return newDecodedResponse;
                 }
 
-                /* TODO: Java client does deserialization inside this method, do we need it ? */
                 boost::shared_ptr<V>
                 resolveResponse(const boost::shared_ptr<protocol::ClientMessage> &clientMessage) {
                     if (defaultValue.get() != NULL) {

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
@@ -146,6 +146,8 @@ namespace hazelcast {
 
                 static std::auto_ptr<ClientMessage> createForEncode(int32_t size);
 
+                static std::auto_ptr<ClientMessage> createForDecode(const ClientMessage &msg);
+
                 static std::auto_ptr<ClientMessage> create(int32_t size);
 
                 //----- Setter methods begin --------------------------------------

--- a/hazelcast/include/hazelcast/util/LittleEndianBufferWrapper.h
+++ b/hazelcast/include/hazelcast/util/LittleEndianBufferWrapper.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <boost/shared_ptr.hpp>
+
 #include "hazelcast/util/Bits.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -72,12 +74,12 @@ namespace hazelcast {
 
             inline uint8_t getUint8() {
                 assert(checkReadAvailable(UINT8_SIZE));
-                return buffer[index++];
+                return (*buffer)[index++];
             }
 
             inline int8_t getInt8() {
                 assert(checkReadAvailable(INT8_SIZE));
-                return buffer[index++];
+                return (*buffer)[index++];
             }
 
             inline bool getBoolean() {
@@ -219,7 +221,8 @@ namespace hazelcast {
             }
 
         protected:
-            LittleEndianBufferWrapper(int32_t size) : buffer(size, 0), capacity(-1), index(-1), readOnly(true) {}
+            LittleEndianBufferWrapper(int32_t size) : buffer(new std::vector<byte>(size, 0)), capacity(-1), index(-1),
+                                                      readOnly(true) {}
 
             inline int32_t getIndex() const {
                 return index;
@@ -231,7 +234,7 @@ namespace hazelcast {
 
         protected:
             inline byte *ix() {
-                return &buffer[index];
+                return &(*buffer)[index];
             }
 
             inline bool checkWriteAvailable(int32_t requestedBytes) const {
@@ -254,7 +257,7 @@ namespace hazelcast {
                 return index + requestedBytes <= capacity;
             }
 
-            std::vector<byte> buffer;
+            boost::shared_ptr<std::vector<byte> > buffer;
             int32_t capacity;
             int32_t index;
             bool readOnly;

--- a/hazelcast/test/src/common/containers/LitlleEndianBufferTest.cpp
+++ b/hazelcast/test/src/common/containers/LitlleEndianBufferTest.cpp
@@ -49,8 +49,8 @@ namespace hazelcast {
                         uint64_t sevenBytesFactor = ONE << 56;
 
                         byte buf[TEST_DATA_SIZE] = {0x8A, 0x9A, 0xAA, 0xBA, 0xCA, 0xDA, 0xEA, 0x8B};
-                        buffer.resize(LARGE_BUFFER_SIZE);
-                        memcpy(&buffer[START_BYTE_NUMBER], buf, TEST_DATA_SIZE);
+                        buffer->resize(LARGE_BUFFER_SIZE);
+                        memcpy(&(*buffer)[START_BYTE_NUMBER], buf, TEST_DATA_SIZE);
 
                         // ----- Test unsigned get starts ---------------------------------
                         // NOTE: When the first bit of the highest byte is equal to 1, than the number is negative,
@@ -128,8 +128,8 @@ namespace hazelcast {
                         byte strBytes[8] = {4, 0, 0, 0, /* This part is the len field which is 4 bytes */
                                             firstChar, firstChar + 1, firstChar + 2, firstChar + 3}; // This is string BCDE
 
-                        buffer.clear();
-                        buffer.insert(buffer.begin(), strBytes, strBytes + 8);
+                        buffer->clear();
+                        buffer->insert(buffer->begin(), strBytes, strBytes + 8);
                         {
                             wrapForRead(8, 0);
                             ASSERT_EQ("BCDE", getStringUtf8());
@@ -145,8 +145,8 @@ namespace hazelcast {
                                                                        firstChar, firstChar + 1, firstChar + 2, firstChar + 3,
                                                                        0x8A, 0x01, 0x00, 0xBA, 0xCA, 0xDA, 0xEA, 0x8B};
 
-                            buffer.clear();
-                            buffer.insert(buffer.begin(), continousBuffer, continousBuffer + 45);
+                            buffer->clear();
+                            buffer->insert(buffer->begin(), continousBuffer, continousBuffer + 45);
 
                             wrapForRead(8 * 10, 0);
 
@@ -232,48 +232,48 @@ namespace hazelcast {
                         // ---- Test consecutive gets ends ---------------------------
 
                         // ---- Write related tests starts --------------------------
-                        buffer.clear();
-                        buffer.resize(30, 0);
+                        buffer->clear();
+                        buffer->resize(30, 0);
                         wrapForWrite(30, 0);
 
                         set((uint8_t) 0x8A);
-                        ASSERT_EQ(0x8A, buffer[0]);
+                        ASSERT_EQ(0x8A, (*buffer)[0]);
                         
                         set(true);
-                        ASSERT_EQ(0x01, buffer[1]);
+                        ASSERT_EQ(0x01, (*buffer)[1]);
 
                         set(false);
-                        ASSERT_EQ(0x00, buffer[2]);
+                        ASSERT_EQ(0x00, (*buffer)[2]);
 
                         set('C');
-                        ASSERT_EQ('C', buffer[3]);
+                        ASSERT_EQ('C', (*buffer)[3]);
 
                         int16_t int16Val = 0x7BCD;
                         set(int16Val);
-                        ASSERT_EQ(0xCD, buffer[4]);
-                        ASSERT_EQ(0x7B, buffer[5]);
+                        ASSERT_EQ(0xCD, (*buffer)[4]);
+                        ASSERT_EQ(0x7B, (*buffer)[5]);
 
                         uint16_t uInt16Val = 0xABCD;
                         set(uInt16Val);
-                        ASSERT_EQ(0xCD, buffer[6]);
-                        ASSERT_EQ(0xAB, buffer[7]);
+                        ASSERT_EQ(0xCD, (*buffer)[6]);
+                        ASSERT_EQ(0xAB, (*buffer)[7]);
 
                         int32_t int32Val = 0xAEBCEEFF;
                         set(int32Val);
-                        ASSERT_EQ(0xFF, buffer[8]);
-                        ASSERT_EQ(0xEE, buffer[9]);
-                        ASSERT_EQ(0xBC, buffer[10]);
-                        ASSERT_EQ(0xAE, buffer[11]);
+                        ASSERT_EQ(0xFF, (*buffer)[8]);
+                        ASSERT_EQ(0xEE, (*buffer)[9]);
+                        ASSERT_EQ(0xBC, (*buffer)[10]);
+                        ASSERT_EQ(0xAE, (*buffer)[11]);
 
 
                         set(std::string("Test Data"));
-                        ASSERT_EQ(0x09, (int)buffer[12]);
-                        ASSERT_EQ(0x0, buffer[13]);
-                        ASSERT_EQ(0x0, buffer[14]);
-                        ASSERT_EQ(0x0, buffer[15]);
-                        ASSERT_EQ('T', buffer[16]);
-                        ASSERT_EQ('e', buffer[17]);
-                        ASSERT_EQ('a', buffer[24]);
+                        ASSERT_EQ(0x09, (int)(*buffer)[12]);
+                        ASSERT_EQ(0x0, (*buffer)[13]);
+                        ASSERT_EQ(0x0, (*buffer)[14]);
+                        ASSERT_EQ(0x0, (*buffer)[15]);
+                        ASSERT_EQ('T', (*buffer)[16]);
+                        ASSERT_EQ('e', (*buffer)[17]);
+                        ASSERT_EQ('a', (*buffer)[24]);
                     }
                 }
             }


### PR DESCRIPTION
Fix for resolving the race when there is concurrent access to client message decoding. A copy message is constructed with a fresh read `index` on the same message buffer and decodes using this new message. This was an existing `TODO` fix which already existed for the Java client.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/569