### PR TITLE
Test fixes for issue #624 and #645

### DIFF
--- a/hazelcast/test/src/HazelcastTests5.cpp
+++ b/hazelcast/test/src/HazelcastTests5.cpp
@@ -1157,9 +1157,6 @@ namespace hazelcast {
 
                     f();
 
-                    // populate near cache
-                    map->get<std::string, std::string>("key1").get();
-
                     // if near cache is enabled
                     if (nearCacheStatsImpl) {
                         ASSERT_TRUE_EVENTUALLY(

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -566,7 +566,7 @@ namespace hazelcast {
                 }
                 
                 void TearDown() override {
-                    q->clear();
+                    q->clear().get();
                 }
                 
                 static void SetUpTestCase() {


### PR DESCRIPTION
Test fixes:

Sync wait clear at the test `TearDown`:

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/624

No need for the get call to populate near cache for `invalidationRequest` count. If the get is there, there is a chance that the invalidation may come before get response is being processed, hence the number of invalidation requests may be 3 (early expiry event will cause `tryUnmark` to fail at `resetToUnmarkedState` which will increment the invalidation request count, this means while the get is waiting the response the entry was invalidated by expiry.) instead of 2.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/645