### PR TITLE
[WIP] Change lifecycle listener APIs

### DIFF
--- a/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
+++ b/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
@@ -18,31 +18,7 @@
 #include <hazelcast/client/HazelcastClient.h>
 #include <hazelcast/client/config/ClientConnectionStrategyConfig.h>
 #include <hazelcast/client/LifecycleListener.h>
-
-class DisconnectedListener : public hazelcast::client::LifecycleListener {
-public:
-    DisconnectedListener() : disconnectedLatch(1), connectedLatch(1) {}
-
-    virtual void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) {
-        if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_DISCONNECTED) {
-            disconnectedLatch.count_down();
-        } else if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_CONNECTED) {
-            connectedLatch.count_down();
-        }
-    }
-
-    void waitForDisconnection() {
-        disconnectedLatch.wait();
-    }
-
-    bool awaitReconnection(int seconds) {
-        return connectedLatch.wait_for(boost::chrono::seconds(seconds)) == boost::cv_status::no_timeout;
-    }
-
-private:
-    boost::latch disconnectedLatch;
-    boost::latch connectedLatch;
-};
+#include <hazelcast/client/LifecycleEvent.h>
 
 
 int main() {
@@ -63,15 +39,23 @@ int main() {
 
     map->put(1, 100);
 
-    DisconnectedListener listener;
-    hz.addLifecycleListener(&listener);
+    boost::latch disconnectedLatch(1);
+    boost::latch connectedLatch(1);
+
+    hz.addLifecycleListener([&](const hazelcast::client::LifecycleEvent &lifecycleEvent) {
+        if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_DISCONNECTED) {
+            disconnectedLatch.count_down();
+        } else if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_CONNECTED) {
+            connectedLatch.count_down();
+        }
+    });
 
     // Please shut down the cluster at this point.
-    listener.waitForDisconnection();
+    disconnectedLatch.wait();
 
     std::cout << "Client is disconnected from the cluster now." << std::endl;
 
-    if (listener.awaitReconnection(10)) {
+    if (connectedLatch.wait_for(boost::chrono::seconds(10)) == boost::cv_status::no_timeout) {
         std::cout << "The client is connected to the cluster within 10 seconds after disconnection as expected." << std::endl;
     }
 
@@ -80,4 +64,3 @@ int main() {
 
     return 0;
 }
-

--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -38,6 +38,7 @@
 #include "hazelcast/client/internal/config/ConfigUtils.h"
 #include "hazelcast/client/config/LoggerConfig.h"
 #include "hazelcast/client/serialization/serialization.h"
+#include "hazelcast/client/LifecycleListener.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -49,8 +50,6 @@ namespace hazelcast {
         class MembershipListener;
 
         class InitialMembershipListener;
-
-        class LifecycleListener;
 
         class InitialMembershipEvent;
 
@@ -259,13 +258,17 @@ namespace hazelcast {
             * @param listener LifecycleListener *listener
             * @return itself ClientConfig
             */
-            ClientConfig &addListener(LifecycleListener *listener);
+            template<typename T>
+            ClientConfig &addLifecycleListener(T &&listener) {
+                lifecycleListeners.emplace_back(std::forward<T>(listener));
+                return *this;
+            }
 
             /**
             *
             * @return registered lifecycleListeners
             */
-            const std::unordered_set<LifecycleListener *> &getLifecycleListeners() const;
+            const std::vector<LifecycleListener> &getLifecycleListeners() const;
 
             /**
             * @deprecated Please use addListener(const std::shared_ptr<MembershipListener> &listener) instead.
@@ -554,7 +557,7 @@ namespace hazelcast {
             std::unordered_set<MembershipListener *> membershipListeners;
             std::unordered_set<std::shared_ptr<MembershipListener> > managedMembershipListeners;
 
-            std::unordered_set<LifecycleListener *> lifecycleListeners;
+            std::vector<LifecycleListener> lifecycleListeners;
 
             std::unordered_map<std::string, std::string> properties;
 

--- a/hazelcast/include/hazelcast/client/HazelcastClient.h
+++ b/hazelcast/include/hazelcast/client/HazelcastClient.h
@@ -266,14 +266,16 @@ namespace hazelcast {
             *
             * @param lifecycleListener Listener object
             */
-            void addLifecycleListener(LifecycleListener *lifecycleListener);
-
+            template<typename T>
+            std::string addLifecycleListener(T &&lifecycleListener) {
+                return clientImpl->addLifecycleListener(std::forward<T>(lifecycleListener));
+            }
             /**
             * Remove lifecycle listener
             * @param lifecycleListener
             * @return true if removed successfully
             */
-            bool removeLifecycleListener(LifecycleListener *lifecycleListener);
+            bool removeLifecycleListener(const std::string &lifecycleListener);
 
             /**
             * Shuts down this HazelcastClient.

--- a/hazelcast/include/hazelcast/client/LifecycleListener.h
+++ b/hazelcast/include/hazelcast/client/LifecycleListener.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "hazelcast/util/HazelcastDll.h"
-#include "hazelcast/client/LifecycleEvent.h"
 
 namespace hazelcast {
     namespace client {
@@ -33,17 +32,8 @@ namespace hazelcast {
          * @see HazelcastClient::addLifecycleListener(LifecycleListener *lifecycleListener)
          *
          */
-        class HAZELCAST_API LifecycleListener {
-        public:
-            /**
-             * Called when instance's state changes
-             * @param lifecycleEvent LifecycleEvent
-             *
-             */
-            virtual void stateChanged(const LifecycleEvent &lifecycleEvent) = 0;
-
-            virtual ~LifecycleListener();
-        };
+        class LifecycleEvent;
+        typedef std::function<void(const LifecycleEvent&)> LifecycleListener;
     }
 }
 

--- a/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
+++ b/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
@@ -173,14 +173,16 @@ namespace hazelcast {
                 *
                 * @param lifecycleListener Listener object
                 */
-                void addLifecycleListener(LifecycleListener *lifecycleListener);
-
+                template<typename T>
+                std::string addLifecycleListener(T &&lifecycleListener) {
+                    return lifecycleService.addLifecycleListener(std::forward<T>(lifecycleListener));
+                }
                 /**
                 * Remove lifecycle listener
                 * @param lifecycleListener
                 * @return true if removed successfully
                 */
-                bool removeLifecycleListener(LifecycleListener *lifecycleListener);
+                bool removeLifecycleListener(const std::string &registrationId);
 
                 /**
                 * Shuts down this HazelcastClient.

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -101,12 +101,8 @@ namespace hazelcast {
             return clientImpl->getCluster();
         }
 
-        void HazelcastClient::addLifecycleListener(LifecycleListener *lifecycleListener) {
-            clientImpl->addLifecycleListener(lifecycleListener);
-        }
-
-        bool HazelcastClient::removeLifecycleListener(LifecycleListener *lifecycleListener) {
-            return clientImpl->removeLifecycleListener(lifecycleListener);
+        bool HazelcastClient::removeLifecycleListener(const std::string &registrationId) {
+            return clientImpl->removeLifecycleListener(registrationId);
         }
 
         void HazelcastClient::shutdown() {
@@ -218,12 +214,8 @@ namespace hazelcast {
                 return cluster;
             }
 
-            void HazelcastClientInstanceImpl::addLifecycleListener(LifecycleListener *lifecycleListener) {
-                lifecycleService.addLifecycleListener(lifecycleListener);
-            }
-
-            bool HazelcastClientInstanceImpl::removeLifecycleListener(LifecycleListener *lifecycleListener) {
-                return lifecycleService.removeLifecycleListener(lifecycleListener);
+            bool HazelcastClientInstanceImpl::removeLifecycleListener(const std::string &registrationId) {
+                return lifecycleService.removeLifecycleListener(registrationId);
             }
 
             void HazelcastClientInstanceImpl::shutdown() {
@@ -505,9 +497,6 @@ namespace hazelcast {
                 object.host = in.read<std::string>();
                 return object;
             }
-        }
-
-        LifecycleListener::~LifecycleListener() {
         }
 
         const std::string IExecutorService::SERVICE_NAME = "hz:impl:executorService";

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -639,11 +639,6 @@ namespace hazelcast {
             return loggerConfig;
         }
 
-        ClientConfig &ClientConfig::addListener(LifecycleListener *listener) {
-            lifecycleListeners.insert(listener);
-            return *this;
-        }
-
         ClientConfig &ClientConfig::addListener(MembershipListener *listener) {
             if (listener == NULL) {
                 BOOST_THROW_EXCEPTION(exception::NullPointerException("ClientConfig::addListener(MembershipListener *)",
@@ -681,7 +676,7 @@ namespace hazelcast {
             return *this;
         }
 
-        const std::unordered_set<LifecycleListener *> &ClientConfig::getLifecycleListeners() const {
+        const std::vector<LifecycleListener> &ClientConfig::getLifecycleListeners() const {
             return lifecycleListeners;
         }
 

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -914,65 +914,6 @@ namespace hazelcast {
                 ClusterTest() : sslFactory(g_srvFactory->getServerAddress(), getSslFilePath()) {}
 
             protected:
-                class ClientAllStatesListener : public LifecycleListener {
-                public:
-
-                    ClientAllStatesListener(boost::latch *startingLatch,
-                                            boost::latch *startedLatch = nullptr,
-                                            boost::latch *connectedLatch = nullptr,
-                                            boost::latch *disconnectedLatch = nullptr,
-                                            boost::latch *shuttingDownLatch = nullptr,
-                                            boost::latch *shutdownLatch = nullptr)
-                            : startingLatch(startingLatch), startedLatch(startedLatch), connectedLatch(connectedLatch),
-                              disconnectedLatch(disconnectedLatch), shuttingDownLatch(shuttingDownLatch),
-                              shutdownLatch(shutdownLatch) {}
-
-                    virtual void stateChanged(const LifecycleEvent &lifecycleEvent) {
-                        switch (lifecycleEvent.getState()) {
-                            case LifecycleEvent::STARTING:
-                                if (startingLatch) {
-                                    startingLatch->count_down();
-                                }
-                                break;
-                            case LifecycleEvent::STARTED:
-                                if (startedLatch) {
-                                    startedLatch->count_down();
-                                }
-                                break;
-                            case LifecycleEvent::CLIENT_CONNECTED:
-                                if (connectedLatch) {
-                                    connectedLatch->count_down();
-                                }
-                                break;
-                            case LifecycleEvent::CLIENT_DISCONNECTED:
-                                if (disconnectedLatch) {
-                                    disconnectedLatch->count_down();
-                                }
-                                break;
-                            case LifecycleEvent::SHUTTING_DOWN:
-                                if (shuttingDownLatch) {
-                                    shuttingDownLatch->count_down();
-                                }
-                                break;
-                            case LifecycleEvent::SHUTDOWN:
-                                if (shutdownLatch) {
-                                    shutdownLatch->count_down();
-                                }
-                                break;
-                            default:
-                                FAIL() << "No such state expected:" << lifecycleEvent.getState();
-                        }
-                    }
-
-                private:
-                    boost::latch *startingLatch;
-                    boost::latch *startedLatch;
-                    boost::latch *connectedLatch;
-                    boost::latch *disconnectedLatch;
-                    boost::latch *shuttingDownLatch;
-                    boost::latch *shutdownLatch;
-                };
-
                 std::unique_ptr<HazelcastServer> startServer(ClientConfig &clientConfig) {
                     if (clientConfig.getNetworkConfig().getSSLConfig().isEnabled()) {
                         return std::unique_ptr<HazelcastServer>(new HazelcastServer(sslFactory));
@@ -1020,9 +961,31 @@ namespace hazelcast {
                 boost::latch disconnectedLatch(1);
                 boost::latch shuttingDownLatch(1);
                 boost::latch shutdownLatch(1);
-                ClientAllStatesListener listener(&startingLatch, &startedLatch, &connectedLatch, &disconnectedLatch,
-                                                 &shuttingDownLatch, &shutdownLatch);
-                clientConfig.addListener(&listener);
+                
+                clientConfig.addLifecycleListener([&](const LifecycleEvent &lifecycleEvent) {
+                    switch (lifecycleEvent.getState()) {
+                        case LifecycleEvent::STARTING:
+                            startingLatch.count_down();
+                            break;
+                        case LifecycleEvent::STARTED:
+                            startedLatch.count_down();
+                            break;
+                        case LifecycleEvent::CLIENT_CONNECTED:
+                            connectedLatch.count_down();
+                            break;
+                        case LifecycleEvent::CLIENT_DISCONNECTED:
+                            disconnectedLatch.count_down();
+                            break;
+                        case LifecycleEvent::SHUTTING_DOWN:
+                            shuttingDownLatch.count_down();
+                            break;
+                        case LifecycleEvent::SHUTDOWN:
+                            shutdownLatch.count_down();
+                            break;
+                        default:
+                            FAIL() << "No such state expected:" << lifecycleEvent.getState();
+                    }
+                });
 
                 HazelcastClient client(clientConfig);
 
@@ -1062,9 +1025,31 @@ namespace hazelcast {
                 boost::latch disconnectedLatch(1);
                 boost::latch shuttingDownLatch(1);
                 boost::latch shutdownLatch(1);
-                ClientAllStatesListener listener(&startingLatch, &startedLatch, &connectedLatch, &disconnectedLatch,
-                                                 &shuttingDownLatch, &shutdownLatch);
-                clientConfig.addListener(&listener);
+
+                clientConfig.addLifecycleListener([&](const LifecycleEvent &lifecycleEvent) {
+                    switch (lifecycleEvent.getState()) {
+                        case LifecycleEvent::STARTING:
+                            startingLatch.count_down();
+                            break;
+                        case LifecycleEvent::STARTED:
+                            startedLatch.count_down();
+                            break;
+                        case LifecycleEvent::CLIENT_CONNECTED:
+                            connectedLatch.count_down();
+                            break;
+                        case LifecycleEvent::CLIENT_DISCONNECTED:
+                            disconnectedLatch.count_down();
+                            break;
+                        case LifecycleEvent::SHUTTING_DOWN:
+                            shuttingDownLatch.count_down();
+                            break;
+                        case LifecycleEvent::SHUTDOWN:
+                            shutdownLatch.count_down();
+                            break;
+                        default:
+                            FAIL() << "No such state expected:" << lifecycleEvent.getState();
+                    }
+                });
 
                 HazelcastClient client(clientConfig);
 

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -813,13 +813,13 @@ namespace hazelcast {
                     }
 
                 protected:
-                    class LifecycleStateListener : public LifecycleListener {
+                    class LifecycleStateListener {
                     public:
                         LifecycleStateListener(boost::latch &connectedLatch,
                                                const LifecycleEvent::LifeCycleState expectedState)
                                 : connectedLatch(connectedLatch), expectedState(expectedState) {}
 
-                        virtual void stateChanged(const LifecycleEvent &event) {
+                        void operator()(const LifecycleEvent &event) {
                             if (event.getState() == expectedState) {
                                 connectedLatch.try_count_down();
                             }
@@ -860,8 +860,8 @@ namespace hazelcast {
                     clientConfig.getNetworkConfig().addAddress(Address("8.8.8.8", 5701))
                             .addAddress(Address("127.0.0.1", 5701)).setConnectionAttemptLimit(INT32_MAX);
                     clientConfig.setProperty("hazelcast.client.shuffle.member.list", "false");
-                    LifecycleStateListener lifecycleListener(connectedLatch, LifecycleEvent::CLIENT_CONNECTED);
-                    clientConfig.addListener(&lifecycleListener);
+                    LifecycleStateListener listener(connectedLatch, LifecycleEvent::CLIENT_CONNECTED);
+                    clientConfig.addLifecycleListener(listener);
                     clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
 
                     HazelcastClient client(clientConfig);
@@ -886,7 +886,7 @@ namespace hazelcast {
                     HazelcastClient client(clientConfig);
                     boost::latch shutdownLatch(1);
                     LifecycleStateListener lifecycleListener(shutdownLatch, LifecycleEvent::SHUTDOWN);
-                    client.addLifecycleListener(&lifecycleListener);
+                    client.addLifecycleListener(lifecycleListener);
 
                     // no exception at this point
                     auto map = client.getMap(randomMapName());
@@ -909,7 +909,7 @@ namespace hazelcast {
                     HazelcastServer hazelcastInstance2(*g_srvFactory);
                     boost::latch shutdownLatch(1);
                     LifecycleStateListener lifecycleListener(shutdownLatch, LifecycleEvent::SHUTDOWN);
-                    client.addLifecycleListener(&lifecycleListener);
+                    client.addLifecycleListener(lifecycleListener);
 
 // no exception at this point
                     auto map = client.getMap(randomMapName());
@@ -931,7 +931,7 @@ namespace hazelcast {
                     HazelcastClient client(clientConfig);
                     boost::latch shutdownLatch(1);
                     LifecycleStateListener lifecycleListener(shutdownLatch, LifecycleEvent::SHUTDOWN);
-                    client.addLifecycleListener(&lifecycleListener);
+                    client.addLifecycleListener(lifecycleListener);
 
 // no exception at this point
                     auto map = client.getMap(randomMapName());
@@ -951,7 +951,7 @@ namespace hazelcast {
                     boost::latch connectedLatch(1);
 
                     LifecycleStateListener listener(connectedLatch, LifecycleEvent::CLIENT_CONNECTED);
-                    clientConfig.addListener(&listener);
+                    clientConfig.addLifecycleListener(listener);
                     clientConfig.getConnectionStrategyConfig().setReconnectMode(
                             config::ClientConnectionStrategyConfig::ASYNC);
                     HazelcastClient client(clientConfig);
@@ -970,7 +970,7 @@ namespace hazelcast {
 
                     clientConfig.getNetworkConfig().setConnectionAttemptLimit(INT32_MAX);
                     LifecycleStateListener listener(initialConnectionLatch, LifecycleEvent::CLIENT_CONNECTED);
-                    clientConfig.addListener(&listener);
+                    clientConfig.addLifecycleListener(listener);
                     clientConfig.getConnectionStrategyConfig().setReconnectMode(
                             config::ClientConnectionStrategyConfig::ASYNC);
                     HazelcastClient client(clientConfig);
@@ -980,7 +980,7 @@ namespace hazelcast {
                     hazelcastInstance.shutdown();
 
                     LifecycleStateListener reconnectListener(reconnectedLatch, LifecycleEvent::CLIENT_CONNECTED);
-                    client.addLifecycleListener(&reconnectListener);
+                    client.addLifecycleListener(reconnectListener);
 
                     HazelcastServer hazelcastInstance2(*g_srvFactory);
 
@@ -1002,7 +1002,7 @@ namespace hazelcast {
 
                     clientConfig.getNetworkConfig().setConnectionAttemptLimit(10);
                     LifecycleStateListener listener(connectedLatch, LifecycleEvent::CLIENT_CONNECTED);
-                    clientConfig.addListener(&listener);
+                    clientConfig.addLifecycleListener(listener);
                     clientConfig.getConnectionStrategyConfig().setReconnectMode(
                             config::ClientConnectionStrategyConfig::ASYNC);
                     HazelcastClient client(clientConfig);
@@ -1017,10 +1017,10 @@ namespace hazelcast {
                     map->put(1, 5).get();
 
                     LifecycleStateListener disconnectListener(disconnectedLatch, LifecycleEvent::CLIENT_DISCONNECTED);
-                    client.addLifecycleListener(&disconnectListener);
+                    client.addLifecycleListener(disconnectListener);
 
                     LifecycleStateListener reconnectListener(reconnectedLatch, LifecycleEvent::CLIENT_CONNECTED);
-                    client.addLifecycleListener(&reconnectListener);
+                    client.addLifecycleListener(reconnectListener);
 
                     ownerServer.shutdown();
 


### PR DESCRIPTION
I've changed the LifecycleListener interface to be a typedef for std::function having the signature of interface's stateChanged method and updated tests and examples accordingly. Documentation and readme are yet to be updated.

However, this approach probably won't work for other listener interfaces as they generally have more than one method.