### PR TITLE
`ClientConfig::set_instance_name` API should work with simple std::string

### DIFF
--- a/examples/soak-test/soak_test.cpp
+++ b/examples/soak-test/soak_test.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *args[]) {
     client_config config;
 
     if (argc > 3) {
-        config.set_instance_name(std::make_shared<std::string>(args[3]));
+        config.set_instance_name(args[3]);
     }
 
     config.get_network_config().add_address(address(server_address, 5701));

--- a/hazelcast/include/hazelcast/client/client_config.h
+++ b/hazelcast/include/hazelcast/client/client_config.h
@@ -315,9 +315,9 @@ namespace hazelcast {
              */
             client_config &set_network_config(const config::client_network_config &network_config);
 
-            const std::shared_ptr<std::string> &get_instance_name() const;
+            const boost::optional<std::string> &get_instance_name() const;
 
-            void set_instance_name(const std::shared_ptr<std::string> &instance_name);
+            client_config &set_instance_name(const std::string &instance_name);
 
             /**
              * Pool size for internal ExecutorService which handles responses etc.
@@ -449,7 +449,7 @@ namespace hazelcast {
 
             std::unordered_map<std::string, config::near_cache_config> near_cache_config_map_;
 
-            std::shared_ptr<std::string> instance_name_;
+            boost::optional<std::string> instance_name_;
 
             /**
              * pool-size for internal ExecutorService which handles responses etc.

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -139,8 +139,8 @@ namespace hazelcast {
                       id_(++CLIENT_ID), random_generator_(std::random_device{}()),
                       uuid_generator_{random_generator_},
                       cp_subsystem_(client_context_), proxy_session_manager_(client_context_) {
-                const std::shared_ptr<std::string> &name = client_config_.get_instance_name();
-                if (name.get() != NULL) {
+                auto &name = client_config_.get_instance_name();
+                if (name) {
                     instance_name_ = *name;
                 } else {
                     std::ostringstream out;

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -797,12 +797,13 @@ namespace hazelcast {
             return *this;
         }
 
-        const std::shared_ptr<std::string> &client_config::get_instance_name() const {
+        const boost::optional<std::string> &client_config::get_instance_name() const {
             return instance_name_;
         }
 
-        void client_config::set_instance_name(const std::shared_ptr<std::string> &instance_name) {
+        client_config &client_config::set_instance_name(const std::string &instance_name) {
             client_config::instance_name_ = instance_name;
+            return *this;
         }
 
         int32_t client_config::get_executor_pool_size() const {

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -552,6 +552,14 @@ namespace hazelcast {
 
                 ASSERT_EQ(logger::level::fine, logger_config.level());
             }
+
+            TEST_F(ClientConfigTest, test_set_instance_name) {
+                HazelcastServer instance(*g_srvFactory);
+                auto test_name = get_test_name();
+                hazelcast_client client(std::move(client_config().set_instance_name(test_name)));
+                ASSERT_EQ(test_name, client.get_name());
+            }
+
         }
     }
 }

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1617,6 +1617,7 @@ namespace hazelcast {
                     }
                 };
             };
+
             TEST_F(ClientMessageTest, testOperationNameGetSet) {
                 protocol::ClientMessage message(8);
                 constexpr const char* operation_name = "OPERATION_NAME";


### PR DESCRIPTION
Change the `ClientConfig::get_instance_name` and `ClientConfig::set_instance_name` to work with simple string. No need to use shared pointer in this API.