### PR TITLE
Windows release build failure (due to the linux only posix `sigaction` api usage) fix 

### DIFF
--- a/examples/soak-test/soak_test.cpp
+++ b/examples/soak-test/soak_test.cpp
@@ -42,13 +42,7 @@ void signalHandler(int s) {
 }
 
 void register_signal_handler() {
-    struct sigaction sigIntHandler;
-
-    sigIntHandler.sa_handler = signalHandler;
-    sigemptyset(&sigIntHandler.sa_mask);
-    sigIntHandler.sa_flags = 0;
-
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    signal(SIGINT, signalHandler);
 }
 
 int main(int argc, char *args[]) {


### PR DESCRIPTION
Make soak-test signal handling portable to windows. `sigaction` is linux API only, but signal works both at linux and windows. Replaced it with simple `signal` api which also exists at linux.

This caused the windows release build to fail.