### PR TITLE
Use override, =default and =delete 

### DIFF
--- a/examples/Org.Website.Samples/ExecutorSample.cpp
+++ b/examples/Org.Website.Samples/ExecutorSample.cpp
@@ -91,12 +91,12 @@ namespace hazelcast {
 
 class PrinterCallback : public ExecutionCallback<std::string> {
 public:
-    virtual void onResponse(const boost::optional<std::string> &response) {
+    void onResponse(const boost::optional<std::string> &response) override {
         std::cout << "The execution of the task is completed successfully and server returned:" << *response
                   << std::endl;
     }
 
-    virtual void onFailure(std::exception_ptr e) {
+    void onFailure(std::exception_ptr e) override {
         try {
             std::rethrow_exception(e);
         } catch (hazelcast::client::exception::IException &e) {
@@ -107,7 +107,7 @@ public:
 
 class MyMemberSelector : public hazelcast::client::cluster::memberselector::MemberSelector {
 public:
-    virtual bool select(const Member &member) const {
+    bool select(const Member &member) const override {
         const std::string *attribute = member.getAttribute("my.special.executor");
         if (attribute == NULL) {
             return false;
@@ -116,7 +116,7 @@ public:
         return *attribute == "true";
     }
 
-    virtual void toString(std::ostream &os) const {
+    void toString(std::ostream &os) const override {
         os << "MyMemberSelector";
     }
 };

--- a/examples/distributed-map/custom-attributes/CarAttributeDemo.cpp
+++ b/examples/distributed-map/custom-attributes/CarAttributeDemo.cpp
@@ -20,7 +20,7 @@
 #include <ostream>
 
 struct Car {
-    Car() {}
+    Car() = default;
 
     explicit Car(const char *name) {
         attributes["name"] = name;

--- a/examples/distributed-map/entry-listener/main.cpp
+++ b/examples/distributed-map/entry-listener/main.cpp
@@ -17,35 +17,35 @@
 
 class MyEntryListener : public hazelcast::client::EntryListener {
 public:
-    void entryAdded(const hazelcast::client::EntryEvent &event) {
+    void entryAdded(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryAdded] " << event << std::endl;
     }
 
-    void entryRemoved(const hazelcast::client::EntryEvent &event) {
+    void entryRemoved(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryRemoved] " << event << std::endl;
     }
 
-    void entryUpdated(const hazelcast::client::EntryEvent &event) {
+    void entryUpdated(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryAdded] " << event << std::endl;
     }
 
-    void entryEvicted(const hazelcast::client::EntryEvent &event) {
+    void entryEvicted(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryUpdated] " << event << std::endl;
     }
 
-    void entryExpired(const hazelcast::client::EntryEvent &event) {
+    void entryExpired(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryExpired] " << event << std::endl;
     }
 
-    void entryMerged(const hazelcast::client::EntryEvent &event) {
+    void entryMerged(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryMerged] " << event << std::endl;
     }
 
-    void mapEvicted(const hazelcast::client::MapEvent &event) {
+    void mapEvicted(const hazelcast::client::MapEvent &event) override {
         std::cout << "[mapEvicted] " << event << std::endl;
     }
 
-    void mapCleared(const hazelcast::client::MapEvent &event) {
+    void mapCleared(const hazelcast::client::MapEvent &event) override {
         std::cout << "[mapCleared] " << event << std::endl;
     }
 };

--- a/examples/distributed-map/query/Employee.cpp
+++ b/examples/distributed-map/query/Employee.cpp
@@ -18,7 +18,7 @@
 namespace hazelcast {
     namespace client {
         namespace examples {
-            Employee::Employee() {}
+            Employee::Employee() = default;
 
             Employee::Employee(std::string name, int32_t age) : age(age), name(name) {
                 by = 2;

--- a/examples/distributed-map/query/Employee.h
+++ b/examples/distributed-map/query/Employee.h
@@ -78,7 +78,7 @@ namespace hazelcast {
             class EmployeeEntryKeyComparator : public EmployeeEntryComparator {
             public:
                 int compare(const std::pair<const int32_t *, const Employee *> *lhs,
-                            const std::pair<const int32_t *, const Employee *> *rhs) const;
+                            const std::pair<const int32_t *, const Employee *> *rhs) const override;
             };
 
             std::ostream &operator<<(std::ostream &out, const Employee &employee);

--- a/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
+++ b/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
@@ -17,35 +17,35 @@
 
 class MapChangeListener : public hazelcast::client::EntryListener {
 public:
-    virtual void entryAdded(const hazelcast::client::EntryEvent &event) {
+    void entryAdded(const hazelcast::client::EntryEvent &event) override {
             std::cout << "Entry added:" << event.getKey().get<int>().value();
     }
 
-    virtual void entryRemoved(const hazelcast::client::EntryEvent &event) {
+    void entryRemoved(const hazelcast::client::EntryEvent &event) override {
         std::cout << "Entry removed:" << event.getKey().get<int>().value();
     }
 
-    virtual void entryUpdated(const hazelcast::client::EntryEvent &event) {
+    void entryUpdated(const hazelcast::client::EntryEvent &event) override {
         std::cout << "Entry updated:" << event.getKey().get<int>().value();
     }
 
-    virtual void entryEvicted(const hazelcast::client::EntryEvent &event) {
+    void entryEvicted(const hazelcast::client::EntryEvent &event) override {
         std::cout << "Entry evicted:" << event.getKey().get<int>().value();
     }
 
-    virtual void entryExpired(const hazelcast::client::EntryEvent &event) {
+    void entryExpired(const hazelcast::client::EntryEvent &event) override {
         std::cout << "Entry expired:" << event.getKey().get<int>().value();
     }
 
-    virtual void entryMerged(const hazelcast::client::EntryEvent &event) {
+    void entryMerged(const hazelcast::client::EntryEvent &event) override {
         std::cout << "Entry merged:" << event.getKey().get<int>().value();
     }
 
-    virtual void mapEvicted(const hazelcast::client::MapEvent &event) {
+    void mapEvicted(const hazelcast::client::MapEvent &event) override {
         std::cout << "Map evicted:" << event.getName();
     }
 
-    virtual void mapCleared(const hazelcast::client::MapEvent &event) {
+    void mapCleared(const hazelcast::client::MapEvent &event) override {
         std::cout << "Map cleared:" << event.getName();
     }
 };

--- a/examples/monitoring/cluster/main.cpp
+++ b/examples/monitoring/cluster/main.cpp
@@ -21,7 +21,7 @@
 class MyInitialMemberListener : public hazelcast::client::InitialMembershipListener {
 
 public:
-    void init(const hazelcast::client::InitialMembershipEvent &event) {
+    void init(const hazelcast::client::InitialMembershipEvent &event) override {
         std::vector<hazelcast::client::Member> members = event.getMembers();
         std::cout << "The following are the initial members in the cluster:" << std::endl;
         for (std::vector<hazelcast::client::Member>::const_iterator it = members.begin(); it != members.end(); ++it) {
@@ -29,17 +29,17 @@ public:
         }
     }
 
-    void memberAdded(const hazelcast::client::MembershipEvent &membershipEvent) {
+    void memberAdded(const hazelcast::client::MembershipEvent &membershipEvent) override {
         std::cout << "[MyInitialMemberListener::memberAdded] New member joined:" <<
         membershipEvent.getMember().getAddress() << std::endl;
     }
 
-    void memberRemoved(const hazelcast::client::MembershipEvent &membershipEvent) {
+    void memberRemoved(const hazelcast::client::MembershipEvent &membershipEvent) override {
         std::cout << "[MyInitialMemberListener::memberRemoved] Member left:" <<
         membershipEvent.getMember().getAddress() << std::endl;
     }
 
-    void memberAttributeChanged(const hazelcast::client::MemberAttributeEvent &memberAttributeEvent) {
+    void memberAttributeChanged(const hazelcast::client::MemberAttributeEvent &memberAttributeEvent) override {
         std::cout << "[MyInitialMemberListener::memberAttributeChanged] Member attribute:" <<
         memberAttributeEvent.getKey()
         << " changed. Value:" << memberAttributeEvent.getValue() << " for member:" <<
@@ -50,17 +50,17 @@ public:
 class MyMemberListener : public hazelcast::client::MembershipListener {
 
 public:
-    void memberAdded(const hazelcast::client::MembershipEvent &membershipEvent) {
+    void memberAdded(const hazelcast::client::MembershipEvent &membershipEvent) override {
         std::cout << "[MyMemberListener::memberAdded] New member joined:" << membershipEvent.getMember().getAddress() <<
         std::endl;
     }
 
-    void memberRemoved(const hazelcast::client::MembershipEvent &membershipEvent) {
+    void memberRemoved(const hazelcast::client::MembershipEvent &membershipEvent) override {
         std::cout << "[MyMemberListener::memberRemoved] Member left:" <<
         membershipEvent.getMember().getAddress() << std::endl;
     }
 
-    void memberAttributeChanged(const hazelcast::client::MemberAttributeEvent &memberAttributeEvent) {
+    void memberAttributeChanged(const hazelcast::client::MemberAttributeEvent &memberAttributeEvent) override {
         std::cout << "[MyMemberListener::memberAttributeChanged] Member attribute:" << memberAttributeEvent.getKey()
         << " changed. Value:" << memberAttributeEvent.getValue() << " for member:" <<
         memberAttributeEvent.getMember().getAddress() << std::endl;

--- a/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
+++ b/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
@@ -23,7 +23,7 @@ class DisconnectedListener : public hazelcast::client::LifecycleListener {
 public:
     DisconnectedListener() : disconnectedLatch(1), connectedLatch(1) {}
 
-    virtual void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) {
+    void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) override {
         if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_DISCONNECTED) {
             disconnectedLatch.count_down();
         } else if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_CONNECTED) {

--- a/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
+++ b/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
@@ -23,7 +23,7 @@ class DisconnectedListener : public hazelcast::client::LifecycleListener {
 public:
     DisconnectedListener() : disconnectedLatch(1), connectedLatch(1) {}
 
-    virtual void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) {
+    void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) override {
         if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_DISCONNECTED) {
             disconnectedLatch.count_down();
         } else if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_CONNECTED) {

--- a/examples/network-configuration/connection-strategy/StartAsync.cpp
+++ b/examples/network-configuration/connection-strategy/StartAsync.cpp
@@ -22,7 +22,7 @@ class ConnectedListener : public hazelcast::client::LifecycleListener {
 public:
     ConnectedListener() : l(1) {}
 
-    virtual void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) {
+    void stateChanged(const hazelcast::client::LifecycleEvent &lifecycleEvent) override {
         if (lifecycleEvent.getState() == hazelcast::client::LifecycleEvent::CLIENT_CONNECTED) {
             l.count_down();
         }

--- a/examples/network-configuration/socket-interceptor/main.cpp
+++ b/examples/network-configuration/socket-interceptor/main.cpp
@@ -18,7 +18,7 @@
 
 class MyInterceptor : public hazelcast::client::SocketInterceptor {
 public:
-    void onConnect(const hazelcast::client::Socket &connectedSocket) {
+    void onConnect(const hazelcast::client::Socket &connectedSocket) override {
         std::cout << "[MyInterceptor::onConnect] Connected to remote host " <<
         connectedSocket.getAddress() << std::endl;
     }

--- a/examples/replicated-map/entry-listener/ListeningReplicatedMap.cpp
+++ b/examples/replicated-map/entry-listener/ListeningReplicatedMap.cpp
@@ -17,35 +17,35 @@
 
 class MyEntryListener : public hazelcast::client::EntryListener {
 public:
-    void entryAdded(const hazelcast::client::EntryEvent &event) {
+    void entryAdded(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryAdded] " << event << std::endl;
     }
 
-    void entryRemoved(const hazelcast::client::EntryEvent &event) {
+    void entryRemoved(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryRemoved] " << event << std::endl;
     }
 
-    void entryUpdated(const hazelcast::client::EntryEvent &event) {
+    void entryUpdated(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryAdded] " << event << std::endl;
     }
 
-    void entryEvicted(const hazelcast::client::EntryEvent &event) {
+    void entryEvicted(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryUpdated] " << event << std::endl;
     }
 
-    void entryExpired(const hazelcast::client::EntryEvent &event) {
+    void entryExpired(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryExpired] " << event << std::endl;
     }
 
-    void entryMerged(const hazelcast::client::EntryEvent &event) {
+    void entryMerged(const hazelcast::client::EntryEvent &event) override {
         std::cout << "[entryMerged] " << event << std::endl;
     }
 
-    void mapEvicted(const hazelcast::client::MapEvent &event) {
+    void mapEvicted(const hazelcast::client::MapEvent &event) override {
         std::cout << "[mapEvicted] " << event << std::endl;
     }
 
-    void mapCleared(const hazelcast::client::MapEvent &event) {
+    void mapCleared(const hazelcast::client::MapEvent &event) override {
         std::cout << "[mapCleared] " << event << std::endl;
     }
 };

--- a/hazelcast/include/hazelcast/client/DistributedObject.h
+++ b/hazelcast/include/hazelcast/client/DistributedObject.h
@@ -72,7 +72,7 @@ namespace hazelcast {
             /**
             * Destructor
             */
-            virtual ~DistributedObject() {}
+            virtual ~DistributedObject() = default;
         };
 
     }

--- a/hazelcast/include/hazelcast/client/EntryAdapter.h
+++ b/hazelcast/include/hazelcast/client/EntryAdapter.h
@@ -31,23 +31,23 @@ namespace hazelcast {
         */
         class HAZELCAST_API EntryAdapter : public EntryListener {
         public:
-            virtual ~EntryAdapter() {}
+            ~EntryAdapter() override = default;
 
-            virtual void entryAdded(const EntryEvent& event) {}
+            void entryAdded(const EntryEvent& event) override {}
 
-            virtual void entryRemoved(const EntryEvent& event) {}
+            void entryRemoved(const EntryEvent& event) override {}
 
-            virtual void entryUpdated(const EntryEvent& event) {}
+            void entryUpdated(const EntryEvent& event) override {}
 
-            virtual void entryEvicted(const EntryEvent& event) {}
+            void entryEvicted(const EntryEvent& event) override {}
 
-            virtual void entryExpired(const EntryEvent& event) {}
+            void entryExpired(const EntryEvent& event) override {}
 
-            virtual void entryMerged(const EntryEvent& event) {}
+            void entryMerged(const EntryEvent& event) override {}
 
-            virtual void mapEvicted(const MapEvent& event) {}
+            void mapEvicted(const MapEvent& event) override {}
 
-            virtual void mapCleared(const MapEvent& event) {}
+            void mapCleared(const MapEvent& event) override {}
         };
     }
 }

--- a/hazelcast/include/hazelcast/client/EntryListener.h
+++ b/hazelcast/include/hazelcast/client/EntryListener.h
@@ -40,7 +40,7 @@ namespace hazelcast {
         */
         class EntryListener {
         public:
-            virtual ~EntryListener() {}
+            virtual ~EntryListener() = default;
 
             /**
             * Invoked when an entry is added.

--- a/hazelcast/include/hazelcast/client/ExecutionCallback.h
+++ b/hazelcast/include/hazelcast/client/ExecutionCallback.h
@@ -39,7 +39,7 @@ namespace hazelcast {
         template <typename V>
         class ExecutionCallback {
         public:
-            virtual ~ExecutionCallback() { }
+            virtual ~ExecutionCallback() = default;
 
             /**
              * Called when an execution is completed successfully.

--- a/hazelcast/include/hazelcast/client/IExecutorService.h
+++ b/hazelcast/include/hazelcast/client/IExecutorService.h
@@ -510,7 +510,7 @@ namespace hazelcast {
                 }
 
             public:
-                virtual void onResponse(const Member &member, const boost::optional<T> &value) {
+                void onResponse(const Member &member, const boost::optional<T> &value) override {
                     multiExecutionCallback->onResponse(member, value);
 
                     std::lock_guard<std::mutex> guard(lock);
@@ -521,8 +521,8 @@ namespace hazelcast {
                     }
                 }
 
-                virtual void
-                onFailure(const Member &member, std::exception_ptr exception) {
+                void
+                onFailure(const Member &member, std::exception_ptr exception) override {
                     multiExecutionCallback->onFailure(member, exception);
 
                     std::lock_guard<std::mutex> guard(lock);
@@ -533,8 +533,8 @@ namespace hazelcast {
                     }
                 }
 
-                virtual void onComplete(const std::unordered_map<Member, boost::optional<T> > &vals,
-                                        const std::unordered_map<Member, std::exception_ptr> &excs) {
+                void onComplete(const std::unordered_map<Member, boost::optional<T> > &vals,
+                                        const std::unordered_map<Member, std::exception_ptr> &excs) override {
                     multiExecutionCallback->onComplete(vals, excs);
                 }
 
@@ -556,11 +556,11 @@ namespace hazelcast {
                         Member member) : multiExecutionCallbackWrapper(multiExecutionCallbackWrapper),
                                                 member(std::move(member)) {}
 
-                virtual void onResponse(const boost::optional<T> &response) {
+                void onResponse(const boost::optional<T> &response) override {
                     multiExecutionCallbackWrapper->onResponse(member, response);
                 }
 
-                virtual void onFailure(std::exception_ptr e) {
+                void onFailure(std::exception_ptr e) override {
                     multiExecutionCallbackWrapper->onFailure(member, e);
                 }
 

--- a/hazelcast/include/hazelcast/client/InitialMembershipListener.h
+++ b/hazelcast/include/hazelcast/client/InitialMembershipListener.h
@@ -55,7 +55,7 @@ namespace hazelcast {
             friend class spi::impl::ClientClusterServiceImpl;
             friend class InitialMembershipListenerDelegator;
         public:
-            virtual ~InitialMembershipListener();
+            ~InitialMembershipListener() override;
 
             /**
              * Is called when this listener is registered.
@@ -65,27 +65,27 @@ namespace hazelcast {
             virtual void init(const InitialMembershipEvent &event) = 0;
 
         private:
-            virtual bool shouldRequestInitialMembers() const;
+            bool shouldRequestInitialMembers() const override;
         };
 
         class InitialMembershipListenerDelegator : public InitialMembershipListener {
         public:
             InitialMembershipListenerDelegator(InitialMembershipListener *listener);
 
-            virtual void init(const InitialMembershipEvent &event);
+            void init(const InitialMembershipEvent &event) override;
 
-            virtual void memberRemoved(const MembershipEvent &membershipEvent);
+            void memberRemoved(const MembershipEvent &membershipEvent) override;
 
-            virtual void memberAdded(const MembershipEvent &membershipEvent);
+            void memberAdded(const MembershipEvent &membershipEvent) override;
 
-            virtual void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent);
+            void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) override;
 
         private:
-            virtual bool shouldRequestInitialMembers() const;
+            bool shouldRequestInitialMembers() const override;
 
-            virtual const std::string &getRegistrationId() const;
+            const std::string &getRegistrationId() const override;
 
-            virtual void setRegistrationId(const std::string &registrationId);
+            void setRegistrationId(const std::string &registrationId) override;
 
             InitialMembershipListener *listener;
         };

--- a/hazelcast/include/hazelcast/client/ItemListener.h
+++ b/hazelcast/include/hazelcast/client/ItemListener.h
@@ -31,7 +31,7 @@ namespace hazelcast {
         */
         class HAZELCAST_API ItemListener {
         public:
-            virtual ~ItemListener() {}
+            virtual ~ItemListener() = default;
 
             /**
             * Invoked when an item is added.

--- a/hazelcast/include/hazelcast/client/MembershipListener.h
+++ b/hazelcast/include/hazelcast/client/MembershipListener.h
@@ -96,20 +96,20 @@ namespace hazelcast {
         public:
             MembershipListenerDelegator(MembershipListener *listener);
 
-            virtual void memberAdded(const MembershipEvent &membershipEvent);
+            void memberAdded(const MembershipEvent &membershipEvent) override;
 
-            virtual void memberRemoved(const MembershipEvent &membershipEvent);
+            void memberRemoved(const MembershipEvent &membershipEvent) override;
 
-            virtual void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent);
+            void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) override;
 
         protected:
             MembershipListener *listener;
 
-            virtual bool shouldRequestInitialMembers() const;
+            bool shouldRequestInitialMembers() const override;
 
-            virtual void setRegistrationId(const std::string &registrationId);
+            void setRegistrationId(const std::string &registrationId) override;
 
-            virtual const std::string &getRegistrationId() const;
+            const std::string &getRegistrationId() const override;
         };
     }
 }

--- a/hazelcast/include/hazelcast/client/MultiExecutionCallback.h
+++ b/hazelcast/include/hazelcast/client/MultiExecutionCallback.h
@@ -40,7 +40,7 @@ namespace hazelcast {
         template<typename V>
         class MultiExecutionCallback {
         public:
-            virtual ~MultiExecutionCallback() {}
+            virtual ~MultiExecutionCallback() = default;
 
             /**
              * Called when an execution is completed on a member.

--- a/hazelcast/include/hazelcast/client/ReplicatedMap.h
+++ b/hazelcast/include/hazelcast/client/ReplicatedMap.h
@@ -265,12 +265,12 @@ namespace hazelcast {
                         : instanceName(instanceName), clusterService(clusterService), serializationService(serializationService)
                         , listener(listener), logger(log) {}
 
-                virtual void handleEntryEventV10(std::unique_ptr<serialization::pimpl::Data> &key,
+                void handleEntryEventV10(std::unique_ptr<serialization::pimpl::Data> &key,
                                                  std::unique_ptr<serialization::pimpl::Data> &value,
                                                  std::unique_ptr<serialization::pimpl::Data> &oldValue,
                                                  std::unique_ptr<serialization::pimpl::Data> &mergingValue,
                                                  const int32_t &eventType, const std::string &uuid,
-                                                 const int32_t &numberOfAffectedEntries) {
+                                                 const int32_t &numberOfAffectedEntries) override {
                     if (eventType == static_cast<int32_t>(EntryEvent::type::CLEAR_ALL)) {
                         fireMapWideEvent(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;

--- a/hazelcast/include/hazelcast/client/Socket.h
+++ b/hazelcast/include/hazelcast/client/Socket.h
@@ -41,8 +41,7 @@ namespace hazelcast {
 
         class HAZELCAST_API Socket {
         public:
-            virtual ~Socket() {
-            }
+            virtual ~Socket() = default;
 
             virtual void
             asyncStart(const std::shared_ptr<connection::Connection> connection,

--- a/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/aws/impl/AwsAddressTranslator.h
@@ -47,12 +47,12 @@ namespace hazelcast {
                      *
                      * @throws IOException if the address can not be translated.
                      */
-                    Address translate(const Address &address);
+                    Address translate(const Address &address) override;
 
                     /**
                      * Update the internal lookup table from AWS.
                      */
-                    void refresh();
+                    void refresh() override;
 
                 private:
                     bool findFromCache(const Address &address, Address &translatedAddress);

--- a/hazelcast/include/hazelcast/client/cluster/memberselector/MemberSelectors.h
+++ b/hazelcast/include/hazelcast/client/cluster/memberselector/MemberSelectors.h
@@ -52,7 +52,7 @@ namespace hazelcast {
                      */
                     virtual bool select(const Member &member) const = 0;
 
-                    virtual ~MemberSelector(){};
+                    virtual ~MemberSelector() = default;
 
                     virtual void toString(std::ostream &os) const = 0;
 
@@ -68,10 +68,10 @@ namespace hazelcast {
                 class MemberSelectors {
                 public:
                     class DataMemberSelector : public MemberSelector {
-                        virtual bool select(const Member &member) const;
+                        bool select(const Member &member) const override;
 
                     public:
-                        virtual void toString(std::ostream &os) const;
+                        void toString(std::ostream &os) const override;
                     };
 
                     static const std::unique_ptr<MemberSelector> DATA_MEMBER_SELECTOR;

--- a/hazelcast/include/hazelcast/client/config/EvictionConfig.h
+++ b/hazelcast/include/hazelcast/client/config/EvictionConfig.h
@@ -42,8 +42,7 @@ namespace hazelcast {
             template<typename K, typename V>
             class EvictionConfig : public internal::eviction::EvictionConfiguration<K, V> {
             public:
-                virtual ~EvictionConfig() {
-                }
+                ~EvictionConfig() override = default;
 
                 /**
                  * Maximum Size Policy
@@ -129,7 +128,7 @@ namespace hazelcast {
                     return *this;
                 }
 
-                const std::shared_ptr<internal::eviction::EvictionPolicyComparator<K, V> > getComparator() const {
+                const std::shared_ptr<internal::eviction::EvictionPolicyComparator<K, V> > getComparator() const override {
                     return comparator;
                 }
 
@@ -139,12 +138,12 @@ namespace hazelcast {
                     return *this;
                 }
 
-                internal::eviction::EvictionStrategyType::Type getEvictionStrategyType() const {
+                internal::eviction::EvictionStrategyType::Type getEvictionStrategyType() const override {
                     // TODO: add support for other/custom eviction strategies
                     return internal::eviction::EvictionStrategyType::DEFAULT_EVICTION_STRATEGY;
                 }
 
-                internal::eviction::EvictionPolicyType getEvictionPolicyType() const {
+                internal::eviction::EvictionPolicyType getEvictionPolicyType() const override {
                     if (evictionPolicy == LFU) {
                         return internal::eviction::LFU;
                     } else if (evictionPolicy == LRU) {

--- a/hazelcast/include/hazelcast/client/config/NearCacheConfig.h
+++ b/hazelcast/include/hazelcast/client/config/NearCacheConfig.h
@@ -122,8 +122,7 @@ namespace hazelcast {
                     }
                 }
 
-                virtual ~NearCacheConfig() {
-                }
+                virtual ~NearCacheConfig() = default;
 
                 /**
                  * Gets the name of the Near Cache.

--- a/hazelcast/include/hazelcast/client/config/matcher/MatchingPointConfigPatternMatcher.h
+++ b/hazelcast/include/hazelcast/client/config/matcher/MatchingPointConfigPatternMatcher.h
@@ -33,8 +33,8 @@ namespace hazelcast {
                  */
                 class HAZELCAST_API MatchingPointConfigPatternMatcher : public ConfigPatternMatcher {
                 public:
-                    virtual std::shared_ptr<std::string>
-                    matches(const std::vector<std::string> &configPatterns, const std::string &itemName) const;
+                    std::shared_ptr<std::string>
+                    matches(const std::vector<std::string> &configPatterns, const std::string &itemName) const override;
 
                 private:
                     int getMatchingPoint(const std::string &pattern, const std::string &itemName) const;

--- a/hazelcast/include/hazelcast/client/connection/AddressProvider.h
+++ b/hazelcast/include/hazelcast/client/connection/AddressProvider.h
@@ -34,7 +34,7 @@ namespace hazelcast {
                  */
                 virtual std::vector<Address> loadAddresses() = 0;
 
-                virtual ~AddressProvider(){};
+                virtual ~AddressProvider() = default;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/connection/AddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/connection/AddressTranslator.h
@@ -29,8 +29,7 @@ namespace hazelcast {
         namespace connection {
             class HAZELCAST_API AddressTranslator {
             public:
-                virtual ~AddressTranslator() {
-                }
+                virtual ~AddressTranslator() = default;
 
                 /**
                  * Translates the given address to another address specific to

--- a/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
+++ b/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
@@ -148,7 +148,7 @@ namespace hazelcast {
 
                 void onClose(Connection &connection);
 
-                virtual void addConnectionListener(const std::shared_ptr<ConnectionListener> &connectionListener);
+                void addConnectionListener(const std::shared_ptr<ConnectionListener> &connectionListener) override;
 
                 util::ILogger &getLogger();
 

--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -75,13 +75,13 @@ namespace hazelcast {
                            std::chrono::steady_clock::duration &connectTimeoutInMillis,
                            boost::asio::ip::tcp::resolver &resolver);
 
-                virtual ~Connection();
+                ~Connection() override;
 
                 void asyncStart();
 
                 void close();
 
-                void close(const std::string &reason);
+                void close(const std::string &reason) override;
 
                 void close(const std::string &reason, std::exception_ptr cause);
 

--- a/hazelcast/include/hazelcast/client/connection/DefaultClientConnectionStrategy.h
+++ b/hazelcast/include/hazelcast/client/connection/DefaultClientConnectionStrategy.h
@@ -37,21 +37,21 @@ namespace hazelcast {
                                                 const config::ClientConnectionStrategyConfig &clientConnectionStrategyConfig);
 
 
-                virtual void start();
+                void start() override;
 
-                virtual void beforeGetConnection(const Address &target);
+                void beforeGetConnection(const Address &target) override;
 
-                virtual void beforeOpenConnection(const Address &target);
+                void beforeOpenConnection(const Address &target) override;
 
-                virtual void onConnectToCluster();
+                void onConnectToCluster() override;
 
-                virtual void onDisconnectFromCluster();
+                void onDisconnectFromCluster() override;
 
-                virtual void onConnect(const std::shared_ptr<Connection> &connection);
+                void onConnect(const std::shared_ptr<Connection> &connection) override;
 
-                virtual void onDisconnect(const std::shared_ptr<Connection> &connection);
+                void onDisconnect(const std::shared_ptr<Connection> &connection) override;
 
-                virtual void shutdown();
+                void shutdown() override;
 
                 static void
                 shutdownWithExternalThread(std::weak_ptr<client::impl::HazelcastClientInstanceImpl> clientImpl);

--- a/hazelcast/include/hazelcast/client/exception/IException.h
+++ b/hazelcast/include/hazelcast/client/exception/IException.h
@@ -53,13 +53,13 @@ namespace hazelcast {
                 IException(const std::string &exceptionName, const std::string &source, const std::string &message,
                            const std::string &details, int32_t errorNo, bool isRuntime = false, bool retryable = false);
 
-                virtual ~IException() noexcept;
+                ~IException() noexcept override;
 
                 /**
                  *
                  * return  pointer to the explanation string.
                  */
-                virtual char const *what() const noexcept;
+                char const *what() const noexcept override;
 
                 const std::string &getSource() const;
 

--- a/hazelcast/include/hazelcast/client/impl/AbstractLoadBalancer.h
+++ b/hazelcast/include/hazelcast/client/impl/AbstractLoadBalancer.h
@@ -44,17 +44,17 @@ namespace hazelcast {
 
                 std::vector<Member> getMembers();
 
-                virtual void init(Cluster &cluster);
+                void init(Cluster &cluster) override;
 
-                void memberAdded(const MembershipEvent &membershipEvent);
+                void memberAdded(const MembershipEvent &membershipEvent) override;
 
-                void memberRemoved(const MembershipEvent &membershipEvent);
+                void memberRemoved(const MembershipEvent &membershipEvent) override;
 
-                virtual void init(const InitialMembershipEvent &event);
+                void init(const InitialMembershipEvent &event) override;
 
-                void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent);
+                void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) override;
 
-                virtual ~AbstractLoadBalancer();
+                ~AbstractLoadBalancer() override;
 
             private:
                 std::mutex membersLock;

--- a/hazelcast/include/hazelcast/client/impl/BaseEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/BaseEventHandler.h
@@ -38,12 +38,12 @@ namespace hazelcast {
             public:
                 BaseEventHandler();
 
-                virtual ~BaseEventHandler();
+                ~BaseEventHandler() override;
                 
                 virtual void handle(std::unique_ptr<protocol::ClientMessage> message) = 0;
 
                 // TODO: Remove the above method after changing and regenerating the codecs
-                virtual void handle(const std::shared_ptr<protocol::ClientMessage> &event);
+                void handle(const std::shared_ptr<protocol::ClientMessage> &event) override;
 
                 std::string registrationId;
 
@@ -53,7 +53,7 @@ namespace hazelcast {
                  *  Note that this method will also be called while first registered node is dead
                  *  and re-registering to a second node.
                  */
-                virtual void beforeListenerRegister() {
+                void beforeListenerRegister() override {
                 }
 
                 /**
@@ -62,7 +62,7 @@ namespace hazelcast {
                  *  Note that this method will also be called while first registered node is dead
                  *  and re-registering to a second node.
                  */
-                virtual void onListenerRegister() {
+                void onListenerRegister() override {
                 }
 
                 void setLogger(util::ILogger *iLogger);

--- a/hazelcast/include/hazelcast/client/impl/EntryEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/EntryEventHandler.h
@@ -43,12 +43,12 @@ namespace hazelcast {
                 : instanceName(instanceName), clusterService(clusterService), serializationService(serializationService)
                 , listener(listener), includeValue(includeValue), logger(log) {}
 
-                virtual void handleEntryEventV10(std::unique_ptr<serialization::pimpl::Data> &key,
+                void handleEntryEventV10(std::unique_ptr<serialization::pimpl::Data> &key,
                                          std::unique_ptr<serialization::pimpl::Data> &value,
                                          std::unique_ptr<serialization::pimpl::Data> &oldValue,
                                          std::unique_ptr<serialization::pimpl::Data> &mergingValue,
                                          const int32_t &eventType, const std::string &uuid,
-                                         const int32_t &numberOfAffectedEntries) {
+                                         const int32_t &numberOfAffectedEntries) override {
                     if (eventType == static_cast<int32_t>(EntryEvent::type::EVICT_ALL) || eventType == static_cast<int32_t>(EntryEvent::type::CLEAR_ALL)) {
                         fireMapWideEvent(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;

--- a/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
+++ b/hazelcast/include/hazelcast/client/impl/HazelcastClientInstanceImpl.h
@@ -227,9 +227,9 @@ namespace hazelcast {
                 int32_t id;
                 std::shared_ptr<ClientLockReferenceIdGenerator> lockReferenceIdGenerator;
                 std::shared_ptr<util::ILogger> logger;
-                HazelcastClientInstanceImpl(const HazelcastClientInstanceImpl& rhs);
+                HazelcastClientInstanceImpl(const HazelcastClientInstanceImpl& rhs) = delete;
 
-                void operator=(const HazelcastClientInstanceImpl& rhs);
+                void operator=(const HazelcastClientInstanceImpl& rhs) = delete;
 
                 std::shared_ptr<spi::ClientListenerService> initListenerService();
 

--- a/hazelcast/include/hazelcast/client/impl/ItemEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/ItemEventHandler.h
@@ -34,8 +34,8 @@ namespace hazelcast {
                         : instanceName(instanceName), clusterService(clusterService),
                           serializationService(serializationService), listener(listener), includeValue(includeValue) {};
 
-                virtual void handleItemEventV10(std::unique_ptr<serialization::pimpl::Data> &item, const std::string &uuid,
-                                        const int32_t &eventType) {
+                void handleItemEventV10(std::unique_ptr<serialization::pimpl::Data> &item, const std::string &uuid,
+                                        const int32_t &eventType) override {
                     TypedData val;
                     if (includeValue) {
                         val = TypedData(std::move(*item), serializationService);

--- a/hazelcast/include/hazelcast/client/impl/Partition.h
+++ b/hazelcast/include/hazelcast/client/impl/Partition.h
@@ -51,7 +51,7 @@ namespace hazelcast {
                  */
                 virtual boost::optional<Member> getOwner() const = 0;
 
-                virtual ~Partition(){};
+                virtual ~Partition() = default;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/impl/RoundRobinLB.h
+++ b/hazelcast/include/hazelcast/client/impl/RoundRobinLB.h
@@ -40,9 +40,9 @@ namespace hazelcast {
 
                 RoundRobinLB(const RoundRobinLB &rhs);
 
-                void init(Cluster &cluster);
+                void init(Cluster &cluster) override;
 
-                const Member next();
+                const Member next() override;
 
             private:
                 util::AtomicInt index;

--- a/hazelcast/include/hazelcast/client/internal/eviction/Evictable.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/Evictable.h
@@ -33,7 +33,7 @@ namespace hazelcast {
                 template <typename V>
                 class Evictable {
                 public:
-                    virtual ~Evictable() { }
+                    virtual ~Evictable() = default;
 
                     /**
                      * Gets the creation time of this {@link Evictable} in milliseconds.

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictableEntryView.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictableEntryView.h
@@ -38,7 +38,7 @@ namespace hazelcast {
                 template <typename K, typename V>
                 class EvictableEntryView {
                 public:
-                    virtual ~EvictableEntryView() { }
+                    virtual ~EvictableEntryView() = default;
 
                     /**
                      * Gets the creation time of this {@link EvictableEntryView} in milliseconds.

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictableStore.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictableStore.h
@@ -44,7 +44,7 @@ namespace hazelcast {
                 template<typename MAPKEY, typename MAPVALUE, typename A, typename E>
                 class EvictableStore {
                 public:
-                    virtual ~EvictableStore() { }
+                    virtual ~EvictableStore() = default;
 
                     /**
                      * The evict method is called by the {@link EvictionStrategy} to eventually evict, by the policy, selected

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionChecker.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionChecker.h
@@ -33,7 +33,7 @@ namespace hazelcast {
                  */
                 class HAZELCAST_API EvictionChecker {
                 public:
-                    virtual ~EvictionChecker() { }
+                    virtual ~EvictionChecker() = default;
 
                     /**
                      * Empty {@link} EvictionChecker to allow eviction always.
@@ -50,8 +50,7 @@ namespace hazelcast {
 
                 class HAZELCAST_API EvictAlways : public EvictionChecker {
                 public:
-                    //@override
-                    bool isEvictionRequired() const;
+                    bool isEvictionRequired() const override;
                 };
             }
         }

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionConfiguration.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionConfiguration.h
@@ -36,7 +36,7 @@ namespace hazelcast {
                 template <typename K, typename V>
                 class EvictionConfiguration {
                 public:
-                    virtual ~EvictionConfiguration() { }
+                    virtual ~EvictionConfiguration() = default;
 
                     /**
                      * Gets the type of eviction strategy.

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionListener.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionListener.h
@@ -36,7 +36,7 @@ namespace hazelcast {
                 template <typename A, typename E>
                 class EvictionListener {
                 public:
-                    virtual ~EvictionListener() { }
+                    virtual ~EvictionListener() = default;
 
                     /**
                      * Empty {@link} EvictionListener

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyComparator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyComparator.h
@@ -36,8 +36,7 @@ namespace hazelcast {
                 template<typename K, typename V>
                 class EvictionPolicyComparator : util::Comparator<EvictableEntryView<K, V> > {
                 public:
-                    virtual ~EvictionPolicyComparator() {
-                    }
+                    ~EvictionPolicyComparator() override = default;
 
                     /**
                      * Integer constant for representing behaviour for giving higher priority to first entry to be evicted.
@@ -68,8 +67,7 @@ namespace hazelcast {
                      *
                      * @return the result of comparison
                      */
-                    //@Override
-                    virtual int compare(const EvictableEntryView<K, V> *e1, const EvictableEntryView<K, V> *e2) const {
+                    int compare(const EvictableEntryView<K, V> *e1, const EvictableEntryView<K, V> *e2) const override {
                         assert(0);
                         return 0;
                     }

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyEvaluator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyEvaluator.h
@@ -44,8 +44,7 @@ namespace hazelcast {
                 template<typename MAPKEY, typename MAPVALUE, typename A, typename E>
                 class EvictionPolicyEvaluator {
                 public:
-                    virtual ~EvictionPolicyEvaluator() {
-                    }
+                    virtual ~EvictionPolicyEvaluator() = default;
 
                     /**
                      * Gets the underlying {@link EvictionPolicyComparator}.

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyEvaluatorProvider.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionPolicyEvaluatorProvider.h
@@ -93,9 +93,9 @@ namespace hazelcast {
                     }
 
                     //Non-constructable class
-                    EvictionPolicyEvaluatorProvider();
+                    EvictionPolicyEvaluatorProvider() = delete;
 
-                    ~EvictionPolicyEvaluatorProvider();
+                    ~EvictionPolicyEvaluatorProvider() = delete;
                 };
 
             }

--- a/hazelcast/include/hazelcast/client/internal/eviction/EvictionStrategy.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/EvictionStrategy.h
@@ -46,8 +46,7 @@ namespace hazelcast {
                 template <typename MAPKEY, typename MAPVALUE,typename A, typename E, typename S>
                 class EvictionStrategy {
                 public:
-                    virtual ~EvictionStrategy() {
-                    }
+                    virtual ~EvictionStrategy() = default;
 
                     /**
                      * Does eviction if eviction is required by given {@link EvictionChecker}.

--- a/hazelcast/include/hazelcast/client/internal/eviction/Expirable.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/Expirable.h
@@ -35,7 +35,7 @@ namespace hazelcast {
                  */
                 class HAZELCAST_API Expirable {
                 public:
-                    virtual ~Expirable() {}
+                    virtual ~Expirable() = default;
 
                     /**
                      * Gets the expiration time in milliseconds.

--- a/hazelcast/include/hazelcast/client/internal/eviction/MaxSizeChecker.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/MaxSizeChecker.h
@@ -31,7 +31,7 @@ namespace hazelcast {
                  */
                 class HAZELCAST_API MaxSizeChecker {
                 public:
-                    virtual ~MaxSizeChecker() { }
+                    virtual ~MaxSizeChecker() = default;
 
                     /**
                      * Checks the state to see if it has reached its maximum configured size

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.h
@@ -36,8 +36,7 @@ namespace hazelcast {
                         template<typename A, typename E>
                         class LFUEvictionPolicyComparator : public EvictionPolicyComparator<A, E> {
                         public:
-                            //@Override
-                            int compare(const EvictableEntryView<A, E> *e1, const EvictableEntryView<A, E> *e2) const {
+                            int compare(const EvictableEntryView<A, E> *e1, const EvictableEntryView<A, E> *e2) const override {
                                 int64_t hits1 = e1->getAccessHit();
                                 int64_t hits2 = e2->getAccessHit();
                                 if (hits2 < hits1) {

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.h
@@ -36,8 +36,7 @@ namespace hazelcast {
                         template<typename A, typename E>
                         class LRUEvictionPolicyComparator : public EvictionPolicyComparator<A, E> {
                         public:
-                            //@Override
-                            int compare(const EvictableEntryView<A, E> *e1, const EvictableEntryView<A, E> *e2) const {
+                            int compare(const EvictableEntryView<A, E> *e1, const EvictableEntryView<A, E> *e2) const override {
                                 int64_t accessTime1 = e1->getLastAccessTime();
                                 int64_t accessTime2 = e2->getLastAccessTime();
                                 if (accessTime2 < accessTime1) {

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.h
@@ -36,8 +36,7 @@ namespace hazelcast {
                         template<typename A, typename E>
                         class RandomEvictionPolicyComparator : public EvictionPolicyComparator<A, E> {
                         public:
-                            //@Override
-                            int compare(const EvictableEntryView<A, E> *e1, const EvictableEntryView<A, E> *e2) const {
+                            int compare(const EvictableEntryView<A, E> *e1, const EvictableEntryView<A, E> *e2) const override {
                                 return 0;
                             }
                         };

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/evaluator/DefaultEvictionPolicyEvaluator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/evaluator/DefaultEvictionPolicyEvaluator.h
@@ -49,8 +49,7 @@ namespace hazelcast {
                                     : evictionPolicyComparator(comparator) {
                             }
 
-                            //@Override
-                            const std::shared_ptr<EvictionPolicyComparator<MAPKEY, MAPVALUE> > getEvictionPolicyComparator() const {
+                            const std::shared_ptr<EvictionPolicyComparator<MAPKEY, MAPVALUE> > getEvictionPolicyComparator() const override {
                                 return evictionPolicyComparator;
                             }
 
@@ -62,9 +61,8 @@ namespace hazelcast {
                              *
                              * @return multiple {@link com.hazelcast.internal.eviction.EvictionCandidate} these are available to be evicted
                              */
-                            //@Override
                             std::unique_ptr<std::vector<std::shared_ptr<eviction::EvictionCandidate<MAPKEY, MAPVALUE, A, E> > > > evaluate(
-                                    util::Iterable<EvictionCandidate<MAPKEY, MAPVALUE, A, E> > &evictionCandidates) const {
+                                    util::Iterable<EvictionCandidate<MAPKEY, MAPVALUE, A, E> > &evictionCandidates) const override {
                                 std::shared_ptr<eviction::EvictionCandidate<MAPKEY, MAPVALUE, A, E> > selectedEvictionCandidate;
                                 int64_t now = util::currentTimeMillis();
                                 util::Iterator<EvictionCandidate<MAPKEY, MAPVALUE, A, E> > *iterator = evictionCandidates.iterator();

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/strategy/AbstractEvictionStrategy.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/strategy/AbstractEvictionStrategy.h
@@ -54,9 +54,8 @@ namespace hazelcast {
                              *
                              * @return evicted entry count
                              */
-                            //@Override
                             int evict(S *evictableStore, EvictionPolicyEvaluator<MAPKEY, MAPVALUE, A, E> *evictionPolicyEvaluator,
-                                      EvictionChecker *evictionChecker, EvictionListener<A, E> *evictionListener) {
+                                      EvictionChecker *evictionChecker, EvictionListener<A, E> *evictionListener) override {
                                 if (evictionChecker != NULL) {
                                     if (evictionChecker->isEvictionRequired()) {
                                         return evictInternal(evictableStore, evictionPolicyEvaluator, evictionListener);

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/strategy/sampling/SamplingBasedEvictionStrategy.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/strategy/sampling/SamplingBasedEvictionStrategy.h
@@ -51,10 +51,9 @@ namespace hazelcast {
                                  *
                                  * @return evicted entry count
                                  */
-                                //@Override
                                 int evictInternal(S *sampleableEvictableStore,
                                                   EvictionPolicyEvaluator<MAPKEY, MAPVALUE, A, E> *evictionPolicyEvaluator,
-                                                  EvictionListener<A, E> *evictionListener) {
+                                                  EvictionListener<A, E> *evictionListener) override {
                                     std::unique_ptr<util::Iterable<EvictionCandidate<MAPKEY, MAPVALUE, A, E> > > samples = sampleableEvictableStore->sample(SAMPLE_COUNT);
                                     std::unique_ptr<std::vector<std::shared_ptr<eviction::EvictionCandidate<MAPKEY, MAPVALUE, A, E> > > > evictionCandidates =
                                             evictionPolicyEvaluator->evaluate(*samples);

--- a/hazelcast/include/hazelcast/client/internal/nearcache/NearCache.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/NearCache.h
@@ -85,10 +85,9 @@ namespace hazelcast {
                      */
                     static std::shared_ptr<V> NULL_OBJECT;
 
-                    virtual ~NearCache() {
-                    }
+                    ~NearCache() override = default;
 
-                    void initialize() {
+                    void initialize() override {
                         assert(0);
                     }
 

--- a/hazelcast/include/hazelcast/client/internal/nearcache/NearCacheRecord.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/NearCacheRecord.h
@@ -48,7 +48,7 @@ namespace hazelcast {
                 public:
                     static const int TIME_NOT_SET = -1;
 
-                    virtual ~NearCacheRecord() { }
+                    ~NearCacheRecord() override = default;
 
                     /**
                      * Sets the value of this {@link NearCacheRecord}.

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
@@ -53,11 +53,9 @@ namespace hazelcast {
                                   serializationService(ss), logger(logger) {
                         }
 
-                        virtual ~DefaultNearCache() {
-                        }
+                        ~DefaultNearCache() override = default;
 
-                        //@Override
-                        void initialize() {
+                        void initialize() override {
                             if (nearCacheRecordStore.get() == NULL) {
                                 nearCacheRecordStore = createNearCacheRecordStore(name, nearCacheConfig);
                             }
@@ -66,20 +64,17 @@ namespace hazelcast {
                             scheduleExpirationTask();
                         }
 
-                        //@Override
-                        const std::string &getName() const {
+                        const std::string &getName() const override {
                             return name;
                         }
 
-                        //@Override
-                        std::shared_ptr<V> get(const std::shared_ptr<KS> &key) {
+                        std::shared_ptr<V> get(const std::shared_ptr<KS> &key) override {
                             util::Preconditions::checkNotNull(key, "key cannot be null on get!");
 
                             return nearCacheRecordStore->get(key);
                         }
 
-                        //@Override
-                        void put(const std::shared_ptr<KS> &key, const std::shared_ptr<V> &value) {
+                        void put(const std::shared_ptr<KS> &key, const std::shared_ptr<V> &value) override {
                             util::Preconditions::checkNotNull<KS>(key, "key cannot be null on put!");
 
                             nearCacheRecordStore->doEvictionIfRequired();
@@ -99,24 +94,21 @@ namespace hazelcast {
                         }
 */
 
-                        bool invalidate(const std::shared_ptr<KS> &key) {
+                        bool invalidate(const std::shared_ptr<KS> &key) override {
                             util::Preconditions::checkNotNull<KS>(key, "key cannot be null on invalidate!");
 
                             return nearCacheRecordStore->invalidate(key);
                         }
 
-                        //@Override
-                        bool isInvalidatedOnChange() const {
+                        bool isInvalidatedOnChange() const override {
                             return nearCacheConfig.isInvalidateOnChange();
                         }
 
-                        //@Override
-                        void clear() {
+                        void clear() override {
                             nearCacheRecordStore->clear();
                         }
 
-                        //@Override
-                        void destroy() {
+                        void destroy() override {
                             expiration_cancelled_.store(true);
                             if (expirationTimer) {
                                 boost::system::error_code ignored;
@@ -125,8 +117,7 @@ namespace hazelcast {
                             nearCacheRecordStore->destroy();
                         }
 
-                        //@Override
-                        const client::config::InMemoryFormat getInMemoryFormat() const {
+                        const client::config::InMemoryFormat getInMemoryFormat() const override {
                             return nearCacheConfig.getInMemoryFormat();
                         }
 
@@ -135,12 +126,11 @@ namespace hazelcast {
                          *
                          * @return the {@link com.hazelcast.monitor.NearCacheStats} instance to monitor this store
                          */
-                        std::shared_ptr<monitor::NearCacheStats> getNearCacheStats() const {
+                        std::shared_ptr<monitor::NearCacheStats> getNearCacheStats() const override {
                             return nearCacheRecordStore->getNearCacheStats();
                         }
 
-                        //@Override
-                        int size() const {
+                        int size() const override {
                             return nearCacheRecordStore->size();
                         }
 

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/KeyStateMarkerImpl.h
@@ -35,17 +35,17 @@ namespace hazelcast {
                     public:
                         KeyStateMarkerImpl(int count);
 
-                        virtual ~KeyStateMarkerImpl();
+                        ~KeyStateMarkerImpl() override;
 
-                        bool tryMark(const serialization::pimpl::Data &key);
+                        bool tryMark(const serialization::pimpl::Data &key) override;
 
-                        bool tryUnmark(const serialization::pimpl::Data &key);
+                        bool tryUnmark(const serialization::pimpl::Data &key) override;
 
-                        bool tryRemove(const serialization::pimpl::Data &key);
+                        bool tryRemove(const serialization::pimpl::Data &key) override;
 
-                        void forceUnmark(const serialization::pimpl::Data &key);
+                        void forceUnmark(const serialization::pimpl::Data &key) override;
 
-                        void init();
+                        void init() override;
                     private:
                         bool casState(const serialization::pimpl::Data &key, STATE expect, STATE update);
 

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/NearCacheRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/NearCacheRecordStore.h
@@ -50,8 +50,7 @@ namespace hazelcast {
                     template<typename K, typename V>
                     class NearCacheRecordStore : public spi::InitializingObject {
                     public:
-                        virtual ~NearCacheRecordStore() {
-                        }
+                        ~NearCacheRecordStore() override = default;
 
                         /**
                          * Gets the value associated with the given {@code key}.

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/maxsize/EntryCountNearCacheMaxSizeChecker.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/maxsize/EntryCountNearCacheMaxSizeChecker.h
@@ -46,8 +46,7 @@ namespace hazelcast {
                                     nearCacheRecordMap(recordMap), maxSize(size) {
                             }
 
-                            //@Override
-                            bool isReachedToMaxSize() const {
+                            bool isReachedToMaxSize() const override {
                                 return (int32_t) nearCacheRecordMap.size() >= maxSize;
                             }
                         private:

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/record/AbstractNearCacheRecord.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/record/AbstractNearCacheRecord.h
@@ -51,84 +51,68 @@ namespace hazelcast {
                                       accessTime(NearCacheRecord<V>::TIME_NOT_SET), accessHit(0) {
                             }
 
-                            //@Override
-                            std::shared_ptr<V> getValue() const {
+                            std::shared_ptr<V> getValue() const override {
                                 return value;
                             }
 
-                            //@Override
-                            void setValue(const std::shared_ptr<V> &value) {
+                            void setValue(const std::shared_ptr<V> &value) override {
                                 AbstractNearCacheRecord::value = value;
                             }
 
-                            //@Override
-                            int64_t getCreationTime() const {
+                            int64_t getCreationTime() const override {
                                 return creationTime;
                             }
 
-                            //@Override
-                            void setCreationTime(int64_t creationTime) {
+                            void setCreationTime(int64_t creationTime) override {
                                 AbstractNearCacheRecord::creationTime = creationTime;
                             }
 
-                            //@Override
                             const std::shared_ptr<util::UUID> &getUuid() const {
                                 return uuid;
                             }
 
-                            //@Override
-                            void setUuid(const std::shared_ptr<util::UUID> &uuid) {
+                            void setUuid(const std::shared_ptr<util::UUID> &uuid) override {
                                 AbstractNearCacheRecord::uuid = uuid;
                             }
 
-                            //@Override
-                            int64_t getExpirationTime() {
+                            int64_t getExpirationTime() override {
                                 return expirationTime;
                             }
 
-                            //@Override
-                            void setExpirationTime(int64_t expirationTime) {
+                            void setExpirationTime(int64_t expirationTime) override {
                                 AbstractNearCacheRecord::expirationTime = expirationTime;
                             }
 
-                            //@Override
-                            int64_t getLastAccessTime() {
+                            int64_t getLastAccessTime() override {
                                 return accessTime;
                             }
 
-                            //@Override
-                            void setAccessTime(int64_t accessTime) {
+                            void setAccessTime(int64_t accessTime) override {
                                 AbstractNearCacheRecord::accessTime = accessTime;
                             }
 
-                            //@Override
-                            int32_t getAccessHit() {
+                            int32_t getAccessHit() override {
                                 return accessHit;
                             }
 
-                            //@Override
-                            void setAccessHit(int32_t accessHit) {
+                            void setAccessHit(int32_t accessHit) override {
                                 AbstractNearCacheRecord::accessHit = accessHit;
                             }
 
-                            //@Override
-                            bool isExpiredAt(int64_t now) {
+                            bool isExpiredAt(int64_t now) override {
                                 int64_t expiration = expirationTime;
                                 return (expiration > NearCacheRecord<V>::TIME_NOT_SET) && (expiration <= now);
                             }
 
-                            //@Override
-                            void incrementAccessHit() {
+                            void incrementAccessHit() override {
                                 ++accessHit;
                             }
 
-                            //@Override
-                            void resetAccessHit() {
+                            void resetAccessHit() override {
                                 accessHit = 0;
                             }
 
-                            //@Override
-                            bool isIdleAt(int64_t maxIdleMilliSeconds, int64_t now) {
+                            bool isIdleAt(int64_t maxIdleMilliSeconds, int64_t now) override {
                                 if (maxIdleMilliSeconds > 0) {
                                     if (accessTime > NearCacheRecord<V>::TIME_NOT_SET) {
                                         return accessTime + maxIdleMilliSeconds < now;
@@ -140,18 +124,15 @@ namespace hazelcast {
                                 }
                             }
 
-                            //@Override
-                            int64_t getInvalidationSequence() const {
+                            int64_t getInvalidationSequence() const override {
                                 return sequence;
                             }
 
-                            //@Override
-                            void setInvalidationSequence(int64_t seq) {
+                            void setInvalidationSequence(int64_t seq) override {
                                 this->sequence = seq;
                             }
 
-                            //@Override
-                            bool hasSameUuid(const std::shared_ptr<util::UUID> &thatUuid) const {
+                            bool hasSameUuid(const std::shared_ptr<util::UUID> &thatUuid) const override {
                                 if (uuid.get() == NULL || thatUuid.get() == NULL) {
                                     return false;
                                 }

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/AbstractNearCacheRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/AbstractNearCacheRecordStore.h
@@ -61,8 +61,7 @@ namespace hazelcast {
                                 }
                             }
 
-                            //@override
-                            void initialize() {
+                            void initialize() override {
                                 const std::shared_ptr<client::config::EvictionConfig<K, V> > &evictionConfig = nearCacheConfig.getEvictionConfig();
                                 this->records = createNearCacheRecordMap(nearCacheConfig);
                                 this->maxSizeChecker = createNearCacheMaxSizeChecker(evictionConfig, nearCacheConfig);
@@ -88,9 +87,8 @@ namespace hazelcast {
                                 return std::shared_ptr<R>();
                             }
 
-                            //@Override
-                            virtual void onEvict(const std::shared_ptr<KS> &key, const std::shared_ptr<R> &record,
-                                                 bool wasExpired) {
+                            void onEvict(const std::shared_ptr<KS> &key, const std::shared_ptr<R> &record,
+                                                 bool wasExpired) override {
                                 if (wasExpired) {
                                     nearCacheStats->incrementExpirations();
                                 } else {
@@ -99,8 +97,7 @@ namespace hazelcast {
                                 nearCacheStats->decrementOwnedEntryCount();
                             }
 
-                            //@Override
-                            std::shared_ptr<V> get(const std::shared_ptr<KS> &key) {
+                            std::shared_ptr<V> get(const std::shared_ptr<KS> &key) override {
                                 checkAvailable();
 
                                 std::shared_ptr<R> record;
@@ -129,8 +126,7 @@ namespace hazelcast {
                             }
 
 
-                            //@Override
-                            void put(const std::shared_ptr<KS> &key, const std::shared_ptr<V> &value) {
+                            void put(const std::shared_ptr<KS> &key, const std::shared_ptr<V> &value) override {
                                 putInternal<V>(key, value);
                             }
 
@@ -142,8 +138,7 @@ namespace hazelcast {
                             }
 */
 
-                            //@Override
-                            bool invalidate(const std::shared_ptr<KS> &key) {
+                            bool invalidate(const std::shared_ptr<KS> &key) override {
                                 checkAvailable();
 
                                 std::shared_ptr<R> record;
@@ -166,8 +161,7 @@ namespace hazelcast {
                                 }
                             }
 
-                            //@Override
-                            void clear() {
+                            void clear() override {
                                 checkAvailable();
 
                                 clearRecords();
@@ -175,8 +169,7 @@ namespace hazelcast {
                                 nearCacheStats->setOwnedEntryMemoryCost(0L);
                             }
 
-                            //@Override
-                            void destroy() {
+                            void destroy() override {
                                 checkAvailable();
 
                                 destroyStore();
@@ -184,20 +177,17 @@ namespace hazelcast {
                                 nearCacheStats->setOwnedEntryMemoryCost(0L);
                             }
 
-                            //@Override
-                            int size() const {
+                            int size() const override {
                                 checkAvailable();
                                 return (int) records->size();
                             }
 
-                            //@Override
-                            virtual std::shared_ptr<monitor::NearCacheStats> getNearCacheStats() const {
+                            std::shared_ptr<monitor::NearCacheStats> getNearCacheStats() const override {
                                 checkAvailable();
                                 return nearCacheStats;
                             }
 
-                            //@Override
-                            void doEvictionIfRequired() {
+                            void doEvictionIfRequired() override {
                                 checkAvailable();
                                 if (isEvictionEnabled()) {
                                     evictionStrategy->evict(records.get(), evictionPolicyEvaluator.get(),
@@ -205,8 +195,7 @@ namespace hazelcast {
                                 }
                             }
 
-                            //@Override
-                            void doEviction() {
+                            void doEviction() override {
                                 checkAvailable();
 
                                 if (isEvictionEnabled()) {
@@ -475,8 +464,7 @@ namespace hazelcast {
                                 MaxSizeEvictionChecker(const eviction::MaxSizeChecker *maxSizeChecker) : maxSizeChecker(
                                         maxSizeChecker) { }
 
-                                //@Override
-                                bool isEvictionRequired() const {
+                                bool isEvictionRequired() const override {
                                     return maxSizeChecker != NULL && maxSizeChecker->isReachedToMaxSize();
                                 }
 

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.h
@@ -44,14 +44,12 @@ namespace hazelcast {
                             ) : ANCRS(nearCacheConfig, serializationService) {
                             }
 
-                            //@Override
-                            const std::shared_ptr<R> getRecord(const std::shared_ptr<KS> &key) {
+                            const std::shared_ptr<R> getRecord(const std::shared_ptr<KS> &key) override {
                                 return ANCRS::records->get(key);
                             }
 
-                            //@Override
                             void onEvict(const std::shared_ptr<KS> &key, const std::shared_ptr<R> &record,
-                                         bool wasExpired) {
+                                         bool wasExpired) override {
                                 ANCRS::onEvict(key,
                                                record,
                                                wasExpired);
@@ -59,8 +57,7 @@ namespace hazelcast {
                                         ANCRS::getTotalStorageMemoryCost(key, record));
                             }
 
-                            //@Override
-                            void doExpiration() {
+                            void doExpiration() override {
                                 std::vector<std::pair<std::shared_ptr<KS>, std::shared_ptr<R> > > entries = ANCRS::records->entrySet();
                                 for (typename std::vector<std::pair<std::shared_ptr<KS>, std::shared_ptr<R> > >::const_iterator it = entries.begin();
                                      it != entries.end(); ++it) {
@@ -74,10 +71,9 @@ namespace hazelcast {
                                 }
                             }
                         protected:
-                            //@Override
                             std::unique_ptr<eviction::MaxSizeChecker> createNearCacheMaxSizeChecker(
                                     const std::shared_ptr<client::config::EvictionConfig<K, V> > &evictionConfig,
-                                    const client::config::NearCacheConfig<K, V> &nearCacheConfig) {
+                                    const client::config::NearCacheConfig<K, V> &nearCacheConfig) override {
                                 typename client::config::EvictionConfig<K, V>::MaxSizePolicy maxSizePolicy = evictionConfig->getMaximumSizePolicy();
                                 if (maxSizePolicy == client::config::EvictionConfig<K, V>::ENTRY_COUNT) {
                                     return std::unique_ptr<eviction::MaxSizeChecker>(
@@ -92,17 +88,15 @@ namespace hazelcast {
                                 BOOST_THROW_EXCEPTION(exception::IllegalArgumentException(out.str()));
                             }
 
-                            //@Override
                             std::unique_ptr<HeapNearCacheRecordMap<K, V, KS, R> > createNearCacheRecordMap(
-                                    const client::config::NearCacheConfig<K, V> &nearCacheConfig) {
+                                    const client::config::NearCacheConfig<K, V> &nearCacheConfig) override {
                                 return std::unique_ptr<HeapNearCacheRecordMap<K, V, KS, R> >(
                                         new HeapNearCacheRecordMap<K, V, KS, R>(ANCRS::serializationService,
                                                                                 DEFAULT_INITIAL_CAPACITY));
                             }
 
-                            //@Override
                             std::shared_ptr<R> putRecord(const std::shared_ptr<KS> &key,
-                                                           const std::shared_ptr<R> &record) {
+                                                           const std::shared_ptr<R> &record) override {
                                 std::shared_ptr<R> oldRecord = ANCRS::records->put(key, record);
                                 ANCRS::nearCacheStats->incrementOwnedEntryMemoryCost(
                                         ANCRS::getTotalStorageMemoryCost(key, record));
@@ -113,13 +107,11 @@ namespace hazelcast {
                                 return oldRecord;
                             }
 
-                            //@OverrideR
-                            std::shared_ptr<R> removeRecord(const std::shared_ptr<KS> &key) {
+                            std::shared_ptr<R> removeRecord(const std::shared_ptr<KS> &key) override {
                                 return ANCRS::records->remove(key);
                             }
 
-                            //@Override
-                            bool containsRecordKey(const std::shared_ptr<KS> &key) const {
+                            bool containsRecordKey(const std::shared_ptr<KS> &key) const override {
                                 return ANCRS::records->containsKey(key);
                             }
 

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/HeapNearCacheRecordMap.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/HeapNearCacheRecordMap.h
@@ -51,8 +51,7 @@ namespace hazelcast {
                                       serializationService(ss) {
                             }
 
-                            virtual ~HeapNearCacheRecordMap() {
-                            }
+                            ~HeapNearCacheRecordMap() override = default;
 
                             class NearCacheEvictableSamplingEntry
                                     : public util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry,
@@ -66,43 +65,35 @@ namespace hazelcast {
                                           serializationService(ss) {
                                 }
 
-                                virtual ~NearCacheEvictableSamplingEntry() {
-                                }
+                                ~NearCacheEvictableSamplingEntry() override = default;
 
-                                //@Override
-                                std::shared_ptr<KS> getAccessor() const {
+                                std::shared_ptr<KS> getAccessor() const override {
                                     return util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::key;
                                 }
 
-                                //@Override
-                                std::shared_ptr<R> getEvictable() const {
+                                std::shared_ptr<R> getEvictable() const override {
                                     return util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::value;
                                 }
 
-                                //@Override
-                                std::shared_ptr<K> getKey() const {
+                                std::shared_ptr<K> getKey() const override {
                                     return serializationService.toSharedObject<K>(
                                             util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::key);
                                 }
 
-                                //@Override
-                                std::shared_ptr<V> getValue() const {
+                                std::shared_ptr<V> getValue() const override {
                                     return std::shared_ptr<V>(serializationService.toSharedObject<V>(
                                             util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::value->getValue()));
                                 }
 
-                                //@Override
-                                int64_t getCreationTime() const {
+                                int64_t getCreationTime() const override {
                                     return util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::value->getCreationTime();
                                 }
 
-                                //@Override
-                                int64_t getLastAccessTime() const {
+                                int64_t getLastAccessTime() const override {
                                     return util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::value->getLastAccessTime();
                                 }
 
-                                //@Override
-                                int64_t getAccessHit() const {
+                                int64_t getAccessHit() const override {
                                     return util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry::value->getAccessHit();
                                 }
 
@@ -110,9 +101,8 @@ namespace hazelcast {
                                 serialization::pimpl::SerializationService &serializationService;
                             };
 
-                            //@Override
                             int evict(std::vector<std::shared_ptr<C> > *evictionCandidates,
-                                      eviction::EvictionListener<KS, R> *evictionListener) {
+                                      eviction::EvictionListener<KS, R> *evictionListener) override {
                                 if (evictionCandidates == NULL) {
                                     return 0;
                                 }
@@ -132,7 +122,6 @@ namespace hazelcast {
                                 return actualEvictedCount;
                             }
 
-                            //@Override
                             std::unique_ptr<util::Iterable<eviction::EvictionCandidate<K, V, KS, R> > > sample(
                                     int32_t sampleCount) const {
                                 std::unique_ptr<util::Iterable<typename util::SampleableConcurrentHashMap<K, V, KS, R>::E> > samples = util::SampleableConcurrentHashMap<K, V, KS, R>::getRandomSamples(
@@ -162,11 +151,11 @@ namespace hazelcast {
                                             : it(adaptedIterator) {
                                     }
 
-                                    bool hasNext() {
+                                    bool hasNext() override {
                                         return it.hasNext();
                                     }
 
-                                    virtual std::shared_ptr<eviction::EvictionCandidate<K, V, KS, R> > next() {
+                                    std::shared_ptr<eviction::EvictionCandidate<K, V, KS, R> > next() override {
                                         std::shared_ptr<typename util::SampleableConcurrentHashMap<K, V, KS, R>::E> obj = it.next();
                                         std::shared_ptr<NearCacheEvictableSamplingEntry> heapObj = std::static_pointer_cast<NearCacheEvictableSamplingEntry>(
                                                 obj);
@@ -174,7 +163,7 @@ namespace hazelcast {
                                                 heapObj);
                                     }
 
-                                    virtual void remove() {
+                                    void remove() override {
                                         it.remove();
                                     }
 
@@ -182,8 +171,7 @@ namespace hazelcast {
                                     util::Iterator<typename util::SampleableConcurrentHashMap<K, V, KS, R>::E> &it;
                                 };
 
-                                //@override
-                                util::Iterator<eviction::EvictionCandidate<K, V, KS, R> > *iterator() {
+                                util::Iterator<eviction::EvictionCandidate<K, V, KS, R> > *iterator() override {
                                     return adaptedIterator.get();
                                 }
 
@@ -193,10 +181,9 @@ namespace hazelcast {
                             };
 
                         protected:
-                            //@Override
                             std::shared_ptr<typename util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry> createSamplingEntry(
                                     std::shared_ptr<KS> &key,
-                                    std::shared_ptr<R> &value) const {
+                                    std::shared_ptr<R> &value) const override {
                                 return std::shared_ptr<typename util::SampleableConcurrentHashMap<K, V, KS, R>::SamplingEntry>(
                                         new NearCacheEvictableSamplingEntry(key, value, serializationService));
                             }

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/NearCacheDataRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/NearCacheDataRecordStore.h
@@ -47,8 +47,7 @@ namespace hazelcast {
                                     : BaseHeapNearCacheRecordStore<K, V, serialization::pimpl::Data, record::NearCacheDataRecord>(name, config, ss) {
                             }
                         protected:
-                            //@Override
-                        virtual int64_t getKeyStorageMemoryCost(KS *key) const {
+                        int64_t getKeyStorageMemoryCost(KS *key) const override {
                                 return
                                     // reference to this key data inside map ("store" field)
                                         REFERENCE_SIZE
@@ -56,8 +55,7 @@ namespace hazelcast {
                                         + (key != NULL ? key->totalSize() : 0);
                             }
 
-                            //@Override
-                            virtual int64_t getRecordStorageMemoryCost(record::NearCacheDataRecord *record) const {
+                            int64_t getRecordStorageMemoryCost(record::NearCacheDataRecord *record) const override {
                                 if (record == NULL) {
                                     return 0L;
                                 }
@@ -77,9 +75,8 @@ namespace hazelcast {
                                         + (sizeof(std::atomic<int32_t>));
                             }
 
-                            //@Override
                             std::unique_ptr<record::NearCacheDataRecord> valueToRecord(
-                                    const std::shared_ptr<serialization::pimpl::Data> &value) {
+                                    const std::shared_ptr<serialization::pimpl::Data> &value) override {
                                 return valueToRecordInternal(value);
                             }
 
@@ -92,8 +89,7 @@ namespace hazelcast {
                             }
 */
 
-                            //@Override
-                            std::shared_ptr<V> recordToValue(const record::NearCacheDataRecord *record) {
+                            std::shared_ptr<V> recordToValue(const record::NearCacheDataRecord *record) override {
                                 const std::shared_ptr<serialization::pimpl::Data> value = record->getValue();
                                 if (value.get() == NULL) {
                                     ANCRS::nearCacheStats->incrementMisses();
@@ -102,9 +98,8 @@ namespace hazelcast {
                                 return ANCRS::dataToValue(value, (V *)NULL);
                             }
 
-                            //@Override
                             void putToRecord(std::shared_ptr<record::NearCacheDataRecord> &record,
-                                             const std::shared_ptr<V> &value) {
+                                             const std::shared_ptr<V> &value) override {
                                 record->setValue(ANCRS::toData(value));
                             }
                         private:

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/NearCacheObjectRecordStore.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/store/NearCacheObjectRecordStore.h
@@ -43,14 +43,12 @@ namespace hazelcast {
                                     name, config, ss) {
                             }
                         protected:
-                            //@Override
-                            virtual int64_t getKeyStorageMemoryCost(KS *key) const {
+                            int64_t getKeyStorageMemoryCost(KS *key) const override {
                                 // memory cost for "OBJECT" in memory format is totally not supported, so just return zero
                                 return 0L;
                             }
 
-                            //@Override
-                            virtual int64_t getRecordStorageMemoryCost(record::NearCacheObjectRecord<V> *record) const {
+                            int64_t getRecordStorageMemoryCost(record::NearCacheObjectRecord<V> *record) const override {
                                 // memory cost for "OBJECT" in memory format is totally not supported, so just return zero
                                 return 0L;
                             }
@@ -66,14 +64,12 @@ namespace hazelcast {
                             }
 */
 
-                            //@Override
                             std::unique_ptr<record::NearCacheObjectRecord<V> > valueToRecord(
-                                    const std::shared_ptr<V> &value) {
+                                    const std::shared_ptr<V> &value) override {
                                 return valueToRecordInternal(value);
                             }
 
-                            //@Override
-                            std::shared_ptr<V> recordToValue(const record::NearCacheObjectRecord<V> *record) {
+                            std::shared_ptr<V> recordToValue(const record::NearCacheObjectRecord<V> *record) override {
                                 const std::shared_ptr<V> value = record->getValue();
                                 if (value.get() == NULL) {
                                     return std::static_pointer_cast<V>(NearCache<K, V>::NULL_OBJECT);
@@ -81,9 +77,8 @@ namespace hazelcast {
                                 return value;
                             }
 
-                            //@Override
                             void putToRecord(std::shared_ptr<record::NearCacheObjectRecord<V> > &record,
-                                             const std::shared_ptr<V> &value) {
+                                             const std::shared_ptr<V> &value) override {
                                 record->setValue(value);
                             }
 

--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -52,7 +52,7 @@ namespace hazelcast {
                               socket_(socketStrand, context) {
                     }
 
-                    ~BaseSocket() {
+                    ~BaseSocket() override {
                         close();
                     }
 
@@ -169,7 +169,7 @@ namespace hazelcast {
                         socket_.lowest_layer().close(ignored);
                     }
 
-                    virtual Address getAddress() const override {
+                    Address getAddress() const override {
                         return Address(socket_.lowest_layer().remote_endpoint().address().to_string(),
                                        remoteEndpoint.getPort());
                     }
@@ -180,7 +180,7 @@ namespace hazelcast {
                      *
                      * @returns An address that represents the local endpoint of the socket.
                      */
-                    virtual std::unique_ptr<Address> localSocketAddress() const override {
+                    std::unique_ptr<Address> localSocketAddress() const override {
                         boost::system::error_code ec;
                         boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> localEndpoint = socket_.lowest_layer().local_endpoint(
                                 ec);

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -424,18 +424,15 @@ namespace hazelcast {
                             : nearCache(cache) {
                     }
 
-                    //@Override
-                    void beforeListenerRegister() {
+                    void beforeListenerRegister() override {
                         nearCache->clear();
                     }
 
-                    //@Override
-                    void onListenerRegister() {
+                    void onListenerRegister() override {
                         nearCache->clear();
                     }
 
-                    //@Override
-                    virtual void handleIMapInvalidationEventV10(std::unique_ptr<Data> &key) {
+                    void handleIMapInvalidationEventV10(std::unique_ptr<Data> &key) override {
                         // null key means Near Cache has to remove all entries in it (see MapAddNearCacheEntryListenerMessageTask)
                         if (key.get() == NULL) {
                             nearCache->clear();
@@ -444,8 +441,7 @@ namespace hazelcast {
                         }
                     }
 
-                    //@Override
-                    virtual void handleIMapBatchInvalidationEventV10(const std::vector<Data> &keys) {
+                    void handleIMapBatchInvalidationEventV10(const std::vector<Data> &keys) override {
                         for (std::vector<serialization::pimpl::Data>::const_iterator it = keys.begin();
                              it != keys.end(); ++it) {
                             nearCache->invalidate(std::shared_ptr<serialization::pimpl::Data>(
@@ -453,21 +449,19 @@ namespace hazelcast {
                         }
                     }
 
-                    //@Override
-                    virtual void handleIMapInvalidationEventV14(std::unique_ptr<serialization::pimpl::Data> &key,
+                    void handleIMapInvalidationEventV14(std::unique_ptr<serialization::pimpl::Data> &key,
                                                                 const std::string &sourceUuid,
                                                                 const util::UUID &partitionUuid,
-                                                                const int64_t &sequence) {
+                                                                const int64_t &sequence) override {
                         // TODO: change with the new near cache impl.
                         handleIMapInvalidationEventV10(key);
                     }
 
-                    //@Override
-                    virtual void
+                    void
                     handleIMapBatchInvalidationEventV14(const std::vector<serialization::pimpl::Data> &keys,
                                                         const std::vector<std::string> &sourceUuids,
                                                         const std::vector<util::UUID> &partitionUuids,
-                                                        const std::vector<int64_t> &sequences) {
+                                                        const std::vector<int64_t> &sequences) override {
                         // TODO: change with the new near cache impl.
                         handleIMapBatchInvalidationEventV10(keys);
                     }
@@ -478,23 +472,23 @@ namespace hazelcast {
 
                 class NearCacheEntryListenerMessageCodec : public spi::impl::ListenerMessageCodec {
                 public:
-                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const {
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override {
                         return protocol::codec::MapAddNearCacheEntryListenerCodec::encodeRequest(name,
                                                                                                  static_cast<int32_t>(listenerFlags),
                                                                                                  localOnly);
                     }
 
-                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const {
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override {
                         return protocol::codec::MapAddNearCacheEntryListenerCodec::ResponseParameters::decode(
                                 std::move(responseMessage)).response;
                     }
 
                     std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const {
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override {
                         return protocol::codec::MapRemoveEntryListenerCodec::encodeRequest(name, realRegistrationId);
                     }
 
-                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const {
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override {
                         return protocol::codec::MapRemoveEntryListenerCodec::ResponseParameters::decode(
                                 std::move(clientMessage)).response;
                     }

--- a/hazelcast/include/hazelcast/client/map/impl/nearcache/InvalidationAwareWrapper.h
+++ b/hazelcast/include/hazelcast/client/map/impl/nearcache/InvalidationAwareWrapper.h
@@ -53,25 +53,20 @@ namespace hazelcast {
                                   keyStateMarker(new internal::nearcache::impl::KeyStateMarkerImpl(partitionCount)) {
                         }
 
-                        virtual ~InvalidationAwareWrapper() {
-                        }
+                        ~InvalidationAwareWrapper() override = default;
 
-                        //@Override
                         void initialize() override {
                             nearCache->initialize();
                         }
 
-                        //@Override
                         const std::string &getName() const override {
                             return nearCache->getName();
                         }
 
-                        //@Override
                         std::shared_ptr<V> get(const std::shared_ptr<K> &key) override {
                             return nearCache->get(key);
                         }
 
-                        //@Override
                         void put(const std::shared_ptr<K> &key, const std::shared_ptr<V> &value) override {
                             nearCache->put(key, value);
                         }
@@ -84,30 +79,25 @@ namespace hazelcast {
                         }
 */
 
-                        //@Override
                         bool invalidate(const std::shared_ptr<K> &key) override {
                             keyStateMarker->tryRemove(*key);
                             return nearCache->invalidate(key);
                         }
 
-                        //@Override
                         bool isInvalidatedOnChange() const override {
                             return nearCache->isInvalidatedOnChange();
                         }
 
-                        //@Override
                         void clear() override {
                             keyStateMarker->init();
                             nearCache->clear();
                         }
 
-                        //@Override
                         void destroy() override {
                             keyStateMarker->init();
                             nearCache->destroy();
                         }
 
-                        //@Override
                         const config::InMemoryFormat getInMemoryFormat() const override {
                             return nearCache->getInMemoryFormat();
                         }
@@ -116,7 +106,6 @@ namespace hazelcast {
                             return nearCache->getNearCacheStats();
                         }
 
-                        //@Override
                         int size() const override {
                             return nearCache->size();
                         }

--- a/hazelcast/include/hazelcast/client/map/impl/nearcache/KeyStateMarker.h
+++ b/hazelcast/include/hazelcast/client/map/impl/nearcache/KeyStateMarker.h
@@ -44,7 +44,7 @@ namespace hazelcast {
                      */
                     class HAZELCAST_API KeyStateMarker {
                     public:
-                        virtual ~KeyStateMarker() {}
+                        virtual ~KeyStateMarker() = default;
 
                         virtual bool tryMark(const serialization::pimpl::Data &key) = 0;
 
@@ -67,15 +67,15 @@ namespace hazelcast {
 
                     class HAZELCAST_API TrueMarkerImpl : public KeyStateMarker {
                     public:
-                        bool tryMark(const serialization::pimpl::Data &key);
+                        bool tryMark(const serialization::pimpl::Data &key) override;
 
-                        bool tryUnmark(const serialization::pimpl::Data &key);
+                        bool tryUnmark(const serialization::pimpl::Data &key) override;
 
-                        bool tryRemove(const serialization::pimpl::Data &key);
+                        bool tryRemove(const serialization::pimpl::Data &key) override;
 
-                        void forceUnmark(const serialization::pimpl::Data &key);
+                        void forceUnmark(const serialization::pimpl::Data &key) override;
 
-                        void init();
+                        void init() override;
                     };
                 }
             }

--- a/hazelcast/include/hazelcast/client/monitor/LocalMapStats.h
+++ b/hazelcast/include/hazelcast/client/monitor/LocalMapStats.h
@@ -30,8 +30,7 @@ namespace hazelcast {
 
             class HAZELCAST_API LocalMapStats {
             public:
-                virtual ~LocalMapStats() {
-                }
+                virtual ~LocalMapStats() = default;
 
                 /**
                  * Returns statistics related to the Near Cache.

--- a/hazelcast/include/hazelcast/client/monitor/NearCacheStats.h
+++ b/hazelcast/include/hazelcast/client/monitor/NearCacheStats.h
@@ -30,8 +30,7 @@ namespace hazelcast {
         namespace monitor {
             class HAZELCAST_API LocalInstanceStats {
             public:
-                virtual ~LocalInstanceStats() {
-                }
+                virtual ~LocalInstanceStats() = default;
 
                 /**
                  * Fill a stat value with this if it is not available
@@ -48,8 +47,7 @@ namespace hazelcast {
                  *
                  * @return creation time of this Near Cache on this member.
                  */
-                //@Override
-                virtual int64_t getCreationTime() = 0;
+                int64_t getCreationTime() override = 0;
 
                 /**
                  * Returns the number of Near Cache entries owned by this member.

--- a/hazelcast/include/hazelcast/client/monitor/impl/NearCacheStatsImpl.h
+++ b/hazelcast/include/hazelcast/client/monitor/impl/NearCacheStatsImpl.h
@@ -37,16 +37,16 @@ namespace hazelcast {
                 public:
                     NearCacheStatsImpl();
 
-                    virtual int64_t getCreationTime();
+                    int64_t getCreationTime() override;
 
-                    virtual int64_t getOwnedEntryCount();
+                    int64_t getOwnedEntryCount() override;
 
                     void setOwnedEntryCount(int64_t ownedEntryCount);
 
                     void incrementOwnedEntryCount();
                     void decrementOwnedEntryCount();
 
-                    virtual int64_t getOwnedEntryMemoryCost();
+                    int64_t getOwnedEntryMemoryCost() override;
 
                     void setOwnedEntryMemoryCost(int64_t ownedEntryMemoryCost);
 
@@ -54,31 +54,31 @@ namespace hazelcast {
 
                     void decrementOwnedEntryMemoryCost(int64_t ownedEntryMemoryCost);
 
-                    virtual int64_t getHits();
+                    int64_t getHits() override;
 
                     // just for testing
                     void setHits(int64_t hits);
 
                     void incrementHits();
 
-                    virtual int64_t getMisses();
+                    int64_t getMisses() override;
 
                     // just for testing
                     void setMisses(int64_t misses);
 
                     void incrementMisses();
 
-                    virtual double getRatio();
+                    double getRatio() override;
 
-                    virtual int64_t getEvictions();
+                    int64_t getEvictions() override;
 
                     void incrementEvictions();
 
-                    virtual int64_t getExpirations();
+                    int64_t getExpirations() override;
 
                     void incrementExpirations();
 
-                    int64_t getInvalidations();
+                    int64_t getInvalidations() override;
 
                     void incrementInvalidations();
 
@@ -88,21 +88,21 @@ namespace hazelcast {
 
                     void resetInvalidationEvents();
 
-                    virtual int64_t getPersistenceCount();
+                    int64_t getPersistenceCount() override;
 
                     void addPersistence(int64_t duration, int32_t writtenBytes, int32_t keyCount);
 
-                    virtual int64_t getLastPersistenceTime();
+                    int64_t getLastPersistenceTime() override;
 
-                    virtual int64_t getLastPersistenceDuration();
+                    int64_t getLastPersistenceDuration() override;
 
-                    virtual int64_t getLastPersistenceWrittenBytes();
+                    int64_t getLastPersistenceWrittenBytes() override;
 
-                    virtual int64_t getLastPersistenceKeyCount();
+                    int64_t getLastPersistenceKeyCount() override;
 
-                    virtual std::string getLastPersistenceFailure();
+                    std::string getLastPersistenceFailure() override;
 
-                    virtual std::string toString();
+                    std::string toString() override;
 
                 private:
                     std::atomic<int64_t> creationTime;

--- a/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientExceptionFactory.h
@@ -71,7 +71,7 @@ namespace hazelcast {
             public:
                 void throwException(const ClientExceptionFactory &clientExceptionFactory, const std::string &source,
                                     const std::string &message,
-                                    const std::string &details = nullptr, int32_t causeErrorCode = -1) const {
+                                    const std::string &details = nullptr, int32_t causeErrorCode = -1) const override {
                     EXCEPTION e(source, message, details);
                     if (causeErrorCode < 0) {
                         throw boost::enable_current_exception(e);
@@ -84,7 +84,7 @@ namespace hazelcast {
                     }
                 }
 
-                void throwException() const {
+                void throwException() const override {
                     return BOOST_THROW_EXCEPTION(EXCEPTION());
                 }
             };

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
@@ -139,7 +139,7 @@ namespace hazelcast {
                 */
                 static const uint16_t HEADER_SIZE = DATA_OFFSET_FIELD_OFFSET + UINT16_SIZE;
 
-                virtual ~ClientMessage();
+                ~ClientMessage() override;
 
                 static std::unique_ptr<ClientMessage> createForEncode(int32_t size);
 

--- a/hazelcast/include/hazelcast/client/protocol/IMessageHandler.h
+++ b/hazelcast/include/hazelcast/client/protocol/IMessageHandler.h
@@ -35,7 +35,7 @@ namespace hazelcast {
         namespace protocol {
             class HAZELCAST_API IMessageHandler {
             public:
-                virtual ~IMessageHandler() {}
+                virtual ~IMessageHandler() = default;
 
                 virtual void handleClientMessage(const std::shared_ptr<spi::impl::ClientInvocation> invocation,
                                                  const std::shared_ptr<ClientMessage> response) = 0;

--- a/hazelcast/include/hazelcast/client/proxy/IListImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IListImpl.h
@@ -95,14 +95,14 @@ namespace hazelcast {
                 public:
                     ListListenerMessageCodec(std::string name, bool includeValue);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
 
                 private:
                     std::string name;

--- a/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
@@ -268,14 +268,14 @@ namespace hazelcast {
                                                               EntryEvent::type listenerFlags,
                                                               serialization::pimpl::Data &&predicate);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
                 private:
                     std::string name;
                     bool includeValue;
@@ -287,14 +287,14 @@ namespace hazelcast {
                 public:
                     MapEntryListenerMessageCodec(std::string name, bool includeValue, EntryEvent::type listenerFlags);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
                 private:
                     std::string name;
                     bool includeValue;
@@ -306,14 +306,14 @@ namespace hazelcast {
                     MapEntryListenerToKeyCodec(std::string name, bool includeValue, EntryEvent::type listenerFlags,
                                                serialization::pimpl::Data key);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
                 private:
                     std::string name;
                     bool includeValue;

--- a/hazelcast/include/hazelcast/client/proxy/ISetImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ISetImpl.h
@@ -80,14 +80,14 @@ namespace hazelcast {
                 public:
                     SetListenerMessageCodec(std::string name, bool includeValue);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
 
                 private:
                     std::string  name;

--- a/hazelcast/include/hazelcast/client/proxy/ITopicImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ITopicImpl.h
@@ -45,14 +45,14 @@ namespace hazelcast {
                 public:
                     TopicListenerMessageCodec(std::string name);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
 
                 private:
                     std::string name;

--- a/hazelcast/include/hazelcast/client/proxy/MultiMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/MultiMapImpl.h
@@ -102,20 +102,20 @@ namespace hazelcast {
 
                 boost::future<void> forceUnlock(const serialization::pimpl::Data& key);
 
-                virtual void onInitialize();
+                void onInitialize() override;
             private:
                 class MultiMapEntryListenerMessageCodec : public spi::impl::ListenerMessageCodec {
                 public:
                     MultiMapEntryListenerMessageCodec(std::string name, bool includeValue);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
                 private:
                     std::string name;
                     bool includeValue;
@@ -126,14 +126,14 @@ namespace hazelcast {
                     MultiMapEntryListenerToKeyCodec(std::string name, bool includeValue,
                                                     serialization::pimpl::Data &&key);
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const;
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const;
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override;
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const;
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override;
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const;
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override;
                 private:
                     std::string  name;
                     bool includeValue;

--- a/hazelcast/include/hazelcast/client/proxy/PartitionSpecificClientProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/PartitionSpecificClientProxy.h
@@ -29,7 +29,7 @@ namespace hazelcast {
                 PartitionSpecificClientProxy(const std::string &serviceName, const std::string &objectName,
                                              spi::ClientContext *context);
 
-                virtual void onInitialize();
+                void onInitialize() override;
 
                 int partitionId;
             };

--- a/hazelcast/include/hazelcast/client/proxy/ProxyImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ProxyImpl.h
@@ -25,7 +25,7 @@ namespace hazelcast {
             protected:
                 ProxyImpl(const std::string &serviceName, const std::string &objectName, spi::ClientContext *context);
 
-                virtual ~ProxyImpl();
+                ~ProxyImpl() override;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
@@ -252,23 +252,23 @@ namespace hazelcast {
                 public:
                     NearCacheInvalidationListenerMessageCodec(const std::string &name) : name(name) {}
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const {
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override {
                         return protocol::codec::ReplicatedMapAddNearCacheEntryListenerCodec::encodeRequest(name, false,
                                                                                                            localOnly);
                     }
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const {
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override {
                         return protocol::codec::ReplicatedMapAddNearCacheEntryListenerCodec::ResponseParameters::decode(
                                 std::move(responseMessage)).response;
                     }
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const {
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::encodeRequest(name,
                                                                                                      realRegistrationId);
                     }
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const {
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::ResponseParameters::decode(
                                 std::move(clientMessage)).response;
                     }
@@ -285,23 +285,23 @@ namespace hazelcast {
                                                                                 serialization::pimpl::Data &&predicateData)
                             : name(name), keyData(keyData), predicateData(predicateData) {}
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const {
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerToKeyWithPredicateCodec::encodeRequest(
                                 name, keyData, predicateData, localOnly);
                     }
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const {
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerToKeyWithPredicateCodec::ResponseParameters::decode(
                                 std::move(responseMessage)).response;
                     }
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const {
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::encodeRequest(name,
                                                                                                      realRegistrationId);
                     }
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const {
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::ResponseParameters::decode(
                                 std::move(clientMessage)).response;
                     }
@@ -318,24 +318,24 @@ namespace hazelcast {
                                                                           serialization::pimpl::Data &&keyData)
                             : name(name), predicateData(keyData) {}
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const {
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerWithPredicateCodec::encodeRequest(name,
                                                                                                                predicateData,
                                                                                                                localOnly);
                     }
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const {
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerWithPredicateCodec::ResponseParameters::decode(
                                 std::move(responseMessage)).response;
                     }
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const {
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::encodeRequest(name,
                                                                                                      realRegistrationId);
                     }
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const {
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::ResponseParameters::decode(
                                 std::move(clientMessage)).response;
                     }
@@ -350,23 +350,23 @@ namespace hazelcast {
                     ReplicatedMapAddEntryListenerToKeyMessageCodec(const std::string &name,
                                                                    serialization::pimpl::Data &&keyData) : name(name), keyData(keyData) {}
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const {
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerToKeyCodec::encodeRequest(name, keyData,
                                                                                                        localOnly);
                     }
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const {
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerToKeyCodec::ResponseParameters::decode(
                                 std::move(responseMessage)).response;
                     }
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const {
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::encodeRequest(name,
                                                                                                      realRegistrationId);
                     }
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const {
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::ResponseParameters::decode(
                                 std::move(clientMessage)).response;
                     }
@@ -380,22 +380,22 @@ namespace hazelcast {
                 public:
                     ReplicatedMapListenerMessageCodec(const std::string &name) : name(name) {}
 
-                    virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const {
+                    std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerCodec::encodeRequest(name, localOnly);
                     }
 
-                    virtual std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const {
+                    std::string decodeAddResponse(protocol::ClientMessage &responseMessage) const override {
                         return protocol::codec::ReplicatedMapAddEntryListenerCodec::ResponseParameters::decode(
                                 std::move(responseMessage)).response;
                     }
 
-                    virtual std::unique_ptr<protocol::ClientMessage>
-                    encodeRemoveRequest(const std::string &realRegistrationId) const {
+                    std::unique_ptr<protocol::ClientMessage>
+                    encodeRemoveRequest(const std::string &realRegistrationId) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::encodeRequest(name,
                                                                                                      realRegistrationId);
                     }
 
-                    virtual bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const {
+                    bool decodeRemoveResponse(protocol::ClientMessage &clientMessage) const override {
                         return protocol::codec::ReplicatedMapRemoveEntryListenerCodec::ResponseParameters::decode(
                                 std::move(clientMessage)).response;
                     }
@@ -410,11 +410,11 @@ namespace hazelcast {
                     ReplicatedMapAddNearCacheEventHandler(
                             const std::shared_ptr<internal::nearcache::NearCache<serialization::pimpl::Data, serialization::pimpl::Data>> &nearCache) : nearCache(nearCache) {}
 
-                    void beforeListenerRegister() {
+                    void beforeListenerRegister() override {
                         nearCache->clear();
                     }
 
-                    void onListenerRegister() {
+                    void onListenerRegister() override {
                         nearCache->clear();
                     }
 
@@ -423,7 +423,7 @@ namespace hazelcast {
                                              std::unique_ptr<serialization::pimpl::Data> &oldValue,
                                              std::unique_ptr<serialization::pimpl::Data> &mergingValue,
                                              const int32_t &eventType, const std::string &uuid,
-                                             const int32_t &numberOfAffectedEntries) {
+                                             const int32_t &numberOfAffectedEntries) override {
                         switch (eventType) {
                             case static_cast<int32_t>(EntryEvent::type::ADDED):
                             case static_cast<int32_t>(EntryEvent::type::REMOVED):

--- a/hazelcast/include/hazelcast/client/serialization/serialization.h
+++ b/hazelcast/include/hazelcast/client/serialization/serialization.h
@@ -574,9 +574,9 @@ namespace hazelcast {
                 int classId;
                 int version;
 
-                ClassDefinition(const ClassDefinition &);
+                ClassDefinition(const ClassDefinition &) = delete;
 
-                ClassDefinition &operator=(const ClassDefinition &rhs);
+                ClassDefinition &operator=(const ClassDefinition &rhs) = delete;
 
                 std::unordered_map<std::string, FieldDefinition> fieldDefinitionsMap;
 
@@ -867,11 +867,11 @@ namespace hazelcast {
                     static getType() { return FieldType::TYPE_UTF_ARRAY; }
 
                 private:
-                    PortableContext(const PortableContext &);
+                    PortableContext(const PortableContext &) = delete;
 
                     ClassDefinitionContext &getClassDefinitionContext(int factoryId);
 
-                    void operator=(const PortableContext &);
+                    void operator=(const PortableContext &) = delete;
 
                     util::SynchronizedMap<int, ClassDefinitionContext> classDefContextMap;
                     const SerializationConfig &serializationConfig;
@@ -1388,9 +1388,9 @@ namespace hazelcast {
 
                     ObjectDataOutput newOutputStream();
                 private:
-                    SerializationService(const SerializationService &);
+                    SerializationService(const SerializationService &) = delete;
 
-                    SerializationService &operator=(const SerializationService &);
+                    SerializationService &operator=(const SerializationService &) = delete;
 
                     const SerializationConfig &serializationConfig;
                     PortableContext portableContext;

--- a/hazelcast/include/hazelcast/client/spi/ClientClusterService.h
+++ b/hazelcast/include/hazelcast/client/spi/ClientClusterService.h
@@ -47,8 +47,7 @@ namespace hazelcast {
              */
             class HAZELCAST_API ClientClusterService {
             public:
-                virtual ~ClientClusterService() {
-                }
+                virtual ~ClientClusterService() = default;
 
                 /**
                  * Gets the member for the given address.

--- a/hazelcast/include/hazelcast/client/spi/ClientInvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/ClientInvocationService.h
@@ -40,8 +40,7 @@ namespace hazelcast {
              */
             class HAZELCAST_API ClientInvocationService : public protocol::IMessageHandler {
             public:
-                virtual ~ClientInvocationService() {
-                }
+                ~ClientInvocationService() override = default;
 
                 virtual void invokeOnConnection(std::shared_ptr<impl::ClientInvocation> invocation,
                                                 std::shared_ptr<connection::Connection> connection) = 0;

--- a/hazelcast/include/hazelcast/client/spi/ClientProxy.h
+++ b/hazelcast/include/hazelcast/client/spi/ClientProxy.h
@@ -51,7 +51,7 @@ namespace hazelcast {
             public:
                 ClientProxy(const std::string &name, const std::string &serviceName, ClientContext &context);
 
-                virtual ~ClientProxy();
+                ~ClientProxy() override;
 
                 /**
                  * Internal API.
@@ -68,9 +68,9 @@ namespace hazelcast {
                  */
                 virtual void onShutdown();
 
-                virtual const std::string &getName() const;
+                const std::string &getName() const override;
 
-                virtual const std::string &getServiceName() const;
+                const std::string &getServiceName() const override;
 
                 /**
                  * Internal API.
@@ -82,7 +82,7 @@ namespace hazelcast {
                 * Destroys this object cluster-wide.
                 * Clears and releases all resources for this object.
                 */
-                boost::future<void> destroy();
+                boost::future<void> destroy() override;
 
                 /**
                  * Internal API.

--- a/hazelcast/include/hazelcast/client/spi/EventHandler.h
+++ b/hazelcast/include/hazelcast/client/spi/EventHandler.h
@@ -53,7 +53,7 @@ namespace hazelcast {
                  */
                 virtual void onListenerRegister() = 0;
 
-                virtual ~EventHandler(){};
+                virtual ~EventHandler() = default;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/spi/InitializingObject.h
+++ b/hazelcast/include/hazelcast/client/spi/InitializingObject.h
@@ -30,7 +30,7 @@ namespace hazelcast {
              */
             class HAZELCAST_API InitializingObject {
             public:
-                virtual ~InitializingObject() { }
+                virtual ~InitializingObject() = default;
 
                 virtual void initialize() = 0;
             };

--- a/hazelcast/include/hazelcast/client/spi/impl/AbstractClientInvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/AbstractClientInvocationService.h
@@ -36,20 +36,20 @@ namespace hazelcast {
                 public:
                     AbstractClientInvocationService(ClientContext &client);
 
-                    virtual ~AbstractClientInvocationService();
+                    ~AbstractClientInvocationService() override;
 
                     bool start();
 
                     void shutdown();
 
-                    std::chrono::steady_clock::duration getInvocationTimeout() const;
+                    std::chrono::steady_clock::duration getInvocationTimeout() const override;
 
-                    std::chrono::steady_clock::duration getInvocationRetryPause() const;
+                    std::chrono::steady_clock::duration getInvocationRetryPause() const override;
 
-                    bool isRedoOperation();
+                    bool isRedoOperation() override;
 
                     void handleClientMessage(const std::shared_ptr<ClientInvocation> invocation,
-                                             const std::shared_ptr<protocol::ClientMessage> response);
+                                             const std::shared_ptr<protocol::ClientMessage> response) override;
 
                 protected:
 

--- a/hazelcast/include/hazelcast/client/spi/impl/AwsAddressProvider.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/AwsAddressProvider.h
@@ -39,9 +39,9 @@ namespace hazelcast {
                 public:
                     AwsAddressProvider(config::ClientAwsConfig &awsConfig, int awsMemberPort, util::ILogger &logger);
 
-                    virtual ~AwsAddressProvider();
+                    ~AwsAddressProvider() override;
 
-                    virtual std::vector<Address> loadAddresses();
+                    std::vector<Address> loadAddresses() override;
 
                 private:
                     std::string awsMemberPort;

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
@@ -55,18 +55,18 @@ namespace hazelcast {
 
                     void shutdown();
 
-                    virtual boost::optional<Member> getMember(const Address &address);
+                    boost::optional<Member> getMember(const Address &address) override;
 
-                    virtual boost::optional<Member> getMember(const std::string &uuid);
+                    boost::optional<Member> getMember(const std::string &uuid) override;
 
-                    virtual std::vector<Member> getMemberList();
+                    std::vector<Member> getMemberList() override;
 
-                    virtual std::vector<Member> getMembers(
-                            const cluster::memberselector::MemberSelector &selector);
+                    std::vector<Member> getMembers(
+                            const cluster::memberselector::MemberSelector &selector) override;
 
-                    virtual std::string addMembershipListener(const std::shared_ptr<MembershipListener> &listener);
+                    std::string addMembershipListener(const std::shared_ptr<MembershipListener> &listener) override;
 
-                    virtual bool removeMembershipListener(const std::string &registrationId);
+                    bool removeMembershipListener(const std::string &registrationId) override;
 
                     void handleMembershipEvent(const MembershipEvent &event);
 
@@ -76,7 +76,7 @@ namespace hazelcast {
 
                     void fireMemberAttributeEvent(const MemberAttributeEvent &event);
 
-                    virtual int getSize();
+                    int getSize() override;
 
                     Client getLocalClient() const;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -161,9 +161,9 @@ namespace hazelcast {
 
                     void execute();
 
-                    ClientInvocation(const ClientInvocation &rhs);
+                    ClientInvocation(const ClientInvocation &rhs) = delete;
 
-                    void operator=(const ClientInvocation &rhs);
+                    void operator=(const ClientInvocation &rhs) = delete;
 
                     std::shared_ptr<protocol::ClientMessage> copyMessage();
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientMembershipListener.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientMembershipListener.h
@@ -60,13 +60,13 @@ namespace hazelcast {
                 public:
                     ClientMembershipListener(ClientContext &client);
 
-                    virtual void handleMemberEventV10(const Member &member, const int32_t &eventType);
+                    void handleMemberEventV10(const Member &member, const int32_t &eventType) override;
 
-                    virtual void handleMemberListEventV10(const std::vector<Member> &members);
+                    void handleMemberListEventV10(const std::vector<Member> &members) override;
 
-                    virtual void handleMemberAttributeChangeEventV10(const std::string &uuid, const std::string &key,
+                    void handleMemberAttributeChangeEventV10(const std::string &uuid, const std::string &key,
                                                                      const int32_t &operationType,
-                                                                     std::unique_ptr<std::string> &value);
+                                                                     std::unique_ptr<std::string> &value) override;
 
                     void listenMembershipEvents(const std::shared_ptr<connection::Connection> &ownerConnection);
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
@@ -61,21 +61,21 @@ namespace hazelcast {
 
                     void listenPartitionTable(const std::shared_ptr<connection::Connection> &ownerConnection);
 
-                    virtual void
+                    void
                     handlePartitionsEventV15(const std::vector<std::pair<Address, std::vector<int32_t> > > &partitions,
-                                             const int32_t &partitionStateVersion);
+                                             const int32_t &partitionStateVersion) override;
 
-                    virtual void beforeListenerRegister();
+                    void beforeListenerRegister() override;
 
-                    virtual void onListenerRegister();
+                    void onListenerRegister() override;
 
-                    virtual std::shared_ptr<Address> getPartitionOwner(int partitionId);
+                    std::shared_ptr<Address> getPartitionOwner(int partitionId) override;
 
-                    virtual int getPartitionId(const serialization::pimpl::Data &key);
+                    int getPartitionId(const serialization::pimpl::Data &key) override;
 
-                    virtual int getPartitionCount();
+                    int getPartitionCount() override;
 
-                    virtual std::shared_ptr<client::impl::Partition> getPartition(int partitionId);
+                    std::shared_ptr<client::impl::Partition> getPartition(int partitionId) override;
 
                 private:
                     class PartitionImpl : public client::impl::Partition {
@@ -83,9 +83,9 @@ namespace hazelcast {
                         PartitionImpl(int partitionId, ClientContext &client,
                                       ClientPartitionServiceImpl &partitionService);
 
-                        virtual int getPartitionId() const;
+                        int getPartitionId() const override;
 
-                        virtual boost::optional<Member> getOwner() const;
+                        boost::optional<Member> getOwner() const override;
 
                     private:
                         int partitionId;

--- a/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressProvider.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressProvider.h
@@ -36,7 +36,7 @@ namespace hazelcast {
                     DefaultAddressProvider(config::ClientNetworkConfig &networkConfig,
                                            bool noOtherAddressProviderExist);
 
-                    virtual std::vector<Address> loadAddresses();
+                    std::vector<Address> loadAddresses() override;
 
                 private:
                     config::ClientNetworkConfig &networkConfig;

--- a/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressTranslator.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressTranslator.h
@@ -29,9 +29,9 @@ namespace hazelcast {
             namespace impl {
                 class HAZELCAST_API DefaultAddressTranslator : public connection::AddressTranslator {
                 public:
-                    virtual Address translate(const Address &address);
+                    Address translate(const Address &address) override;
 
-                    virtual void refresh();
+                    void refresh() override;
                 };
             }
         }

--- a/hazelcast/include/hazelcast/client/spi/impl/ListenerMessageCodec.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ListenerMessageCodec.h
@@ -35,8 +35,7 @@ namespace hazelcast {
             namespace impl {
                 class HAZELCAST_API ListenerMessageCodec {
                 public:
-                    virtual ~ListenerMessageCodec() {
-                    }
+                    virtual ~ListenerMessageCodec() = default;
 
                     virtual std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const = 0;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/NonSmartClientInvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/NonSmartClientInvocationService.h
@@ -35,15 +35,15 @@ namespace hazelcast {
                     NonSmartClientInvocationService(ClientContext &client);
 
                     void invokeOnConnection(std::shared_ptr<impl::ClientInvocation> invocation,
-                                            std::shared_ptr<connection::Connection> connection);
+                                            std::shared_ptr<connection::Connection> connection) override;
 
                     void invokeOnPartitionOwner(std::shared_ptr<impl::ClientInvocation> invocation,
-                                                int partitionId);
+                                                int partitionId) override;
 
-                    void invokeOnRandomTarget(std::shared_ptr<impl::ClientInvocation> invocation);
+                    void invokeOnRandomTarget(std::shared_ptr<impl::ClientInvocation> invocation) override;
 
                     void invokeOnTarget(std::shared_ptr<impl::ClientInvocation> invocation,
-                                        const std::shared_ptr<Address> &target);
+                                        const std::shared_ptr<Address> &target) override;
 
                     std::shared_ptr<connection::Connection> getOwnerConnection();
                 };

--- a/hazelcast/include/hazelcast/client/spi/impl/SmartClientInvocationService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/SmartClientInvocationService.h
@@ -35,15 +35,15 @@ namespace hazelcast {
                     SmartClientInvocationService(ClientContext &client);
 
                     void invokeOnConnection(std::shared_ptr<impl::ClientInvocation> invocation,
-                                            std::shared_ptr<connection::Connection> connection);
+                                            std::shared_ptr<connection::Connection> connection) override;
 
                     void invokeOnPartitionOwner(std::shared_ptr<impl::ClientInvocation> invocation,
-                                                int partitionId);
+                                                int partitionId) override;
 
-                    void invokeOnRandomTarget(std::shared_ptr<impl::ClientInvocation> invocation);
+                    void invokeOnRandomTarget(std::shared_ptr<impl::ClientInvocation> invocation) override;
 
                     void invokeOnTarget(std::shared_ptr<impl::ClientInvocation> invocation,
-                                        const std::shared_ptr<Address> &target);
+                                        const std::shared_ptr<Address> &target) override;
 
 
                 private:

--- a/hazelcast/include/hazelcast/client/spi/impl/listener/AbstractClientListenerService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/listener/AbstractClientListenerService.h
@@ -64,15 +64,15 @@ namespace hazelcast {
                         void handleClientMessage(const std::shared_ptr<ClientInvocation> invocation,
                                                  const std::shared_ptr<protocol::ClientMessage> response);
 
-                        virtual boost::future<std::string>
+                        boost::future<std::string>
                         registerListener(std::unique_ptr<ListenerMessageCodec> &&listenerMessageCodec,
-                                         std::unique_ptr<client::impl::BaseEventHandler> &&handler);
+                                         std::unique_ptr<client::impl::BaseEventHandler> &&handler) override;
 
-                        virtual boost::future<bool> deregisterListener(const std::string registrationId);
+                        boost::future<bool> deregisterListener(const std::string registrationId) override;
 
-                        virtual void connectionAdded(const std::shared_ptr<connection::Connection> connection);
+                        void connectionAdded(const std::shared_ptr<connection::Connection> connection) override;
 
-                        virtual void connectionRemoved(const std::shared_ptr<connection::Connection> connection);
+                        void connectionRemoved(const std::shared_ptr<connection::Connection> connection) override;
 
                     protected:
                         AbstractClientListenerService(ClientContext &clientContext, int32_t eventThreadCount);

--- a/hazelcast/include/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.h
@@ -28,7 +28,7 @@ namespace hazelcast {
                         NonSmartClientListenerService(ClientContext &clientContext, int32_t eventThreadCount);
 
                     protected:
-                        virtual bool registersLocalOnly() const;
+                        bool registersLocalOnly() const override;
 
                     };
                 }

--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/AbstractCallIdSequence.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/AbstractCallIdSequence.h
@@ -44,19 +44,19 @@ namespace hazelcast {
                      */
                     class HAZELCAST_API AbstractCallIdSequence : public CallIdSequence {
                     public:
-                        virtual ~AbstractCallIdSequence();
+                        ~AbstractCallIdSequence() override;
 
                         AbstractCallIdSequence(int32_t maxConcurrentInvocations);
 
-                        virtual int32_t getMaxConcurrentInvocations() const;
+                        int32_t getMaxConcurrentInvocations() const override;
 
-                        virtual int64_t next();
+                        int64_t next() override;
 
-                        virtual int64_t forceNext();
+                        int64_t forceNext() override;
 
-                        virtual void complete();
+                        void complete() override;
 
-                        virtual int64_t getLastCallId();
+                        int64_t getLastCallId() override;
 
                         int64_t getTail();
 

--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequence.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequence.h
@@ -52,8 +52,7 @@ namespace hazelcast {
                         /**
                          * Destructor
                          */
-                        virtual ~CallIdSequence() {
-                        }
+                        virtual ~CallIdSequence() = default;
 
                         /**
                          * Returns the maximum concurrent invocations supported. INT32_MAX means there is no max.

--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequenceWithBackpressure.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequenceWithBackpressure.h
@@ -47,7 +47,7 @@ namespace hazelcast {
                         CallIdSequenceWithBackpressure(int32_t maxConcurrentInvocations, int64_t backoffTimeoutMs);
 
                     protected:
-                        virtual void handleNoSpaceLeft();
+                        void handleNoSpaceLeft() override;
 
                     private:
                         int64_t backoffTimeoutNanos;

--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequenceWithoutBackpressure.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/CallIdSequenceWithoutBackpressure.h
@@ -37,17 +37,17 @@ namespace hazelcast {
                     public:
                         CallIdSequenceWithoutBackpressure();
 
-                        virtual ~CallIdSequenceWithoutBackpressure();
+                        ~CallIdSequenceWithoutBackpressure() override;
 
-                        virtual int32_t getMaxConcurrentInvocations() const;
+                        int32_t getMaxConcurrentInvocations() const override;
 
-                        virtual int64_t next();
+                        int64_t next() override;
 
-                        virtual int64_t forceNext();
+                        int64_t forceNext() override;
 
-                        virtual void complete();
+                        void complete() override;
 
-                        virtual int64_t getLastCallId();
+                        int64_t getLastCallId() override;
 
                     private:
                         std::atomic<int64_t> head;

--- a/hazelcast/include/hazelcast/client/spi/impl/sequence/FailFastCallIdSequence.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/sequence/FailFastCallIdSequence.h
@@ -45,7 +45,7 @@ namespace hazelcast {
                         FailFastCallIdSequence(int32_t maxConcurrentInvocations);
 
                     protected:
-                        virtual void handleNoSpaceLeft();
+                        void handleNoSpaceLeft() override;
                     };
                 }
             }

--- a/hazelcast/include/hazelcast/client/topic/MessageListener.h
+++ b/hazelcast/include/hazelcast/client/topic/MessageListener.h
@@ -37,7 +37,7 @@ namespace hazelcast {
              */
             class HAZELCAST_API MessageListener {
             public:
-                virtual ~MessageListener() { }
+                virtual ~MessageListener() = default;
 
                 /**
                 * Invoked when a message is received for the added topic. Note that topic guarantees message ordering.

--- a/hazelcast/include/hazelcast/client/topic/impl/TopicEventHandlerImpl.h
+++ b/hazelcast/include/hazelcast/client/topic/impl/TopicEventHandlerImpl.h
@@ -37,8 +37,8 @@ namespace hazelcast {
                             :instanceName(instanceName), clusterService(clusterService),
                             serializationService(serializationService), listener(messageListener) {}
 
-                    virtual void handleTopicEventV10(serialization::pimpl::Data &&item, const int64_t &publishTime,
-                                             const std::string &uuid) {
+                    void handleTopicEventV10(serialization::pimpl::Data &&item, const int64_t &publishTime,
+                                             const std::string &uuid) override {
                         listener(Message(instanceName, TypedData(std::move(item), serializationService), publishTime,
                                         clusterService.getMember(uuid)));
                     }

--- a/hazelcast/include/hazelcast/client/txn/ClientTransactionUtil.h
+++ b/hazelcast/include/hazelcast/client/txn/ClientTransactionUtil.h
@@ -57,7 +57,7 @@ namespace hazelcast {
             private:
                 class TransactionExceptionFactory : public util::ExceptionUtil::RuntimeExceptionFactory {
                 public:
-                    virtual void rethrow(std::exception_ptr throwable, const std::string &message);
+                    void rethrow(std::exception_ptr throwable, const std::string &message) override;
                 };
 
                 static const std::shared_ptr<util::ExceptionUtil::RuntimeExceptionFactory> exceptionFactory;

--- a/hazelcast/include/hazelcast/util/Comparator.h
+++ b/hazelcast/include/hazelcast/util/Comparator.h
@@ -20,7 +20,7 @@ namespace hazelcast {
         template <typename T>
         class Comparator {
         public:
-            virtual ~Comparator() { }
+            virtual ~Comparator() = default;
 
             /**
              * @lhs First value to compare

--- a/hazelcast/include/hazelcast/util/ConcurrentQueue.h
+++ b/hazelcast/include/hazelcast/util/ConcurrentQueue.h
@@ -32,9 +32,7 @@ namespace hazelcast {
         /* Non blocking - synchronized queue - does not delete memory ever */
         class ConcurrentQueue {
         public:
-            ConcurrentQueue() {
-
-            }
+            ConcurrentQueue() = default;
 
             void offer(T *e) {
                 std::lock_guard<std::mutex> lg(m);

--- a/hazelcast/include/hazelcast/util/ConcurrentSet.h
+++ b/hazelcast/include/hazelcast/util/ConcurrentSet.h
@@ -33,8 +33,7 @@ namespace hazelcast {
         template <typename T>
         class ConcurrentSet {
         public:
-            ConcurrentSet() {
-            }
+            ConcurrentSet() = default;
 
             /**
              * Adds the specified element to this set if it is not already present

--- a/hazelcast/include/hazelcast/util/Disposable.h
+++ b/hazelcast/include/hazelcast/util/Disposable.h
@@ -26,8 +26,7 @@ namespace hazelcast {
          */
         class HAZELCAST_API Disposable {
         public:
-            virtual ~Disposable() {
-            }
+            virtual ~Disposable() = default;
 
             /**
              * Disposes this object and releases any data and/or resources associated

--- a/hazelcast/include/hazelcast/util/ExceptionUtil.h
+++ b/hazelcast/include/hazelcast/util/ExceptionUtil.h
@@ -45,7 +45,7 @@ namespace hazelcast {
 
         private:
             class HazelcastExceptionFactory : public RuntimeExceptionFactory {
-                virtual void rethrow(std::exception_ptr throwable, const std::string &message);
+                void rethrow(std::exception_ptr throwable, const std::string &message) override;
             };
 
             static const std::shared_ptr<RuntimeExceptionFactory> &HAZELCAST_EXCEPTION_FACTORY();

--- a/hazelcast/include/hazelcast/util/ILogger.h
+++ b/hazelcast/include/hazelcast/util/ILogger.h
@@ -88,9 +88,9 @@ namespace hazelcast {
             std::once_flag elOnceflag;
             std::mutex mutex_;
 
-            ILogger(const ILogger &);
+            ILogger(const ILogger &) = delete;
 
-            ILogger &operator=(const ILogger &);
+            ILogger &operator=(const ILogger &) = delete;
 
             void composeMessage(std::ostringstream &out) {}
 

--- a/hazelcast/include/hazelcast/util/Iterable.h
+++ b/hazelcast/include/hazelcast/util/Iterable.h
@@ -25,8 +25,7 @@ namespace hazelcast {
         template <typename T>
         class Iterable {
         public:
-            virtual ~Iterable() {
-            }
+            virtual ~Iterable() = default;
 
             /**
              * Returns an iterator over a set of elements of type T.

--- a/hazelcast/include/hazelcast/util/Iterator.h
+++ b/hazelcast/include/hazelcast/util/Iterator.h
@@ -23,8 +23,7 @@ namespace hazelcast {
         template <typename E>
         class Iterator {
         public:
-            virtual ~Iterator() {
-            }
+            virtual ~Iterator() = default;
 
             /**
              * Returns <tt>true</tt> if the iteration has more elements. (In other

--- a/hazelcast/include/hazelcast/util/LittleEndianBufferWrapper.h
+++ b/hazelcast/include/hazelcast/util/LittleEndianBufferWrapper.h
@@ -34,8 +34,7 @@ namespace hazelcast {
     namespace util {
         class HAZELCAST_API LittleEndianBufferWrapper {
         public:
-            virtual ~LittleEndianBufferWrapper() {
-            }
+            virtual ~LittleEndianBufferWrapper() = default;
 
             enum TypeSizes {
                 INT8_SIZE = 1,

--- a/hazelcast/include/hazelcast/util/SampleableConcurrentHashMap.h
+++ b/hazelcast/include/hazelcast/util/SampleableConcurrentHashMap.h
@@ -227,8 +227,7 @@ namespace hazelcast {
                     }
                 }
 
-                //@Override
-                util::Iterator<E> *iterator() {
+                util::Iterator<E> *iterator() override {
                     return this;
                 }
 
@@ -268,14 +267,12 @@ namespace hazelcast {
                     currentSample.reset();
                 }
 
-                //@Override
-                bool hasNext() {
+                bool hasNext() override {
                     iterate();
                     return currentSample.get() != NULL;
                 }
 
-                //@Override
-                std::shared_ptr<E> next() {
+                std::shared_ptr<E> next() override {
                     if (currentSample.get() != NULL) {
                         return currentSample;
                     } else {
@@ -284,8 +281,7 @@ namespace hazelcast {
                     }
                 }
 
-                //@Override
-                void remove() {
+                void remove() override {
                     throw client::exception::UnsupportedOperationException("Removing is not supported");
                 }
 

--- a/hazelcast/include/hazelcast/util/Sync.h
+++ b/hazelcast/include/hazelcast/util/Sync.h
@@ -29,13 +29,12 @@ namespace hazelcast {
         template<typename T>
         class Sync {
         public:
-            Sync() {}
+            Sync() = default;
 
             Sync(const T &v) : v(v) {
             }
 
-            virtual ~Sync() {
-            }
+            virtual ~Sync() = default;
 
             T operator--(int) {
                 std::lock_guard<std::mutex> lockGuard(mutex);

--- a/hazelcast/include/hazelcast/util/SynchronizedMap.h
+++ b/hazelcast/include/hazelcast/util/SynchronizedMap.h
@@ -41,8 +41,7 @@ namespace hazelcast {
         template <typename K, typename V>
         class SynchronizedMap {
         public:
-            SynchronizedMap() {
-            }
+            SynchronizedMap() = default;
 
             SynchronizedMap(const SynchronizedMap<K, V> &rhs) {
                 *this = rhs;

--- a/hazelcast/include/hazelcast/util/UTFUtil.h
+++ b/hazelcast/include/hazelcast/util/UTFUtil.h
@@ -77,9 +77,9 @@ namespace hazelcast {
             }
 
         private:
-            UTFUtil();
+            UTFUtil() = delete;
 
-            UTFUtil(const UTFUtil &);
+            UTFUtil(const UTFUtil &) = delete;
         };
     }
 }

--- a/hazelcast/include/hazelcast/util/concurrent/BackoffIdleStrategy.h
+++ b/hazelcast/include/hazelcast/util/concurrent/BackoffIdleStrategy.h
@@ -47,7 +47,7 @@ namespace hazelcast {
                 BackoffIdleStrategy(int64_t maxSpins, int64_t maxYields, int64_t minParkPeriodNs,
                                     int64_t maxParkPeriodNs);
 
-                virtual bool idle(int64_t n);
+                bool idle(int64_t n) override;
 
             private:
                 int64_t parkTime(int64_t n) const;

--- a/hazelcast/include/hazelcast/util/concurrent/IdleStrategy.h
+++ b/hazelcast/include/hazelcast/util/concurrent/IdleStrategy.h
@@ -35,8 +35,7 @@ namespace hazelcast {
                 /**
                  * Destructor
                  */
-                virtual ~IdleStrategy() {
-                }
+                virtual ~IdleStrategy() = default;
 
                 /**
                  * Perform current idle strategy's step <i>n</i>.

--- a/hazelcast/include/hazelcast/util/concurrent/TimeUnit.h
+++ b/hazelcast/include/hazelcast/util/concurrent/TimeUnit.h
@@ -166,21 +166,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API NanoSeconds : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
 
             /**
@@ -188,21 +188,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API MicroSeconds : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
 
             /**
@@ -210,21 +210,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API MilliSeconds : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
 
             /**
@@ -232,21 +232,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API Seconds : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
 
             /**
@@ -254,21 +254,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API Minutes : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
 
             /**
@@ -276,21 +276,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API Hours : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
 
             /**
@@ -298,21 +298,21 @@ namespace hazelcast {
              */
             class HAZELCAST_API Days : public TimeUnit {
             public:
-                virtual int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const;
+                int64_t convert(int64_t sourceDuration, const TimeUnit &sourceUnit) const override;
 
-                virtual int64_t toNanos(int64_t duration) const;
+                int64_t toNanos(int64_t duration) const override;
 
-                virtual int64_t toMicros(int64_t duration) const;
+                int64_t toMicros(int64_t duration) const override;
 
-                virtual int64_t toMillis(int64_t duration) const;
+                int64_t toMillis(int64_t duration) const override;
 
-                virtual int64_t toSeconds(int64_t duration) const;
+                int64_t toSeconds(int64_t duration) const override;
 
-                virtual int64_t toMinutes(int64_t duration) const;
+                int64_t toMinutes(int64_t duration) const override;
 
-                virtual int64_t toHours(int64_t duration) const;
+                int64_t toHours(int64_t duration) const override;
 
-                virtual int64_t toDays(int64_t duration) const;
+                int64_t toDays(int64_t duration) const override;
             };
         }
     }

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -177,8 +177,7 @@ namespace hazelcast {
                 statistics.reset(new statistics::Statistics(clientContext));
             }
 
-            HazelcastClientInstanceImpl::~HazelcastClientInstanceImpl() {
-            }
+            HazelcastClientInstanceImpl::~HazelcastClientInstanceImpl() = default;
 
             void HazelcastClientInstanceImpl::start() {
                 startLogger();
@@ -372,8 +371,7 @@ namespace hazelcast {
                 return logger;
             }
 
-            BaseEventHandler::~BaseEventHandler() {
-            }
+            BaseEventHandler::~BaseEventHandler() = default;
 
             void BaseEventHandler::handle(const std::shared_ptr<protocol::ClientMessage> &event) {
                 std::unique_ptr<protocol::ClientMessage> e(new protocol::ClientMessage(*event));
@@ -414,8 +412,7 @@ namespace hazelcast {
             }
         }
 
-        LoadBalancer::~LoadBalancer() {
-        }
+        LoadBalancer::~LoadBalancer() = default;
 
         const int Address::ID = cluster::impl::ADDRESS;
 
@@ -507,8 +504,7 @@ namespace hazelcast {
             }
         }
 
-        LifecycleListener::~LifecycleListener() {
-        }
+        LifecycleListener::~LifecycleListener() = default;
 
         const std::string IExecutorService::SERVICE_NAME = "hz:impl:executorService";
 
@@ -790,8 +786,7 @@ namespace hazelcast {
                                                     details % source).str()) {
             }
 
-            IException::~IException() noexcept {
-            }
+            IException::~IException() noexcept = default;
 
             char const *IException::what() const noexcept {
                 return report.c_str();
@@ -826,7 +821,7 @@ namespace hazelcast {
                 return retryable;
             }
 
-            IException::IException() {}
+            IException::IException() = default;
 
             RetryableHazelcastException::RetryableHazelcastException(const std::string &source,
                                                                      const std::string &message,

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -176,8 +176,7 @@ namespace hazelcast {
                 cluster(&cluster), member(member), eventType(eventType), members(membersList) {
         }
 
-        MembershipEvent::~MembershipEvent() {
-        }
+        MembershipEvent::~MembershipEvent() = default;
 
         const std::vector<Member> MembershipEvent::getMembers() const {
             return members;
@@ -221,8 +220,7 @@ namespace hazelcast {
             return name;
         }
 
-        MembershipListener::~MembershipListener() {
-        }
+        MembershipListener::~MembershipListener() = default;
 
         const std::string &MembershipListener::getRegistrationId() const {
             return registrationId;
@@ -266,8 +264,7 @@ namespace hazelcast {
             return listener->getRegistrationId();
         }
 
-        InitialMembershipListener::~InitialMembershipListener() {
-        }
+        InitialMembershipListener::~InitialMembershipListener() = default;
 
         bool InitialMembershipListener::shouldRequestInitialMembers() const {
             return true;
@@ -332,9 +329,7 @@ namespace hazelcast {
                 index.store(const_cast<RoundRobinLB &>(rhs).index.load());
             }
 
-            MemberAttributeChange::MemberAttributeChange() {
-
-            }
+            MemberAttributeChange::MemberAttributeChange() = default;
 
             MemberAttributeChange::MemberAttributeChange(std::unique_ptr<std::string> &uuid,
                                                          MemberAttributeEvent::MemberAttributeOperationType const &operationType,
@@ -400,8 +395,7 @@ namespace hazelcast {
                 return membersRef;
             }
 
-            AbstractLoadBalancer::~AbstractLoadBalancer() {
-            }
+            AbstractLoadBalancer::~AbstractLoadBalancer() = default;
 
             AbstractLoadBalancer::AbstractLoadBalancer() : cluster(NULL) {
             }
@@ -426,7 +420,7 @@ namespace hazelcast {
             }
 
             namespace impl {
-                VectorClock::VectorClock() {}
+                VectorClock::VectorClock() = default;
 
                 VectorClock::VectorClock(const VectorClock::TimestampVector &replicaLogicalTimestamps)
                         : replicaTimestampEntries(replicaLogicalTimestamps) {

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -293,9 +293,7 @@ namespace hazelcast {
 
             const int ReliableTopicConfig::DEFAULT_READ_BATCH_SIZE = 10;
 
-            ReliableTopicConfig::ReliableTopicConfig() {
-
-            }
+            ReliableTopicConfig::ReliableTopicConfig() = default;
 
             ReliableTopicConfig::ReliableTopicConfig(const char *topicName) : readBatchSize(DEFAULT_READ_BATCH_SIZE),
                                                                               name(topicName) {

--- a/hazelcast/src/hazelcast/client/discovery.cpp
+++ b/hazelcast/src/hazelcast/client/discovery.cpp
@@ -69,8 +69,7 @@ namespace hazelcast {
                                                                                   endpoint(endpoint) {
                 }
 
-                EC2RequestSigner::~EC2RequestSigner() {
-                }
+                EC2RequestSigner::~EC2RequestSigner() = default;
 
                 std::string EC2RequestSigner::sign(const std::unordered_map<std::string, std::string> &attributes) {
                     std::string canonicalRequest = getCanonicalizedRequest(attributes);
@@ -294,8 +293,7 @@ namespace hazelcast {
                 const char *Constants::GET = "GET";
                 const char *Constants::ECS_CREDENTIALS_ENV_VAR_NAME = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
 
-                Filter::Filter() {
-                }
+                Filter::Filter() = default;
 
                 /**
                  *
@@ -401,8 +399,7 @@ namespace hazelcast {
                     addFilters();
                 }
 
-                DescribeInstances::~DescribeInstances() {
-                }
+                DescribeInstances::~DescribeInstances() = default;
 
                 std::unordered_map<std::string, std::string> DescribeInstances::execute() {
                     std::string signature = rs->sign(attributes);

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -67,7 +67,7 @@
 
 namespace hazelcast {
     namespace client {
-        SocketInterceptor::~SocketInterceptor() {}
+        SocketInterceptor::~SocketInterceptor() = default;
 
         namespace connection {
             int ClientConnectionManagerImpl::DEFAULT_CONNECTION_ATTEMPT_LIMIT_SYNC = 2;
@@ -814,8 +814,7 @@ namespace hazelcast {
                 }
             }
 
-            ClientConnectionManagerImpl::AuthCallback::~AuthCallback() {
-            }
+            ClientConnectionManagerImpl::AuthCallback::~AuthCallback() = default;
 
             AuthenticationFuture::AuthenticationFuture(const Address &address,
                                                        util::SynchronizedMap<Address, FutureTuple> &connectionsInProgress)
@@ -912,8 +911,7 @@ namespace hazelcast {
                 socket = socketFactory.create(address, connectTimeoutInMillis);
             }
 
-            Connection::~Connection() {
-            }
+            Connection::~Connection() = default;
 
             void Connection::authenticate() {
                 auto thisConnection = shared_from_this();
@@ -1142,8 +1140,7 @@ namespace hazelcast {
                       clientConnectionStrategyConfig(clientConnectionStrategyConfig) {
             }
 
-            ClientConnectionStrategy::~ClientConnectionStrategy() {
-            }
+            ClientConnectionStrategy::~ClientConnectionStrategy() = default;
 
             HeartbeatManager::HeartbeatManager(spi::ClientContext &client,
                                                ClientConnectionManagerImpl &connectionManager)

--- a/hazelcast/src/hazelcast/client/protocol.cpp
+++ b/hazelcast/src/hazelcast/client/protocol.cpp
@@ -63,8 +63,7 @@ namespace hazelcast {
                 setFrameLength(size);
             }
 
-            ClientMessage::~ClientMessage() {
-            }
+            ClientMessage::~ClientMessage() = default;
 
             void ClientMessage::wrapForEncode(int32_t size) {
                 wrapForWrite(size, HEADER_SIZE);
@@ -409,8 +408,7 @@ namespace hazelcast {
                 return codec::AddressCodec::calculateDataSize(param);
             }
 
-            ExceptionFactory::~ExceptionFactory() {
-            }
+            ExceptionFactory::~ExceptionFactory() = default;
 
             ClientExceptionFactory::ClientExceptionFactory() {
                 registerException(UNDEFINED,
@@ -601,8 +599,7 @@ namespace hazelcast {
                     : connection(connection) {
             }
 
-            ClientMessageBuilder::~ClientMessageBuilder() {
-            }
+            ClientMessageBuilder::~ClientMessageBuilder() = default;
 
             bool ClientMessageBuilder::onData(util::ByteBuffer &buffer) {
                 bool isCompleted = false;

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -995,7 +995,7 @@ namespace hazelcast {
                                  spi::ClientContext *context)
                     : ClientProxy(objectName, serviceName, *context), SerializingProxy(*context, objectName) {}
 
-            ProxyImpl::~ProxyImpl() {}
+            ProxyImpl::~ProxyImpl() = default;
 
             SerializingProxy::SerializingProxy(spi::ClientContext &context, const std::string &objectName)
                     : serializationService_(context.getSerializationService()),
@@ -1987,7 +1987,7 @@ namespace hazelcast {
             return name;
         }
 
-        ItemEventBase::~ItemEventBase() {}
+        ItemEventBase::~ItemEventBase() = default;
 
         FlakeIdGenerator::FlakeIdGenerator(const std::string &objectName, spi::ClientContext *context)
                 : FlakeIdGeneratorImpl(SERVICE_NAME, objectName, context) {}

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -474,7 +474,7 @@ namespace hazelcast {
             ClientProxy::ClientProxy(const std::string &name, const std::string &serviceName, ClientContext &context)
                     : name(name), serviceName(serviceName), context(context) {}
 
-            ClientProxy::~ClientProxy() {}
+            ClientProxy::~ClientProxy() = default;
 
             const std::string &ClientProxy::getName() const {
                 return name;
@@ -605,8 +605,7 @@ namespace hazelcast {
                     connection.write(clientInvocation);
                 }
 
-                AbstractClientInvocationService::~AbstractClientInvocationService() {
-                }
+                AbstractClientInvocationService::~AbstractClientInvocationService() = default;
 
                 AbstractClientInvocationService::ResponseProcessor::ResponseProcessor(util::ILogger &invocationLogger,
                                                                                       AbstractClientInvocationService &invocationService,
@@ -1224,8 +1223,7 @@ namespace hazelcast {
                         invokeCount(0) {
                 }
 
-                ClientInvocation::~ClientInvocation() {
-                }
+                ClientInvocation::~ClientInvocation() = default;
 
                 boost::future<protocol::ClientMessage> ClientInvocation::invoke() {
                     assert (clientMessage.get() != NULL);
@@ -1693,8 +1691,7 @@ namespace hazelcast {
                     return privateToPublic;
                 }
 
-                AwsAddressProvider::~AwsAddressProvider() {
-                }
+                AwsAddressProvider::~AwsAddressProvider() = default;
 
                 Address DefaultAddressTranslator::translate(const Address &address) {
                     return address;
@@ -1895,8 +1892,7 @@ namespace hazelcast {
                 namespace sequence {
                     CallIdSequenceWithoutBackpressure::CallIdSequenceWithoutBackpressure() : head(0) {}
 
-                    CallIdSequenceWithoutBackpressure::~CallIdSequenceWithoutBackpressure() {
-                    }
+                    CallIdSequenceWithoutBackpressure::~CallIdSequenceWithoutBackpressure() = default;
 
                     int32_t CallIdSequenceWithoutBackpressure::getMaxConcurrentInvocations() const {
                         return INT32_MAX;
@@ -1931,8 +1927,7 @@ namespace hazelcast {
                         }
                     }
 
-                    AbstractCallIdSequence::~AbstractCallIdSequence() {
-                    }
+                    AbstractCallIdSequence::~AbstractCallIdSequence() = default;
 
                     int32_t AbstractCallIdSequence::getMaxConcurrentInvocations() const {
                         return maxConcurrentInvocations;
@@ -2047,8 +2042,7 @@ namespace hazelcast {
                         invocationRetryPause = invocationService.getInvocationRetryPause();
                     }
 
-                    AbstractClientListenerService::~AbstractClientListenerService() {
-                    }
+                    AbstractClientListenerService::~AbstractClientListenerService() = default;
 
                     boost::future<std::string>
                     AbstractClientListenerService::registerListener(
@@ -2321,7 +2315,7 @@ namespace hazelcast {
                         return serverRegistrationId < rhs.serverRegistrationId;
                     }
 
-                    ClientEventRegistration::ClientEventRegistration() {}
+                    ClientEventRegistration::ClientEventRegistration() = default;
 
                     SmartClientListenerService::SmartClientListenerService(ClientContext &clientContext,
                                                                            int32_t eventThreadCount)
@@ -2477,7 +2471,7 @@ namespace hazelcast {
                         return os;
                     }
 
-                    ClientRegistrationKey::ClientRegistrationKey() {}
+                    ClientRegistrationKey::ClientRegistrationKey() = default;
 
                     bool operator==(const ClientRegistrationKey &lhs, const ClientRegistrationKey &rhs) {
                         return lhs.userRegistrationId == rhs.userRegistrationId;

--- a/hazelcast/src/hazelcast/client/stats.cpp
+++ b/hazelcast/src/hazelcast/client/stats.cpp
@@ -260,7 +260,7 @@ namespace hazelcast {
             const int64_t LocalInstanceStats::STAT_NOT_AVAILABLE = -99L;
 
             namespace impl {
-                LocalMapStatsImpl::LocalMapStatsImpl() {}
+                LocalMapStatsImpl::LocalMapStatsImpl() = default;
 
                 LocalMapStatsImpl::LocalMapStatsImpl(const std::shared_ptr<monitor::NearCacheStats> &s) : nearCacheStats(s) {}
 

--- a/hazelcast/src/hazelcast/client/transactions.cpp
+++ b/hazelcast/src/hazelcast/client/transactions.cpp
@@ -529,7 +529,7 @@ namespace hazelcast {
                     : proxy::SerializingProxy(context.getClientContext(), objectName), serviceName(serviceName),
                       name(objectName), context(context) {}
 
-            TransactionalObject::~TransactionalObject() {}
+            TransactionalObject::~TransactionalObject() = default;
 
             const std::string &TransactionalObject::getServiceName() {
                 return serviceName;

--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -247,8 +247,7 @@ namespace hazelcast {
 
 namespace hazelcast {
     namespace util {
-        Clearable::~Clearable() {
-        }
+        Clearable::~Clearable() = default;
     }
 }
 
@@ -271,8 +270,7 @@ namespace hazelcast {
 
 namespace hazelcast {
     namespace util {
-        Destroyable::~Destroyable() {
-        }
+        Destroyable::~Destroyable() = default;
     }
 }
 
@@ -297,8 +295,7 @@ namespace hazelcast {
 
 namespace hazelcast {
     namespace util {
-        Closeable::~Closeable() {
-        }
+        Closeable::~Closeable() = default;
     }
 }
 
@@ -316,8 +313,7 @@ namespace hazelcast {
             easyLogger = el::Loggers::getLogger(instanceName);
         }
 
-        ILogger::~ILogger() {
-        }
+        ILogger::~ILogger() = default;
 
         bool ILogger::start() {
             std::string configurationFileName = loggerConfig.getConfigurationFileName();
@@ -1378,8 +1374,7 @@ namespace hazelcast {
             return hazelcastExceptionFactory;
         }
 
-        ExceptionUtil::RuntimeExceptionFactory::~RuntimeExceptionFactory() {
-        }
+        ExceptionUtil::RuntimeExceptionFactory::~RuntimeExceptionFactory() = default;
 
         void ExceptionUtil::HazelcastExceptionFactory::rethrow(
                 std::exception_ptr throwable, const std::string &message) {

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -747,8 +747,7 @@ namespace hazelcast {
                 hazelcast::util::sleep(seconds);
             }
 
-            ClientTestSupportBase::ClientTestSupportBase() {
-            }
+            ClientTestSupportBase::ClientTestSupportBase() = default;
 
             std::string ClientTestSupportBase::generateKeyOwnedBy(spi::ClientContext &context, const Member &member) {
                 spi::ClientPartitionService &partitionService = context.getPartitionService();
@@ -927,7 +926,7 @@ namespace hazelcast {
                               disconnectedLatch(disconnectedLatch), shuttingDownLatch(shuttingDownLatch),
                               shutdownLatch(shutdownLatch) {}
 
-                    virtual void stateChanged(const LifecycleEvent &lifecycleEvent) {
+                    void stateChanged(const LifecycleEvent &lifecycleEvent) override {
                         switch (lifecycleEvent.getState()) {
                             case LifecycleEvent::STARTING:
                                 if (startingLatch) {
@@ -1128,7 +1127,7 @@ namespace hazelcast {
                 MySocketInterceptor(boost::latch &latch1) : interceptorLatch(latch1) {
                 }
 
-                void onConnect(const hazelcast::client::Socket &connectedSocket) {
+                void onConnect(const hazelcast::client::Socket &connectedSocket) override {
                     ASSERT_EQ("127.0.0.1", connectedSocket.getAddress().getHost());
                     ASSERT_NE(0, connectedSocket.getAddress().getPort());
                     interceptorLatch.count_down();
@@ -1307,13 +1306,13 @@ namespace hazelcast {
 
                 }
 
-                void memberAdded(const MembershipEvent &event) {
+                void memberAdded(const MembershipEvent &event) override {
                 }
 
-                void memberRemoved(const MembershipEvent &event) {
+                void memberRemoved(const MembershipEvent &event) override {
                 }
 
-                void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) {
+                void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) override {
                     if (memberAttributeEvent.getOperationType() != MemberAttributeEvent::PUT) {
                         return;
                     }
@@ -1654,7 +1653,7 @@ namespace hazelcast {
         namespace test {
             class SimpleListenerTest : public ClientTestSupportBase, public ::testing::TestWithParam<ClientConfig *> {
             public:
-                SimpleListenerTest() {}
+                SimpleListenerTest() = default;
 
             protected:
                 class MyEntryListener : public EntryAdapter {
@@ -1684,23 +1683,23 @@ namespace hazelcast {
                               _memberRemoved(_memberRemoved) {
                     }
 
-                    void init(const InitialMembershipEvent &event) {
+                    void init(const InitialMembershipEvent &event) override {
                         std::vector<Member> const &members = event.getMembers();
                         if (members.size() == 1) {
                             _memberAdded.count_down();
                         }
                     }
 
-                    void memberAdded(const MembershipEvent &event) {
+                    void memberAdded(const MembershipEvent &event) override {
                         _memberAdded.count_down();
                     }
 
-                    void memberRemoved(const MembershipEvent &event) {
+                    void memberRemoved(const MembershipEvent &event) override {
                         _memberRemoved.count_down();
                     }
 
 
-                    void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) {
+                    void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) override {
                         _attributeLatch.count_down();
                     }
 
@@ -1719,15 +1718,15 @@ namespace hazelcast {
                               _memberRemoved(_memberRemoved) {
                     }
 
-                    void memberAdded(const MembershipEvent &event) {
+                    void memberAdded(const MembershipEvent &event) override {
                         _memberAdded.count_down();
                     }
 
-                    void memberRemoved(const MembershipEvent &event) {
+                    void memberRemoved(const MembershipEvent &event) override {
                         _memberRemoved.count_down();
                     }
 
-                    void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) {
+                    void memberAttributeChanged(const MemberAttributeEvent &memberAttributeEvent) override {
                         memberAttributeEvent.getKey();
                         _attributeLatch.count_down();
                     }
@@ -1964,7 +1963,7 @@ namespace hazelcast {
             public:
                 ClientTxnMapTest();
 
-                ~ClientTxnMapTest();
+                ~ClientTxnMapTest() override;
 
             protected:
                 HazelcastServer instance;
@@ -1975,8 +1974,7 @@ namespace hazelcast {
             ClientTxnMapTest::ClientTxnMapTest() : instance(*g_srvFactory), client(getNewClient()) {
             }
 
-            ClientTxnMapTest::~ClientTxnMapTest() {
-            }
+            ClientTxnMapTest::~ClientTxnMapTest() = default;
 
             TEST_F(ClientTxnMapTest, testPutGet) {
                 std::string name = "testPutGet";
@@ -2311,7 +2309,7 @@ namespace hazelcast {
             public:
                 ClientTxnSetTest();
 
-                ~ClientTxnSetTest();
+                ~ClientTxnSetTest() override;
 
             protected:
                 HazelcastServer instance;
@@ -2321,7 +2319,7 @@ namespace hazelcast {
             ClientTxnSetTest::ClientTxnSetTest() : instance(*g_srvFactory), client(getNewClient()) {
             }
 
-            ClientTxnSetTest::~ClientTxnSetTest() {}
+            ClientTxnSetTest::~ClientTxnSetTest() = default;
 
             TEST_F(ClientTxnSetTest, testAddRemove) {
                 auto s = client.getSet("testAddRemove");
@@ -2351,7 +2349,7 @@ namespace hazelcast {
             public:
                 ClientTxnTest();
 
-                ~ClientTxnTest();
+                ~ClientTxnTest() override;
 
             protected:
                 HazelcastServerFactory & hazelcastInstanceFactory;
@@ -2363,7 +2361,7 @@ namespace hazelcast {
 
             class MyLoadBalancer : public impl::AbstractLoadBalancer {
             public:
-                const Member next() {
+                const Member next() override {
                     std::vector<Member> members = getMembers();
                     size_t len = members.size();
                     if (len == 0) {
@@ -2385,13 +2383,13 @@ namespace hazelcast {
                 MyMembershipListener(boost::latch &countDownLatch)
                         : countDownLatch(countDownLatch) {}
 
-                void memberAdded(const MembershipEvent &membershipEvent) {}
+                void memberAdded(const MembershipEvent &membershipEvent) override {}
 
-                void memberRemoved(const MembershipEvent &membershipEvent) {
+                void memberRemoved(const MembershipEvent &membershipEvent) override {
                     countDownLatch.count_down();
                 }
 
-                void memberAttributeChanged(const MemberAttributeEvent& memberAttributeEvent) {}
+                void memberAttributeChanged(const MemberAttributeEvent& memberAttributeEvent) override {}
             private:
                 boost::latch &countDownLatch;
             };
@@ -2574,7 +2572,7 @@ namespace hazelcast {
             class ClientTxnListTest : public ClientTestSupport {
             public:
                 ClientTxnListTest();
-                ~ClientTxnListTest();
+                ~ClientTxnListTest() override;
             protected:
                 HazelcastServer instance;
                 ClientConfig clientConfig;
@@ -2583,7 +2581,7 @@ namespace hazelcast {
 
             ClientTxnListTest::ClientTxnListTest() : instance(*g_srvFactory), client(getNewClient()) {}
 
-            ClientTxnListTest::~ClientTxnListTest() {}
+            ClientTxnListTest::~ClientTxnListTest() = default;
 
             TEST_F(ClientTxnListTest, testAddRemove) {
                 auto l = client.getList("testAddRemove");
@@ -2612,7 +2610,7 @@ namespace hazelcast {
             class ClientTxnMultiMapTest : public ClientTestSupport {
             public:
                 ClientTxnMultiMapTest();
-                ~ClientTxnMultiMapTest();
+                ~ClientTxnMultiMapTest() override;
             protected:
                 HazelcastServer instance;
                 HazelcastClient client;
@@ -2621,7 +2619,7 @@ namespace hazelcast {
             ClientTxnMultiMapTest::ClientTxnMultiMapTest()
                     : instance(*g_srvFactory), client(getNewClient()) {}
 
-            ClientTxnMultiMapTest::~ClientTxnMultiMapTest() {}
+            ClientTxnMultiMapTest::~ClientTxnMultiMapTest() = default;
 
             TEST_F(ClientTxnMultiMapTest, testRemoveIfExists) {
                 TransactionContext context = client.newTransactionContext();
@@ -2687,7 +2685,7 @@ namespace hazelcast {
             class ClientTxnQueueTest : public ClientTestSupport {
             public:
                 ClientTxnQueueTest();
-                ~ClientTxnQueueTest();
+                ~ClientTxnQueueTest() override;
             protected:
                 HazelcastServer instance;
                 HazelcastClient client;
@@ -2695,7 +2693,7 @@ namespace hazelcast {
 
             ClientTxnQueueTest::ClientTxnQueueTest() : instance(*g_srvFactory), client(getNewClient()) {}
 
-            ClientTxnQueueTest::~ClientTxnQueueTest() {}
+            ClientTxnQueueTest::~ClientTxnQueueTest() = default;
 
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPoll1) {
                 std::string name = "defQueue";
@@ -2918,7 +2916,7 @@ namespace hazelcast {
         namespace test {
             class RuntimeAvailableProcessorsTest : public ::testing::Test {
             protected:
-                virtual void TearDown() {
+                void TearDown() override {
                     RuntimeAvailableProcessors::resetOverride();
                 }
             };

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -351,14 +351,14 @@ namespace hazelcast {
                 }
 
             protected:
-                virtual void SetUp() {
+                void SetUp() override {
                     ASSERT_TRUE(testLogger->start());
 
                     originalStdout = std::cout.rdbuf();
                     std::cout.rdbuf(buffer.rdbuf());
                 }
 
-                virtual void TearDown() {
+                void TearDown() override {
                     std::cout.rdbuf(originalStdout);
                 }
 
@@ -488,13 +488,13 @@ namespace hazelcast {
                 }
 
             protected:
-                virtual void SetUp() {
+                void SetUp() override {
                     originalStdout = std::cout.rdbuf();
 
                     std::cout.rdbuf(buffer.rdbuf());
                 }
 
-                virtual void TearDown() {
+                void TearDown() override {
                     std::cout.rdbuf(originalStdout);
                 }
 
@@ -819,7 +819,7 @@ namespace hazelcast {
                                                const LifecycleEvent::LifeCycleState expectedState)
                                 : connectedLatch(connectedLatch), expectedState(expectedState) {}
 
-                        virtual void stateChanged(const LifecycleEvent &event) {
+                        void stateChanged(const LifecycleEvent &event) override {
                             if (event.getState() == expectedState) {
                                 connectedLatch.try_count_down();
                             }
@@ -1114,7 +1114,7 @@ namespace hazelcast {
             public:
                 class Child {
                 public:
-                    Child() {}
+                    Child() = default;
 
                     Child(std::string name) : name(name) {}
 
@@ -1136,7 +1136,7 @@ namespace hazelcast {
                         return lhs.child == rhs.child;
                     }
 
-                    Parent() {}
+                    Parent() = default;
 
                     Parent(Child child) : child(child) {}
 
@@ -1223,7 +1223,7 @@ namespace hazelcast {
                 public:
                     SimplePartitionAwareObject() : testKey(5) {}
 
-                    virtual const int *getPartitionKey() const {
+                    const int *getPartitionKey() const override {
                         return &testKey;
                     }
 

--- a/hazelcast/test/src/HazelcastTests5.cpp
+++ b/hazelcast/test/src/HazelcastTests5.cpp
@@ -390,7 +390,7 @@ namespace hazelcast {
         namespace test {
             class CallIdSequenceWithBackpressureTest : public ClientTestSupport {
             public:
-                CallIdSequenceWithBackpressureTest() {}
+                CallIdSequenceWithBackpressureTest() = default;
 
             protected:
                 class ThreeSecondDelayCompleteOperation {
@@ -726,7 +726,7 @@ namespace hazelcast {
         namespace test {
             class ClientExpirationListenerTest : public ClientTestSupport {
             protected:
-                virtual void TearDown() {
+                void TearDown() override {
                     // clear maps
                     imap->clear().get();
                 }
@@ -769,7 +769,7 @@ namespace hazelcast {
 
                 }
 
-                void entryExpired(const EntryEvent &event) {
+                void entryExpired(const EntryEvent &event) override {
                     latch1.count_down();
                 }
 
@@ -809,11 +809,11 @@ namespace hazelcast {
 
                 }
 
-                void entryEvicted(const EntryEvent &event) {
+                void entryEvicted(const EntryEvent &event) override {
                     evictedLatch.count_down();
                 }
 
-                void entryExpired(const EntryEvent &event) {
+                void entryExpired(const EntryEvent &event) override {
                     expiredLatch.count_down();
                 }
 
@@ -862,7 +862,7 @@ namespace hazelcast {
                 PartitionAwareInt(int partitionKey, int actualKey)
                         : partitionKey(partitionKey), actualKey(actualKey) {}
 
-                virtual const int *getPartitionKey() const {
+                const int *getPartitionKey() const override {
                     return &partitionKey;
                 }
 
@@ -885,8 +885,7 @@ namespace hazelcast {
                     addAddress(Address(g_srvFactory->getServerAddress(), 5701));
                 }
 
-                virtual ~MapClientConfig() {
-                }
+                virtual ~MapClientConfig() = default;
             };
 
             class NearCachedDataMapClientConfig : public MapClientConfig {
@@ -968,7 +967,7 @@ namespace hazelcast {
                     int multiplier;
                 };
             protected:
-                virtual void TearDown() {
+                void TearDown() override {
                     // clear maps
                     employees->destroy();
                     intMap->destroy();
@@ -1058,7 +1057,7 @@ namespace hazelcast {
                     EvictedEntryListener(const std::shared_ptr<boost::latch> &evictLatch) : evictLatch(
                             evictLatch) {}
 
-                    virtual void entryEvicted(const EntryEvent &event) {
+                    void entryEvicted(const EntryEvent &event) override {
                         evictLatch->count_down();
                     }
                 private:
@@ -1074,19 +1073,19 @@ namespace hazelcast {
                             : addLatch(addLatch), removeLatch(removeLatch), updateLatch(updateLatch),
                               evictLatch(evictLatch) {}
 
-                    void entryAdded(const EntryEvent &event) {
+                    void entryAdded(const EntryEvent &event) override {
                         addLatch.count_down();
                     }
 
-                    void entryRemoved(const EntryEvent &event) {
+                    void entryRemoved(const EntryEvent &event) override {
                         removeLatch.count_down();
                     }
 
-                    void entryUpdated(const EntryEvent &event) {
+                    void entryUpdated(const EntryEvent &event) override {
                         updateLatch.count_down();
                     }
 
-                    void entryEvicted(const EntryEvent &event) {
+                    void entryEvicted(const EntryEvent &event) override {
                         evictLatch.count_down();
                     }
                 private:
@@ -1101,11 +1100,11 @@ namespace hazelcast {
                     MyListener(boost::latch &latch1, boost::latch &nullLatch)
                             : latch1(latch1), nullLatch(nullLatch) {}
 
-                    void entryAdded(const EntryEvent &event) {
+                    void entryAdded(const EntryEvent &event) override {
                         latch1.count_down();
                     }
 
-                    void entryEvicted(const EntryEvent &event) {
+                    void entryEvicted(const EntryEvent &event) override {
                         auto oldValue = event.getOldValue().get<std::string>();
                         if (!oldValue.has_value() || oldValue.value().compare("")) {
                             nullLatch.count_down();
@@ -1121,7 +1120,7 @@ namespace hazelcast {
                 public:
                     ClearListener(boost::latch &latch1) : latch1(latch1) {}
 
-                    void mapCleared(const MapEvent &event) {
+                    void mapCleared(const MapEvent &event) override {
                         latch1.count_down();
                     }
                 private:
@@ -1132,7 +1131,7 @@ namespace hazelcast {
                 public:
                     EvictListener(boost::latch &latch1) : latch1(latch1) {}
 
-                    void mapEvicted(const MapEvent &event) {
+                    void mapEvicted(const MapEvent &event) override {
                         latch1.count_down();
                     }
                 private:
@@ -1145,7 +1144,7 @@ namespace hazelcast {
                                                       hazelcast::util::AtomicInt &atomicInteger)
                             : latch1(latch1), atomicInteger(atomicInteger) {}
 
-                    void entryAdded(const EntryEvent &event) {
+                    void entryAdded(const EntryEvent &event) override {
                         ++atomicInteger;
                         latch1.count_down();
                     }

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -368,7 +368,7 @@ namespace hazelcast {
                 public:
                     MyListItemListener(boost::latch &latch1) : latch1(latch1) {}
 
-                    void itemAdded(const ItemEvent &itemEvent) {
+                    void itemAdded(const ItemEvent &itemEvent) override {
                         auto type = itemEvent.getEventType();
                         ASSERT_EQ(ItemEventType::ADDED, type);
                         ASSERT_EQ("MyList", itemEvent.getName());
@@ -379,12 +379,12 @@ namespace hazelcast {
                         latch1.count_down();
                     }
 
-                    void itemRemoved(const ItemEvent &item) {}
+                    void itemRemoved(const ItemEvent &item) override {}
                 private:
                     boost::latch &latch1;
                 };
 
-                virtual void TearDown() {
+                void TearDown() override {
                     // clear list
                     list->clear();
                 }
@@ -587,7 +587,7 @@ namespace hazelcast {
                     }
                 }
                 
-                virtual void TearDown() {
+                void TearDown() override {
                     q->clear();
                 }
                 
@@ -877,7 +877,7 @@ namespace hazelcast {
 
                 static const size_t numberOfMembers;
 
-                virtual void TearDown() {
+                void TearDown() override {
                 }
 
                 static void SetUpTestCase() {
@@ -904,10 +904,10 @@ namespace hazelcast {
                     FailingExecutionCallback(const std::shared_ptr<boost::latch> &latch1) : latch1(
                             latch1) {}
 
-                    virtual void onResponse(const boost::optional<std::string> &response) {
+                    void onResponse(const boost::optional<std::string> &response) override {
                     }
 
-                    virtual void onFailure(std::exception_ptr e) {
+                    void onFailure(std::exception_ptr e) override {
                         exception = e;
                         latch1->count_down();
                     }
@@ -925,11 +925,11 @@ namespace hazelcast {
                 public:
                     SuccessfullExecutionCallback(const std::shared_ptr<boost::latch> &latch1) : latch1(latch1) {}
 
-                    virtual void onResponse(const boost::optional<std::string> &response) {
+                    void onResponse(const boost::optional<std::string> &response) override {
                         latch1->count_down();
                     }
 
-                    virtual void onFailure(std::exception_ptr e) {
+                    void onFailure(std::exception_ptr e) override {
                     }
 
                 private:
@@ -940,12 +940,12 @@ namespace hazelcast {
                 public:
                     ResultSettingExecutionCallback(const std::shared_ptr<boost::latch> &latch1) : latch1(latch1) {}
 
-                    virtual void onResponse(const boost::optional<std::string> &response) {
+                    void onResponse(const boost::optional<std::string> &response) override {
                         result.set(std::move(response));
                         latch1->count_down();
                     }
 
-                    virtual void onFailure(std::exception_ptr e) {
+                    void onFailure(std::exception_ptr e) override {
                     }
 
                     boost::optional<std::string> getResult() {
@@ -967,18 +967,18 @@ namespace hazelcast {
                                                                                                            completeLatch(
                                                                                                                    completeLatch) {}
 
-                    virtual void onResponse(const Member &member, const boost::optional<std::string> &response) {
+                    void onResponse(const Member &member, const boost::optional<std::string> &response) override {
                         if (response && *response == msg + APPENDAGE) {
                             responseLatch->count_down();
                         }
                     }
 
-                    virtual void
-                    onFailure(const Member &member, std::exception_ptr exception) {
+                    void
+                    onFailure(const Member &member, std::exception_ptr exception) override {
                     }
 
-                    virtual void onComplete(const std::unordered_map<Member, boost::optional<std::string> > &values,
-                                            const std::unordered_map<Member, std::exception_ptr> &exceptions) {
+                    void onComplete(const std::unordered_map<Member, boost::optional<std::string> > &values,
+                                            const std::unordered_map<Member, std::exception_ptr> &exceptions) override {
                         typedef std::unordered_map<Member, boost::optional<std::string> > VALUE_MAP;
                         std::string expectedValue(msg + APPENDAGE);
                         for (const VALUE_MAP::value_type &entry  : values) {
@@ -1000,18 +1000,18 @@ namespace hazelcast {
                                                std::shared_ptr<boost::latch> completeLatch)
                             : responseLatch(std::move(responseLatch)), completeLatch(std::move(completeLatch)) {}
 
-                    virtual void onResponse(const Member &member, const boost::optional<std::string> &response) {
+                    void onResponse(const Member &member, const boost::optional<std::string> &response) override {
                         if (!response) {
                             responseLatch->count_down();
                         }
                     }
 
-                    virtual void
-                    onFailure(const Member &member, std::exception_ptr exception) {
+                    void
+                    onFailure(const Member &member, std::exception_ptr exception) override {
                     }
 
-                    virtual void onComplete(const std::unordered_map<Member, boost::optional<std::string> > &values,
-                                            const std::unordered_map<Member, std::exception_ptr> &exceptions) {
+                    void onComplete(const std::unordered_map<Member, boost::optional<std::string> > &values,
+                                            const std::unordered_map<Member, std::exception_ptr> &exceptions) override {
                         typedef std::unordered_map<Member, boost::optional<std::string> > VALUE_MAP;
                         for (const VALUE_MAP::value_type &entry  : values) {
                             if (!entry.second) {

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -790,11 +790,11 @@ namespace hazelcast {
             public:
                 MySetItemListener(boost::latch &latch1) : latch1(latch1) {}
 
-                void itemAdded(const ItemEvent &itemEvent) {
+                void itemAdded(const ItemEvent &itemEvent) override {
                     latch1.count_down();
                 }
 
-                void itemRemoved(const ItemEvent &item) {}
+                void itemRemoved(const ItemEvent &item) override {}
 
             private:
                 boost::latch &latch1;
@@ -808,7 +808,7 @@ namespace hazelcast {
                     }
                 }
 
-                virtual void TearDown() {
+                void TearDown() override {
                     set->clear();
                 }
 
@@ -1004,7 +1004,7 @@ namespace hazelcast {
                 };
 
             protected:
-                virtual void TearDown() {
+                void TearDown() override {
                     if (topic) {
                         topic->destroy();
                     }

--- a/hazelcast/test/src/executor/tasks/Tasks.h
+++ b/hazelcast/test/src/executor/tasks/Tasks.h
@@ -67,15 +67,15 @@ namespace hazelcast {
                     };
 
                     struct SelectAllMembers : public cluster::memberselector::MemberSelector {
-                        virtual bool select(const Member &member) const;
+                        bool select(const Member &member) const override;
 
-                        virtual void toString(std::ostream &os) const;
+                        void toString(std::ostream &os) const override;
                     };
 
                     struct SelectNoMembers : public cluster::memberselector::MemberSelector {
-                        virtual bool select(const Member &member) const;
+                        bool select(const Member &member) const override;
 
-                        virtual void toString(std::ostream &os) const;
+                        void toString(std::ostream &os) const override;
                     };
 
                     struct SerializedCounterCallable {

--- a/hazelcast/test/src/main.cpp
+++ b/hazelcast/test/src/main.cpp
@@ -37,13 +37,12 @@ namespace hazelcast {
 
 class ServerFactoryEnvironment : public ::testing::Environment {
 public:
-    ServerFactoryEnvironment() {
+    ServerFactoryEnvironment() = default;
+
+    void SetUp() override {
     }
 
-    void SetUp() {
-    }
-
-    void TearDown() {
+    void TearDown() override {
         delete hazelcast::client::test::g_srvFactory;
     }
 };

--- a/hazelcast/test/src/serialization/Serializables.cpp
+++ b/hazelcast/test/src/serialization/Serializables.cpp
@@ -20,7 +20,7 @@
 namespace hazelcast {
     namespace client {
         namespace test {
-            Employee::Employee() {}
+            Employee::Employee() = default;
 
             Employee::Employee(std::string name, int32_t age) : age(age), name(name) {
                 by = 2;

--- a/hazelcast/test/src/serialization/Serializables.h
+++ b/hazelcast/test/src/serialization/Serializables.h
@@ -101,7 +101,7 @@ namespace hazelcast {
             class EmployeeEntryKeyComparator : public EmployeeEntryComparator {
             public:
                 int compare(const std::pair<const int32_t *, const Employee *> *lhs,
-                            const std::pair<const int32_t *, const Employee *> *rhs) const;
+                            const std::pair<const int32_t *, const Employee *> *rhs) const override;
             };
 
             std::ostream &operator<<(std::ostream &out, const Employee &employee);


### PR DESCRIPTION
Ran clang-tidy's checks `modernize-use-override`, `modernize-use-equals-delete` and `modernize-use-equals-default` on all of the code files excluding generated sources and external libraries. Also removed some "//@Override" annotation lines which were probably copy-pasted from the Java client. 

We may also consider to apply other modernization fixes ([listed here](https://clang.llvm.org/extra/clang-tidy/checks/list.html)), and maybe add a clang-tidy configuration for the project.

**Edit**: Here are the script I wrote to apply these fixes and the configuration file used by clang-tidy:

```bash
#!/usr/bin/env bash

SRC_FILES=$(find examples/ hazelcast/ | grep -v generated-sources | grep -v cpp-controller | grep -v soak-test | grep -E "\.cpp$" );

echo "Clang-tidy is going to work on these source files:";
for file in $SRC_FILES
do
    echo "  | $file";
done
echo;

HEADER_FILTER="($(pwd)/hazelcast/include/.*)|($(pwd)/hazelcast/test/.*)|($(pwd)/examples/.*)";

echo "Header filter:";
echo "  | $HEADER_FILTER";
echo;


echo "Effective checks:"
for check in $(clang-tidy --list-checks | tail -n +2)
do
    echo "  | $check"
done
echo;


clang-tidy -p $(pwd)/build-debug --header-filter=$HEADER_FILTER $SRC_FILES -fix
```

.clang-tidy:
```yaml
Checks:          'modernize-use-override,modernize-use-equals-delete,modernize-use-equals-default,-clang-diagnostic-*,-clang-analyzer-*'
```

Also I used -DCMAKE_EXPORT_COMPILE_COMMANDS=1 when running cmake to create a compile-commands.json file under the build path which then read by clang-tidy.