### PR TITLE
Remove `const_cast`s

### DIFF
--- a/examples/aws/AwsClientWithKey.cpp
+++ b/examples/aws/AwsClientWithKey.cpp
@@ -31,7 +31,7 @@ int main() {
 
     // The default is to use port 5701 if this is not explicitely set. You can enable the below line if your hazelcast
     // server is running on another port.
-    //clientConfig.getProperties()[ hazelcast::client::ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+    //clientConfig.setProperty(hazelcast::client::ClientProperties::PROP_AWS_MEMBER_PORT, "60000");
 
     // The following assumes that you provide the environment parameters AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).

--- a/hazelcast/include/hazelcast/client/ClientConfig.h
+++ b/hazelcast/include/hazelcast/client/ClientConfig.h
@@ -375,7 +375,7 @@ namespace hazelcast {
             *
             * @return properties map
             */
-            std::unordered_map<std::string, std::string> &getProperties();
+            const std::unordered_map<std::string, std::string> &getProperties() const;
 
             /**
             * Sets the value of a named property

--- a/hazelcast/include/hazelcast/client/aws/security/EC2RequestSigner.h
+++ b/hazelcast/include/hazelcast/client/aws/security/EC2RequestSigner.h
@@ -55,9 +55,7 @@ namespace hazelcast {
 
                     std::vector<std::string> getListOfEntries(const std::unordered_map<std::string, std::string> &entries) const;
 
-                    void addComponents(std::vector<std::string> &components,
-                                       const std::unordered_map<std::string, std::string> &attributes,
-                                       const std::string &key) const;
+                    static std::string formatAttribute(const std::string &key, const std::string &value);
 
                     /* Task 2 */
                     std::string createStringToSign(const std::string &canonicalRequest) const;

--- a/hazelcast/include/hazelcast/client/impl/AbstractLoadBalancer.h
+++ b/hazelcast/include/hazelcast/client/impl/AbstractLoadBalancer.h
@@ -57,7 +57,7 @@ namespace hazelcast {
                 ~AbstractLoadBalancer() override;
 
             private:
-                std::mutex membersLock;
+                mutable std::mutex membersLock;
                 std::vector<Member> membersRef;
                 Cluster *cluster;
             };

--- a/hazelcast/include/hazelcast/client/internal/eviction/Expirable.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/Expirable.h
@@ -42,7 +42,7 @@ namespace hazelcast {
                      * @return expiration time.
                      * @see System#currentTimeMillis()
                      */
-                    virtual int64_t getExpirationTime() = 0;
+                    virtual int64_t getExpirationTime() const = 0;
 
                     /**
                      * Sets the expiration time in milliseconds.
@@ -57,7 +57,7 @@ namespace hazelcast {
                      * @param now time in milliseconds.
                      * @return true if expired.
                      */
-                    virtual bool isExpiredAt(int64_t now) = 0;
+                    virtual bool isExpiredAt(int64_t now) const = 0;
                 };
             }
         }

--- a/hazelcast/include/hazelcast/client/internal/eviction/impl/evaluator/DefaultEvictionPolicyEvaluator.h
+++ b/hazelcast/include/hazelcast/client/internal/eviction/impl/evaluator/DefaultEvictionPolicyEvaluator.h
@@ -108,7 +108,7 @@ namespace hazelcast {
                                     const Expirable *expirable = dynamic_cast<const Expirable *>(evictable);
                                     if (expirable != NULL) {
                                         // If there is an expired candidate, let's evict that one immediately
-                                        expired = (const_cast<Expirable *>(expirable))->isExpiredAt(now);
+                                        expired = expirable->isExpiredAt(now);
                                     }
                                 }
                                 return expired;

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/record/AbstractNearCacheRecord.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/record/AbstractNearCacheRecord.h
@@ -75,7 +75,7 @@ namespace hazelcast {
                                 AbstractNearCacheRecord::uuid = uuid;
                             }
 
-                            int64_t getExpirationTime() override {
+                            int64_t getExpirationTime() const override {
                                 return expirationTime;
                             }
 
@@ -99,7 +99,7 @@ namespace hazelcast {
                                 AbstractNearCacheRecord::accessHit = accessHit;
                             }
 
-                            bool isExpiredAt(int64_t now) override {
+                            bool isExpiredAt(int64_t now) const override {
                                 int64_t expiration = expirationTime;
                                 return (expiration > NearCacheRecord<V>::TIME_NOT_SET) && (expiration <= now);
                             }

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -104,9 +104,9 @@ namespace hazelcast {
 
                     void notifyException(std::exception_ptr exception);
 
-                    std::shared_ptr<connection::Connection> getSendConnection();
+                    std::shared_ptr<connection::Connection> getSendConnection() const;
 
-                    std::shared_ptr<connection::Connection> getSendConnectionOrWait();
+                    std::shared_ptr<connection::Connection> getSendConnectionOrWait() const;
 
                     void
                     setSendConnection(const std::shared_ptr<connection::Connection> &sendConnection);

--- a/hazelcast/include/hazelcast/util/Sync.h
+++ b/hazelcast/include/hazelcast/util/Sync.h
@@ -73,11 +73,11 @@ namespace hazelcast {
                 v = i;
             }
 
-            operator T() {
+            operator T() const {
                 return get();
             }
 
-            T get() {
+            T get() const {
                 std::lock_guard<std::mutex> lockGuard(mutex);
                 return v;
             }
@@ -87,17 +87,17 @@ namespace hazelcast {
                 return --v;
             }
 
-            bool operator<=(const T &i) {
+            bool operator<=(const T &i) const {
                 std::lock_guard<std::mutex> lockGuard(mutex);
                 return v <= i;
             }
 
-            bool operator==(const T &i) {
+            bool operator==(const T &i) const {
                 std::lock_guard<std::mutex> lockGuard(mutex);
                 return i == v;
             }
 
-            bool operator!=(const T &i) {
+            bool operator!=(const T &i) const {
                 std::lock_guard<std::mutex> lockGuard(mutex);
                 return i != v;
             }
@@ -112,8 +112,7 @@ namespace hazelcast {
             }
 
         protected:
-
-            std::mutex mutex;
+            mutable std::mutex mutex;
             T v;
         };
     }

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -129,7 +129,7 @@ namespace hazelcast {
             std::atomic<int32_t> HazelcastClientInstanceImpl::CLIENT_ID(0);
 
             HazelcastClientInstanceImpl::HazelcastClientInstanceImpl(const ClientConfig &config)
-                    : clientConfig(config), clientProperties(const_cast<ClientConfig &>(config).getProperties()),
+                    : clientConfig(config), clientProperties(config.getProperties()),
                       clientContext(*this),
                       serializationService(clientConfig.getSerializationConfig()), clusterService(clientContext),
                       transactionManager(clientContext, *clientConfig.getLoadBalancer()), cluster(clusterService),

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -322,11 +322,11 @@ namespace hazelcast {
                 return members[++index % members.size()];
             }
 
-            RoundRobinLB::RoundRobinLB(const RoundRobinLB &rhs) : index(const_cast<RoundRobinLB &>(rhs).index.load()) {
+            RoundRobinLB::RoundRobinLB(const RoundRobinLB &rhs) : index(rhs.index.load()) {
             }
 
             void RoundRobinLB::operator=(const RoundRobinLB &rhs) {
-                index.store(const_cast<RoundRobinLB &>(rhs).index.load());
+                index.store(rhs.index.load());
             }
 
             MemberAttributeChange::MemberAttributeChange() = default;
@@ -362,7 +362,7 @@ namespace hazelcast {
             }
 
             void AbstractLoadBalancer::operator=(const AbstractLoadBalancer &rhs) {
-                std::lock_guard<std::mutex> lg(const_cast<std::mutex &>(rhs.membersLock));
+                std::lock_guard<std::mutex> lg(rhs.membersLock);
                 std::lock_guard<std::mutex> lg2(membersLock);
                 membersRef = rhs.membersRef;
                 cluster = rhs.cluster;

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -720,7 +720,7 @@ namespace hazelcast {
         }
 
 
-        std::unordered_map<std::string, std::string> &ClientConfig::getProperties() {
+        const std::unordered_map<std::string, std::string> &ClientConfig::getProperties() const {
             return properties;
         }
 

--- a/hazelcast/src/hazelcast/client/discovery.cpp
+++ b/hazelcast/src/hazelcast/client/discovery.cpp
@@ -126,20 +126,17 @@ namespace hazelcast {
                 std::vector<std::string> EC2RequestSigner::getListOfEntries(
                         const std::unordered_map<std::string, std::string> &entries) const {
                     std::vector<std::string> components;
-                    for (std::unordered_map<std::string, std::string>::const_iterator it = entries.begin();
-                         it != entries.end(); ++it) {
-                        addComponents(components, entries, it->first);
+                    for (const auto &entry: entries) {
+                        components.push_back(formatAttribute(entry.first, entry.second));
                     }
                     return components;
                 }
 
-                void EC2RequestSigner::addComponents(std::vector<std::string> &components,
-                                                     const std::unordered_map<std::string, std::string> &attributes,
-                                                     const std::string &key) const {
+                std::string EC2RequestSigner::formatAttribute(const std::string &key, const std::string &value) {
                     std::ostringstream out;
-                    out << utility::AwsURLEncoder::urlEncode(key) << '=' << utility::AwsURLEncoder::urlEncode(
-                            (const_cast<std::unordered_map<std::string, std::string> &>(attributes))[key]);
-                    components.push_back(out.str());
+                    out << utility::AwsURLEncoder::urlEncode(key) << '=' 
+                        << utility::AwsURLEncoder::urlEncode(value);
+                    return out.str();
                 }
 
                 /* Task 2 */

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -1100,9 +1100,8 @@ namespace hazelcast {
             }
 
             std::ostream &operator<<(std::ostream &os, const Connection &connection) {
-                Connection &conn = const_cast<Connection &>(connection);
                 os << "ClientConnection{"
-                   << "alive=" << conn.isAlive()
+                   << "alive=" << connection.isAlive()
                    << ", connectionId=" << connection.getConnectionId()
                    << ", remoteEndpoint=";
                 if (connection.getRemoteEndpoint().get()) {
@@ -1110,9 +1109,9 @@ namespace hazelcast {
                 } else {
                     os << "null";
                 }
-                os << ", lastReadTime=" << util::StringUtil::timeToString(conn.lastReadTime())
-                   << ", closedTime=" << util::StringUtil::timeToString(std::chrono::steady_clock::time_point(conn.closedTimeDuration))
-                   << ", connected server version=" << conn.connectedServerVersionString
+                os << ", lastReadTime=" << util::StringUtil::timeToString(connection.lastReadTime())
+                   << ", closedTime=" << util::StringUtil::timeToString(std::chrono::steady_clock::time_point(connection.closedTimeDuration))
+                   << ", connected server version=" << connection.connectedServerVersionString
                    << '}';
 
                 return os;

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -1406,7 +1406,7 @@ namespace hazelcast {
                     std::vector<CipherInfo> supportedCiphers;
                     for (int i = 0; i < sk_SSL_CIPHER_num(ciphers); ++i) {
                         struct SSLSocket::CipherInfo info;
-                        SSL_CIPHER *cipher = const_cast<SSL_CIPHER *>(sk_SSL_CIPHER_value(ciphers, i));
+                        const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
                         info.name = SSL_CIPHER_get_name(cipher);
                         info.numberOfBits = SSL_CIPHER_get_bits(cipher, 0);
                         info.version = SSL_CIPHER_get_version(cipher);

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1406,11 +1406,10 @@ namespace hazelcast {
                     } else {
                         target << "random";
                     }
-                    ClientInvocation &nonConstInvocation = const_cast<ClientInvocation &>(invocation);
-                    os << "ClientInvocation{" << "requestMessage = " << *nonConstInvocation.clientMessage.get()
+                    os << "ClientInvocation{" << "requestMessage = " << *invocation.clientMessage.get()
                        << ", objectName = "
                        << invocation.objectName << ", target = " << target.str() << ", sendConnection = ";
-                    std::shared_ptr<connection::Connection> sendConnection = nonConstInvocation.getSendConnection();
+                    std::shared_ptr<connection::Connection> sendConnection = invocation.getSendConnection();
                     if (sendConnection.get()) {
                         os << *sendConnection;
                     } else {
@@ -1448,11 +1447,11 @@ namespace hazelcast {
                                                  nullptr, std::make_shared<Address>(address)));
                 }
 
-                std::shared_ptr<connection::Connection> ClientInvocation::getSendConnection() {
+                std::shared_ptr<connection::Connection> ClientInvocation::getSendConnection() const {
                     return sendConnection;
                 }
 
-                std::shared_ptr<connection::Connection> ClientInvocation::getSendConnectionOrWait() {
+                std::shared_ptr<connection::Connection> ClientInvocation::getSendConnectionOrWait() const {
                     while (sendConnection.get().get() == NULL && lifecycleService.isRunning()) {
                         std::this_thread::yield();
                     }

--- a/hazelcast/src/hazelcast/client/transactions.cpp
+++ b/hazelcast/src/hazelcast/client/transactions.cpp
@@ -64,9 +64,7 @@ namespace hazelcast {
                                                                               threadId(rhs.threadId), txnId(rhs.txnId),
                                                                               state(rhs.state),
                                                                               startTime(rhs.startTime) {
-                TransactionProxy &nonConstRhs = const_cast<TransactionProxy &>(rhs);
-
-                TRANSACTION_EXISTS.store(nonConstRhs.TRANSACTION_EXISTS.load());
+                TRANSACTION_EXISTS.store(rhs.TRANSACTION_EXISTS.load());
             }
 
             const std::string &TransactionProxy::getTxnId() const {

--- a/hazelcast/test/src/HazelcastTests5.cpp
+++ b/hazelcast/test/src/HazelcastTests5.cpp
@@ -736,7 +736,7 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     ClientConfig clientConfig(getConfig());
-                    clientConfig.getProperties()[ClientProperties::PROP_HEARTBEAT_TIMEOUT] = "20";
+                    clientConfig.setProperty(ClientProperties::PROP_HEARTBEAT_TIMEOUT, "20");
                     client = new HazelcastClient(clientConfig);
                     imap = client->getMap("IntMap");
                 }
@@ -838,7 +838,7 @@ namespace hazelcast {
                 static void SetUpTestSuite() {
                     instance = new HazelcastServer(*g_srvFactory);
                     ClientConfig clientConfig(getConfig());
-                    clientConfig.getProperties()[ClientProperties::PROP_HEARTBEAT_TIMEOUT] = "20";
+                    clientConfig.setProperty(ClientProperties::PROP_HEARTBEAT_TIMEOUT, "20");
                     client = new HazelcastClient(clientConfig);
                     map = client->getMap("map");
                 }

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1703,12 +1703,12 @@ namespace hazelcast {
                 TEST_F (AwsConfigTest, testInvalidAwsMemberPortConfig) {
                     ClientConfig clientConfig;
 
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "65536";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "65536");
                     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
                             setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(getenv("AWS_SECRET_ACCESS_KEY")).
                             setTagKey("aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
 
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "-1";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "-1");
 
                     ASSERT_THROW(HazelcastClient hazelcastClient(clientConfig),
                                  exception::InvalidConfigurationException);
@@ -1733,7 +1733,7 @@ namespace hazelcast {
                 TEST_F (AwsClientTest, testClientAwsMemberNonDefaultPortConfig) {
                     ClientConfig clientConfig;
 
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "60000");
                     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
                             setAccessKey(std::getenv("AWS_ACCESS_KEY_ID")).setSecretKey(std::getenv("AWS_SECRET_ACCESS_KEY")).
                             setTagKey("aws-test-tag").setTagValue("aws-tag-value-1");
@@ -1753,7 +1753,7 @@ namespace hazelcast {
 
                 TEST_F (AwsClientTest, testClientAwsMemberWithSecurityGroupDefaultIamRole) {
                     ClientConfig clientConfig;
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "60000");
                     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
                             setSecurityGroupName("launch-wizard-147");
 
@@ -1778,7 +1778,7 @@ namespace hazelcast {
                                                                                                                                         TEST_F (AwsClientTest, testFipsEnabledAwsDiscovery) {
                     ClientConfig clientConfig;
 
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "60000");
                     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).
                             setAccessKey(getenv("AWS_ACCESS_KEY_ID")).setSecretKey(getenv("AWS_SECRET_ACCESS_KEY")).
                             setTagKey("aws-test-tag").setTagValue("aws-tag-value-1");
@@ -1808,7 +1808,7 @@ namespace hazelcast {
                                                                                                                                         TEST_F (AwsClientTest, testRetrieveCredentialsFromIamRoleAndConnect) {
                     ClientConfig clientConfig;
 
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "60000");
                     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).setIamRole("cloudbees-role").setTagKey(
                             "aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
 
@@ -1818,7 +1818,7 @@ namespace hazelcast {
                 TEST_F (AwsClientTest, testRetrieveCredentialsFromInstanceProfileDefaultIamRoleAndConnect) {
                     ClientConfig clientConfig;
 
-                    clientConfig.getProperties()[ClientProperties::PROP_AWS_MEMBER_PORT] = "60000";
+                    clientConfig.setProperty(ClientProperties::PROP_AWS_MEMBER_PORT, "60000");
                     clientConfig.getNetworkConfig().getAwsConfig().setEnabled(true).setTagKey(
                             "aws-test-tag").setTagValue("aws-tag-value-1").setInsideAws(true);
 


### PR DESCRIPTION
There are `const_cast`s used in the codebase merely because either a member function wasn't properly const-qualified or a mutex wasn't declared as mutable. And there are some cases where the const_cast is unnecessary (I assume those were necessary for the old hand-crafted atomic variables). 
This PR removes all `const_cast`s excluding those that are in the tests (we still have `const_casts`s in the tests), and adds const qualifier to member functions where necessary. There is one breaking change in the public API:

old:
```c++
std::unordered_map<std::string, std::string> &ClientConfig::getProperties();
```
new:
```c++
const std::unordered_map<std::string, std::string> &ClientConfig::getProperties() const;
```

We still have ClientConfig::setProperty for write access. 
