### PR TITLE
Fix basic_latch_test.test_try_set_count_when_count_is_not_zero

### DIFF
--- a/hazelcast/test/src/cp_test.cpp
+++ b/hazelcast/test/src/cp_test.cpp
@@ -333,7 +333,7 @@ namespace hazelcast {
                     ASSERT_TRUE(latch_->try_set_count(10).get());
 
                     ASSERT_FALSE(latch_->try_set_count(20).get());
-                    ASSERT_FALSE(latch_->try_set_count(0).get());
+                    ASSERT_FALSE(latch_->try_set_count(1).get());
                     ASSERT_EQ(10, latch_->get_count().get());
                 }
 


### PR DESCRIPTION
Makes the test same with https://github.com/hazelcast/hazelcast/blob/cb6f5b3a36021bccb3ff7cd0c6397c938a0664e5/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/AbstractCountDownLatchBasicTest.java#L77-L83

The test was changed in: https://github.com/hazelcast/hazelcast/pull/17528