### PR TITLE
Nightly build failure fixes

### DIFF
--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -12,6 +12,6 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel.i686
 
 RUN dnf install -y wget bzip2
-RUN dnf install -y wget bzip2 && wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
+RUN dnf install -y wget bzip2 && wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
 
 

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -9,5 +9,5 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel
 
 # install boost 1.72.0
-RUN dnf install -y wget bzip2 && wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
+RUN dnf install -y wget bzip2 && wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
 

--- a/hazelcast/include/hazelcast/client/map/DataEntryView.h
+++ b/hazelcast/include/hazelcast/client/map/DataEntryView.h
@@ -33,8 +33,6 @@ namespace hazelcast {
     namespace client {
         namespace map {
             class HAZELCAST_API DataEntryView {
-
-
             public:
                 DataEntryView(const serialization::pimpl::Data &key, const serialization::pimpl::Data &value, int64_t cost,
                               int64_t creationTime, int64_t expirationTime, int64_t hits, int64_t lastAccessTime,

--- a/hazelcast/include/hazelcast/client/protocol/codec/DataEntryViewCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/DataEntryViewCodec.h
@@ -20,13 +20,10 @@
 #define HAZELCAST_CLIENT_PROTOCOL_CODEC_ENTRYVIEWCODEC_
 
 #include "hazelcast/util/HazelcastDll.h"
+#include "hazelcast/client/map/DataEntryView.h"
 
 namespace hazelcast {
     namespace client {
-        namespace map {
-            class DataEntryView;
-        }
-
         namespace protocol {
             class ClientMessage;
 

--- a/hazelcast/src/hazelcast/client/serialization.cpp
+++ b/hazelcast/src/hazelcast/client/serialization.cpp
@@ -30,6 +30,8 @@
  * limitations under the License.
  */
 
+#include <boost/concept_check.hpp>
+
 #include "hazelcast/client/serialization/VersionedPortable.h"
 #include "hazelcast/client/HazelcastJsonValue.h"
 #include "hazelcast/client/TypedData.h"
@@ -1868,6 +1870,7 @@ namespace hazelcast {
                         SerializationConstants::CONSTANT_TYPE_PORTABLE == type.typeId) {
                         int32_t objectTypeId = objectDataInput.readInt();
                         assert(type.typeId == objectTypeId);
+                        boost::ignore_unused_variable_warning(objectTypeId);
 
                         if (SerializationConstants::CONSTANT_TYPE_DATA == type.typeId) {
                             bool identified = objectDataInput.readBoolean();

--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -35,6 +35,8 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include <boost/concept_check.hpp>
+
 #ifdef HZ_BUILD_WITH_SSL
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/basic_resolver.hpp>
@@ -657,6 +659,7 @@ namespace hazelcast {
             struct tm localBrokenTime;
             int result = util::localtime(&brokenTime, &localBrokenTime);
             assert(!result);
+            boost::ignore_unused_variable_warning(result);
 
             std::ostringstream oss;
             oss << std::put_time(&localBrokenTime, "%Y-%m-%d %H:%M:%S");

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -1447,16 +1447,13 @@ namespace hazelcast {
             }
 
 #ifdef HZ_BUILD_WITH_SSL
-
             INSTANTIATE_TEST_SUITE_P(All,
                                      ClusterTest,
                                      ::testing::Values(new SmartTcpClientConfig(), new SmartSSLClientConfig()));
 #else
             INSTANTIATE_TEST_SUITE_P(All,
                                      ClusterTest,
-                                     ::testing::Values(new SmartTcpClientConfig()));                                                                                                                                    INSTANTIATE_TEST_SUITE_P(All,
-                                    ClusterTest,
-                                    ::testing::Values(new SmartTcpClientConfig()));
+                                     ::testing::Values(new SmartTcpClientConfig()));
 #endif
         }
     }


### PR DESCRIPTION
Added 32 bit build of Boost library to linux images.

Added the missing include for `DataEntryView` which caused nightly build failures.

Added ignore statements for unused assert statements when the Release build mode is being build so that Release builds do not fail.

Fix to test instantiation of `ClusterTest` when non-ssl is being used.