### PR TITLE
Utilize listener flags for EntryListener

### DIFF
--- a/hazelcast/include/hazelcast/client/EntryEvent.h
+++ b/hazelcast/include/hazelcast/client/EntryEvent.h
@@ -48,7 +48,6 @@ namespace hazelcast {
                 MERGED = 1 << 6 ,
                 EXPIRED = 1 << 7,
                 INVALIDATION = 1 << 8,
-                ALL = 0xFF
             };
 
             EntryEvent(const std::string &name, const Member &member, type eventType,

--- a/hazelcast/include/hazelcast/client/EntryListener.h
+++ b/hazelcast/include/hazelcast/client/EntryListener.h
@@ -19,13 +19,14 @@
 #include <functional>
 #include <utility>
 
+#include "hazelcast/client/EntryEvent.h"
 #include "hazelcast/util/null_event_handler.h"
 #include "hazelcast/util/type_traits.h"
 
 namespace hazelcast {
     namespace client {
+        class IMap;
         class MapEvent;
-        class EntryEvent;
         class ReplicatedMap;
         namespace impl {
             template<typename> class EntryEventHandler;
@@ -56,6 +57,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onEntryAdded(Handler &&h) & {
                 entryAdded = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::ADDED);
                 return *this;
             }
 
@@ -78,6 +80,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onEntryRemoved(Handler &&h) & {
                 entryRemoved = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::REMOVED);
                 return *this;
             }
 
@@ -100,6 +103,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onEntryUpdated(Handler &&h) & {
                 entryUpdated = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::UPDATED);
                 return *this;
             }
             
@@ -122,6 +126,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onEntryEvicted(Handler &&h) & {
                 entryEvicted = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::EVICTED);
                 return *this;
             }
 
@@ -144,6 +149,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onEntryExpired(Handler &&h) & {
                 entryExpired = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::EXPIRED);
                 return *this;
             }
 
@@ -166,6 +172,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onEntryMerged(Handler &&h) & {
                 entryMerged = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::MERGED);
                 return *this;
             }
 
@@ -188,6 +195,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onMapEvicted(Handler &&h) & {
                 mapEvicted = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::EVICT_ALL);
                 return *this;
             }
 
@@ -210,6 +218,7 @@ namespace hazelcast {
                      typename = util::enable_if_rvalue_ref_t<Handler &&>>
             EntryListener &onMapCleared(Handler &&h) & {
                 mapCleared = std::forward<Handler>(h);
+                add_flag(EntryEvent::type::CLEAR_ALL);
                 return *this;
             }
 
@@ -238,9 +247,16 @@ namespace hazelcast {
             MapHandlerType mapEvicted = nullMapEventHandler,
                            mapCleared = nullMapEventHandler;
 
+            int32_t flags = 0;
+
+            void add_flag(EntryEvent::type t) {
+                flags |= static_cast<int32_t>(t);
+            }
+
             template<typename>
             friend class impl::EntryEventHandler;
             friend class ReplicatedMap;
+            friend class IMap;
         };
     }
 }

--- a/hazelcast/include/hazelcast/client/IMap.h
+++ b/hazelcast/include/hazelcast/client/IMap.h
@@ -479,7 +479,7 @@ namespace hazelcast {
                                         getName(), getContext().getClientClusterService(),
                                         getContext().getSerializationService(),
                                         std::move(listener),
-                                        includeValue, getContext().getLogger())), includeValue);
+                                        includeValue, getContext().getLogger())), includeValue, listener.flags);
             }
 
             /**
@@ -506,7 +506,7 @@ namespace hazelcast {
                                         getName(), getContext().getClientClusterService(),
                                         getContext().getSerializationService(),
                                         std::move(listener),
-                                        includeValue, getContext().getLogger())), toData<P>(predicate), includeValue);
+                                        includeValue, getContext().getLogger())), toData<P>(predicate), includeValue, listener.flags);
             }
 
             /**
@@ -530,7 +530,7 @@ namespace hazelcast {
                                         getName(), getContext().getClientClusterService(),
                                         getContext().getSerializationService(),
                                         std::move(listener),
-                                        includeValue, getContext().getLogger())), includeValue, toData<K>(key));
+                                        includeValue, getContext().getLogger())), includeValue, toData<K>(key), listener.flags);
             }
 
             /**

--- a/hazelcast/include/hazelcast/client/IMap.h
+++ b/hazelcast/include/hazelcast/client/IMap.h
@@ -473,13 +473,14 @@ namespace hazelcast {
             * @return registrationId of added listener that can be used to remove the entry listener.
             */
             boost::future<std::string> addEntryListener(EntryListener &&listener, bool includeValue) {
+                const auto listener_flags = listener.flags;
                 return proxy::IMapImpl::addEntryListener(
                         std::unique_ptr<impl::BaseEventHandler>(
                                 new impl::EntryEventHandler<protocol::codec::MapAddEntryListenerCodec::AbstractEventHandler>(
                                         getName(), getContext().getClientClusterService(),
                                         getContext().getSerializationService(),
                                         std::move(listener),
-                                        includeValue, getContext().getLogger())), includeValue, listener.flags);
+                                        includeValue, getContext().getLogger())), includeValue, listener_flags);
             }
 
             /**
@@ -500,13 +501,14 @@ namespace hazelcast {
             template<typename P>
             boost::future<std::string>
             addEntryListener(EntryListener &&listener, const P &predicate, bool includeValue) {
+                const auto listener_flags = listener.flags;
                 return proxy::IMapImpl::addEntryListener(
                         std::unique_ptr<impl::BaseEventHandler>(
                                 new impl::EntryEventHandler<protocol::codec::MapAddEntryListenerWithPredicateCodec::AbstractEventHandler>(
                                         getName(), getContext().getClientClusterService(),
                                         getContext().getSerializationService(),
                                         std::move(listener),
-                                        includeValue, getContext().getLogger())), toData<P>(predicate), includeValue, listener.flags);
+                                        includeValue, getContext().getLogger())), toData<P>(predicate), includeValue, listener_flags);
             }
 
             /**
@@ -524,13 +526,14 @@ namespace hazelcast {
             */
             template<typename K>
             boost::future<std::string> addEntryListener(EntryListener &&listener, bool includeValue, const K &key) {
+                const auto listener_flags = listener.flags;
                 return proxy::IMapImpl::addEntryListener(
                         std::unique_ptr<impl::BaseEventHandler>(
                                 new impl::EntryEventHandler<protocol::codec::MapAddEntryListenerToKeyCodec::AbstractEventHandler>(
                                         getName(), getContext().getClientClusterService(),
                                         getContext().getSerializationService(),
                                         std::move(listener),
-                                        includeValue, getContext().getLogger())), includeValue, toData<K>(key), listener.flags);
+                                        includeValue, getContext().getLogger())), includeValue, toData<K>(key), listener_flags);
             }
 
             /**

--- a/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
@@ -158,15 +158,15 @@ namespace hazelcast {
                 boost::future<std::string> addInterceptor(const serialization::pimpl::Data &interceptor);
 
                 boost::future<std::string>
-                addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler, bool includeValue);
+                addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler, bool includeValue, int32_t listener_flags);
 
                 boost::future<std::string>
                 addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler, Data &&predicate,
-                                 bool includeValue);
+                                 bool includeValue, int32_t listener_flags);
 
                 boost::future<std::string>
                 addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler, bool includeValue,
-                                 Data &&key);
+                                 Data &&key, int32_t listener_flags);
 
                 boost::future<std::unique_ptr<map::DataEntryView>> getEntryViewData(const serialization::pimpl::Data &key);
 
@@ -265,7 +265,7 @@ namespace hazelcast {
                 class MapEntryListenerWithPredicateMessageCodec : public spi::impl::ListenerMessageCodec {
                 public:
                     MapEntryListenerWithPredicateMessageCodec(std::string name, bool includeValue,
-                                                              EntryEvent::type listenerFlags,
+                                                              int32_t listenerFlags,
                                                               serialization::pimpl::Data &&predicate);
 
                     std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
@@ -279,13 +279,13 @@ namespace hazelcast {
                 private:
                     std::string name;
                     bool includeValue;
-                    EntryEvent::type listenerFlags;
+                    int32_t listenerFlags;
                     serialization::pimpl::Data predicate;
                 };
 
                 class MapEntryListenerMessageCodec : public spi::impl::ListenerMessageCodec {
                 public:
-                    MapEntryListenerMessageCodec(std::string name, bool includeValue, EntryEvent::type listenerFlags);
+                    MapEntryListenerMessageCodec(std::string name, bool includeValue, int32_t listenerFlags);
 
                     std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
 
@@ -298,12 +298,12 @@ namespace hazelcast {
                 private:
                     std::string name;
                     bool includeValue;
-                    EntryEvent::type listenerFlags;
+                    int32_t listenerFlags;
                 };
 
                 class MapEntryListenerToKeyCodec : public spi::impl::ListenerMessageCodec {
                 public:
-                    MapEntryListenerToKeyCodec(std::string name, bool includeValue, EntryEvent::type listenerFlags,
+                    MapEntryListenerToKeyCodec(std::string name, bool includeValue, int32_t listenerFlags,
                                                serialization::pimpl::Data key);
 
                     std::unique_ptr<protocol::ClientMessage> encodeAddRequest(bool localOnly) const override;
@@ -317,19 +317,19 @@ namespace hazelcast {
                 private:
                     std::string name;
                     bool includeValue;
-                    EntryEvent::type listenerFlags;
+                    int32_t listenerFlags;
                     serialization::pimpl::Data key;
                 };
 
                 std::unique_ptr<spi::impl::ListenerMessageCodec>
-                createMapEntryListenerCodec(bool includeValue, EntryEvent::type listenerFlags);
+                createMapEntryListenerCodec(bool includeValue, int32_t listenerFlags);
 
                 std::unique_ptr<spi::impl::ListenerMessageCodec>
                 createMapEntryListenerCodec(bool includeValue, serialization::pimpl::Data &&predicate,
-                                            EntryEvent::type listenerFlags);
+                                            int32_t listenerFlags);
 
                 std::unique_ptr<spi::impl::ListenerMessageCodec>
-                createMapEntryListenerCodec(bool includeValue, EntryEvent::type listenerFlags,
+                createMapEntryListenerCodec(bool includeValue, int32_t listenerFlags,
                                             serialization::pimpl::Data &&key);
             };
         }

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -1240,18 +1240,14 @@ namespace hazelcast {
             }
 
             // TODO: We can use generic template Listener instead of impl::BaseEventHandler to prevent the virtual function calls
-            boost::future<std::string> IMapImpl::addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler, bool includeValue) {
-                // TODO: Use appropriate flags for the event type as implemented in Java instead of EntryEventType::ALL
-                auto listenerFlags = EntryEvent::type::ALL;
-                return registerListener(createMapEntryListenerCodec(includeValue, listenerFlags), std::move(entryEventHandler));
+            boost::future<std::string> IMapImpl::addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler, bool includeValue, int32_t listener_flags) {
+                return registerListener(createMapEntryListenerCodec(includeValue, listener_flags), std::move(entryEventHandler));
             }
 
             boost::future<std::string>
             IMapImpl::addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler,
-                    Data &&predicate, bool includeValue) {
-                // TODO: Use appropriate flags for the event type as implemented in Java instead of EntryEventType::ALL
-                EntryEvent::type listenerFlags = EntryEvent::type::ALL;
-                return registerListener(createMapEntryListenerCodec(includeValue, std::move(predicate), listenerFlags), std::move(entryEventHandler));
+                    Data &&predicate, bool includeValue, int32_t listener_flags) {
+                return registerListener(createMapEntryListenerCodec(includeValue, std::move(predicate), listener_flags), std::move(entryEventHandler));
             }
 
             boost::future<bool> IMapImpl::removeEntryListener(const std::string &registrationId) {
@@ -1259,10 +1255,8 @@ namespace hazelcast {
             }
 
             boost::future<std::string> IMapImpl::addEntryListener(std::unique_ptr<impl::BaseEventHandler> &&entryEventHandler,
-                                                   bool includeValue, Data &&key) {
-                // TODO: Use appropriate flags for the event type as implemented in Java instead of EntryEventType::ALL
-                EntryEvent::type listenerFlags = EntryEvent::type::ALL;
-                return registerListener(createMapEntryListenerCodec(includeValue, listenerFlags, std::move(key)),
+                                                   bool includeValue, Data &&key, int32_t listener_flags) {
+                return registerListener(createMapEntryListenerCodec(includeValue, listener_flags, std::move(key)),
                                         std::move(entryEventHandler));
             }
 
@@ -1425,19 +1419,19 @@ namespace hazelcast {
 
             std::unique_ptr<spi::impl::ListenerMessageCodec>
             IMapImpl::createMapEntryListenerCodec(bool includeValue, serialization::pimpl::Data &&predicate,
-                                                  EntryEvent::type listenerFlags) {
+                                                  int32_t listenerFlags) {
                 return std::unique_ptr<spi::impl::ListenerMessageCodec>(
                         new MapEntryListenerWithPredicateMessageCodec(getName(), includeValue, listenerFlags, std::move(predicate)));
             }
 
             std::unique_ptr<spi::impl::ListenerMessageCodec>
-            IMapImpl::createMapEntryListenerCodec(bool includeValue, EntryEvent::type listenerFlags) {
+            IMapImpl::createMapEntryListenerCodec(bool includeValue, int32_t listenerFlags) {
                 return std::unique_ptr<spi::impl::ListenerMessageCodec>(
                         new MapEntryListenerMessageCodec(getName(), includeValue, listenerFlags));
             }
 
             std::unique_ptr<spi::impl::ListenerMessageCodec>
-            IMapImpl::createMapEntryListenerCodec(bool includeValue, EntryEvent::type listenerFlags,
+            IMapImpl::createMapEntryListenerCodec(bool includeValue, int32_t listenerFlags,
                                                   serialization::pimpl::Data &&key) {
                 return std::unique_ptr<spi::impl::ListenerMessageCodec>(
                         new MapEntryListenerToKeyCodec(getName(), includeValue, listenerFlags, key));
@@ -1450,7 +1444,7 @@ namespace hazelcast {
 
             IMapImpl::MapEntryListenerMessageCodec::MapEntryListenerMessageCodec(std::string name,
                                                                                  bool includeValue,
-                                                                                 EntryEvent::type listenerFlags) : name(std::move(name)),
+                                                                                 int32_t listenerFlags) : name(std::move(name)),
                                                                                                           includeValue(
                                                                                                                   includeValue),
                                                                                                           listenerFlags(
@@ -1501,12 +1495,12 @@ namespace hazelcast {
             }
 
             IMapImpl::MapEntryListenerToKeyCodec::MapEntryListenerToKeyCodec(std::string name, bool includeValue,
-                                                                             EntryEvent::type listenerFlags,
+                                                                             int32_t listenerFlags,
                                                                              serialization::pimpl::Data key)
                     : name(std::move(name)), includeValue(includeValue), listenerFlags(listenerFlags), key(std::move(key)) {}
 
             IMapImpl::MapEntryListenerWithPredicateMessageCodec::MapEntryListenerWithPredicateMessageCodec(
-                    std::string name, bool includeValue, EntryEvent::type listenerFlags,
+                    std::string name, bool includeValue, int32_t listenerFlags,
                     serialization::pimpl::Data &&predicate) : name(std::move(name)), includeValue(includeValue),
                                                              listenerFlags(listenerFlags), predicate(predicate) {}
 


### PR DESCRIPTION
Now with the new EntryListener API (#604), the user can explicitly express which event types they want to listen to. 
This PR sets the listenerFlags parameter on the codec accordingly and avoids redundant events to be fired.