### PR TITLE
Test fix - wait remote invalidation request - ClientNearCacheTest_BasicClientNearCacheTest/whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnNearCacheAdapter

### DIFF
--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -488,8 +488,11 @@ namespace hazelcast {
                 nearCachedMap->put<int, std::string>(1, "newValue").get();
 
                 // wait for the invalidation to be processed
-                WAIT_EQ_EVENTUALLY(size - 1, nearCache->size());
+                ASSERT_EQ(size - 1, nearCache->size());
                 ASSERT_EQ(1, stats->getInvalidations());
+                auto stats_impl = std::static_pointer_cast<monitor::impl::NearCacheStatsImpl>(stats);
+                // one from local and one from remote
+                ASSERT_EQ_EVENTUALLY(2, stats_impl->getInvalidationRequests());
 
                 int64_t expectedMisses = getExpectedMissesWithLocalUpdatePolicy();
                 int64_t expectedHits = getExpectedHitsWithLocalUpdatePolicy();


### PR DESCRIPTION
The issue can be reproduced in these steps:
1. Build with -DHZ_COMPILE_WITH_SSL=OFF
2. Fresh start remote controller (since JVM will be called, the remote invalidation event is delivered a little late)
3. Run the test `--gtest_filter=BasicClientNearCacheTest.whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnNearCacheAdapter:BasicClientNearCacheTest/*`

Explanation: The local invalidation is completed but remote did not come. Then a get retrieves the new value and it is a miss. The next get request is expected to be a hit but if the event comes before the get is executed, the value is invalidated due to remote event and the get will another miss. hence, the test fails. We need wait until the remote event is processed before getting the new value.

Fix to test ClientNearCacheTest_BasicClientNearCacheTest/whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnNearCacheAdapter: Wait for invalidation request from remote before trying near cache gets for the new value.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/642

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/623