### PR TITLE
Update README doc to update the API changes introduced in 4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,12 @@
         * [7.3.4.1. Configuring Client Reconnect Strategy](#7341-configuring-client-reconnect-strategy)
   * [7.4. Using Distributed Data Structures](#74-using-distributed-data-structures)
     * [7.4.1. Using Map](#741-using-map)
-        * [7.4.1.1. Using IMap Non-Blocking Async Methods](#7411-using-imap-non-blocking-async-methods)
-    * [7.4.2. Using MultiMap](#742-using-multimap)
+    * [7.4.2. Using multi_map](#742-using-multimap)
     * [7.4.3. Using Replicated Map](#743-using-replicated-map)
     * [7.4.4. Using Queue](#744-using-queue)
     * [7.4.5. Using Set](#745-using-set)
     * [7.4.6. Using List](#746-using-list)
     * [7.4.7. Using Ringbuffer](#747-using-ringbuffer)
-        * [7.4.7.1. Using Ringbuffer Non-Blocking Async Methods](#7471-using-ringbuffer-non-blocking-async-methods)
     * [7.4.8. Using Reliable Topic](#748-using-reliable-topic) 
     * [7.4.9. Using PN Counter](#7412-using-pn-counter)
     * [7.4.10. Using Flake ID Generator](#7413-using-flake-id-generator)
@@ -100,10 +98,10 @@
         * [7.6.1.6 Callback When Task Completes](#7616-callback-when-task-completes)
             * [7.6.1.6.1 Example Task to Callback](#76161-example-task-to-callback)
         * [7.6.1.7 Selecting Members for Task Execution](#7617-selecting-members-for-task-execution)
-    * [7.6.2. Using EntryProcessor](#762-using-entryprocessor)
+    * [7.6.2. Using entry_processor](#762-using-entryprocessor)
   * [7.7. Distributed Query](#77-distributed-query)
     * [7.7.1. How Distributed Query Works](#771-how-distributed-query-works)
-      * [7.7.1.1. Employee Map Query Example](#7711-employee-map-query-example)
+      * [7.7.1.1. employee Map Query Example](#7711-employee-map-query-example)
       * [7.7.1.2. Querying by Combining Predicates with AND, OR, NOT](#7712-querying-by-combining-predicates-with-and-or-not)
       * [7.7.1.3. Querying with SQL](#7713-querying-with-sql)
       * [7.7.1.4. Querying with JSON Strings](#7714-querying-with-json-strings)
@@ -120,17 +118,12 @@
   * [7.9. Monitoring and Logging](#79-monitoring-and-logging)
       * [7.9.1. Enabling Client Statistics](#791-enabling-client-statistics)
       * [7.9.2. Logging Configuration](#792-logging-configuration)
-  * [7.10 Raw Pointer API](#710-raw-pointer-api)
-  * [7.11 Mixed Object Types Supporting Hazelcast Client](#711-mixed-object-types-supporting-hazelcastclient)
-    * [7.11.1 TypedData API](#7111-typeddata-api) 
+  * [7.10 Mixed Object Types Supporting Hazelcast Client](#710-mixed-object-types-supporting-hazelcastclient)
+    * [7.10.1 typed_data API](#7101-typeddata-api) 
 * [8. Development and Testing](#8-development-and-testing)
-  * [8.1. Building and Using Client From Sources](#81-building-and-using-client-from-sources)
-      * [8.1.1 Mac](#811-mac)
-      * [8.1.2 Linux](#812-linux)
-      * [8.1.3 Windows](#813-windows)
-  * [8.2. Testing](#82-testing)
-    * [8.2.1 Tested Platforms](#821-tested-platforms)
-  * [8.3. Reproducing Released Libraries](#83-reproducing-released-libraries)
+  * [8.1. Testing](#81-testing)
+    * [8.1.1 Tested Platforms](#811-tested-platforms)
+  * [8.2. Reproducing Released Libraries](#82-reproducing-released-libraries)
 * [9. Getting Help](#9-getting-help)
 * [10. Contributing](#10-contributing)
 * [11. License](#11-license)
@@ -162,10 +155,11 @@ This chapter provides information on how to get started with your Hazelcast C++ 
 ## 1.1. Requirements
 
 - Windows, Linux or MacOS
-- Java 8 or newer
-- Hazelcast IMDG 4.0 or newer
+- Java 8 or newer (for server side)
+- Hazelcast IMDG 4.0 or newer (for server side)
 - Latest Hazelcast C++ Client
-- Latest [Boost](https://www.boost.org/) Library 
+- Latest [Boost](https://www.boost.org/) Library (C++ client dependency)
+- Feature complete C++11 compiler (feature completenes for compiler C++11 and standard library C++11 is required. The minimum complete compiler for gcc is gcc 5.0)
 
 ## 1.2. Working with Hazelcast IMDG Clusters
 
@@ -256,11 +250,11 @@ Unzip the file. Following is the directory structure for Linux 64-bit zip. The s
 For compilation, you need to include the `hazelcast/include` directory in your distribution. You also need to link your application to the appropriate static or shared Hazelcast library. e.g. cmake lines needed to include and link to Hazelcast 64-bit library:
 ```Cmake
 	include_directories(hazelcast/include)
-    link_directories(hazelcast/Linux_64/lib)
+    link_directories(hazelcast/lib)
 	link_libraries(HazelcastClient4.0_64)
 ``` 
  
-If you want to use the TLS feature, use the `lib` directory with TLS support enabled, e.g., `hazelcast/Linux_64/lib/tls`. If you are using TLS, then you also need to link to OpenSSL and link to the OpenSSL libraries. E.g. if you are using cmake, we do the following:
+If you want to use the TLS feature, use the `lib` directory with TLS support enabled, e.g., `hazelcast/lib/tls`. If you are using TLS, then you also need to link to OpenSSL and link to the OpenSSL libraries. E.g. if you are using cmake, we do the following:
 ```Cmake
     include(FindOpenSSL)
 	find_package(OpenSSL REQUIRED)
@@ -295,11 +289,11 @@ For Linux, there are 32- and 64-bit distributions.
 
 Here is an example script to build with the static library with boost dependencies (assume that ${Boost_INCLUDE_DIR} is the boost include folder path and ${Boost_LIBRARY_DIR} is the path of the folder with the boost libraries):
 
-`g++ main.cpp -o my_app -Ihazelcast/include -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lboost_thread -lboost_chrono hazelcast/Linux_64/lib/libHazelcast4.0_64.a`
+`g++ main.cpp -o my_app -Ihazelcast/include -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lboost_thread -lboost_chrono hazelcast/lib/libHazelcast4.0_64.a`
 
 Here is an example script to build with the shared library:
 
-`c++ main.cpp -o my_app -Ihazelcast/include -Lhazelcast/Linux_64/lib -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lHazelcast4.0_64 -lboost_thread -lboost_chrono`
+`c++ main.cpp -o my_app -Ihazelcast/include -Lhazelcast/lib -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lHazelcast4.0_64 -lboost_thread -lboost_chrono`
 
 #### 1.3.1.3 Windows Client
 
@@ -445,7 +439,7 @@ pass this object to the client when starting it, as shown below.
     hazelcast::client::client_config config;
     config.set_cluster_name("my-cluster"); // the server is configured to use the `my_cluster` as the cluster name hence we need to match it to be able to connect to the server.
     config.get_network_config().add_address(address("192.168.1.10", 5701));    
-    hazelcast::client::hazelcast_client hz(std::move(config)); // Connects to the cluster member at ip address `192.168.1.10` and port 5701
+    hazelcast::client::hazelcast_client hz(std::move(std::move(config))); // Connects to the cluster member at ip address `192.168.1.10` and port 5701
 ```
 
 If you run the Hazelcast IMDG members in a different server than the client, you most probably have configured the members' ports and cluster
@@ -453,7 +447,7 @@ names as explained in the previous section. If you did, then you need to make ce
 
 ### 1.4.2.1 Cluster Name
 
-You need to provide the name of the cluster only if it is explicitly configured on the server-side (otherwise the default value of `dev` is used).
+You only need to provide the name of the cluster if it is explicitely configured at the server side (otherwise the default value of `dev` is used).
 
 ```C++
     hazelcast::client::client_config config;
@@ -475,7 +469,7 @@ The value of this property will be:
 
 * the programmatically configured value, if programmatically set,
 * the environment variable value, if the environment variable is set,
-* the default value, if none of the above is set.
+* the default value, if none of the above is set->
 
 See the following for an example client system property configuration:
 
@@ -540,7 +534,7 @@ Let's manipulate a distributed map on a cluster using the client.
 Save the following file as `IT.cpp` and compile it using a command similar to the following (Linux g++ compilation is used for demonstration):
 
 ```C++
-`g++ IT.cpp -o IT  -Ihazelcast/include -Lhazelcast/Linux_64/lib -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lHazelcast4.0_64 -lboost_thread -lboost_chrono`
+`g++ IT.cpp -o IT  -Ihazelcast/include -Lhazelcast/lib -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lHazelcast4.0_64 -lboost_thread -lboost_chrono`
 ```
 Then, you can run the application using the following command:
  
@@ -555,12 +549,12 @@ Then, you can run the application using the following command:
 int main() {
     hazelcast::client::hazelcast_client hz; // Connects to the cluster
 
-    auto personnel = hz.get_map("personnelMap");
-    personnel->put<std::string, std::string>("Alice", "IT");
-    personnel->put<std::string, std::string>("Bob", "IT");
-    personnel->put<std::string, std::string>("Clark", "IT");
+    auto personnel = hz.get_map("personnel_map");
+    personnel->put<std::string, std::string>("Alice", "IT").get();
+    personnel->put<std::string, std::string>("Bob", "IT").get();
+    personnel->put<std::string, std::string>("Clark", "IT").get();
     std::cout << "Added IT personnel. Logging all known personnel" << std::endl;
-    for (const auto &entry : personnel.entry_set()) {
+    for (const auto &entry : personnel.entry_set().get()) {
         std::cout << entry.first << " is in " << entry.second << " department." << std::endl;
     }
     
@@ -588,14 +582,15 @@ Clark is in IT department
 Bob is in IT department
 ```
 
-You see this example puts all the IT personnel into a cluster-wide `personnelMap` and then prints all the known personnel.
+You see this example puts all the IT personnel into a cluster-wide `personnel_map` and then prints all the known personnel.
 
 Now create a `Sales.cpp` file, compile and run it as shown below.
 
 **Compile:**
 
 ```C++
-g++ Sales.cpp -o Sales -lpthread -Ihazelcast/Linux_64/hazelcast/external/include -Ihazelcast/Linux_64/hazelcast/include -Lhazelcast/Linux_64/lib -lHazelcast4.0_64
+`g++ Sales.cpp -o Sales -Ihazelcast/include -Lhazelcast/lib -I${Boost_INCLUDE_DIR} -L${Boost_LIBRARY_DIR} -lHazelcast4.0_64 -lboost_thread -lboost_chrono`
+
 ```
 **Run**
 
@@ -610,18 +605,16 @@ Then, you can run the application using the following command:
 ```C++
 #include <hazelcast/client/hazelcast_client.h>
 int main() {
-    hazelcast::client::client_config config;
-    hazelcast::client::hazelcast_client hz(config); // Connects to the cluster
+    hazelcast::client::hazelcast_client hz; // Connects to the cluster
 
-    auto personnel = hz.get_map("personnelMap");
-    personnel->put<std::string, std::string>("Denise", "Sales");
-    personnel->put<std::string, std::string>("Erwing", "Sales");
-    personnel->put<std::string, std::string>("Fatih", "Sales");
-    personnel->put<std::string, std::string>("Bob", "IT");
-    personnel->put<std::string, std::string>("Clark", "IT");
-    std::cout << "Added Sales personnel. Logging all known personnel" << std::endl;
-    auto entries = personnel.entry_set();
-    for (const auto &entry : entries) {
+    auto personnel = hz.get_map("personnel_map");
+    personnel->put<std::string, std::string>("Denise", "Sales").get();
+    personnel->put<std::string, std::string>("Erwing", "Sales").get();
+    personnel->put<std::string, std::string>("Fatih", "Sales").get();
+    personnel->put<std::string, std::string>("Bob", "IT").get();
+    personnel->put<std::string, std::string>("Clark", "IT").get();
+    std::cout << "Added all sales personnel. Logging all known personnel" << std::endl;
+    for (const auto &entry : personnel.entry_set().get()) {
         std::cout << entry.first << " is in " << entry.second << " department." << std::endl;
     }
 
@@ -632,7 +625,17 @@ int main() {
 **Output**
 
 ```
-24/10/2018 13:54:06.600 INFO: [0x700006a44000] hz.client_1[dev] [3.10.2-SNAPSHOT] lifecycle_service::lifecycle_event CLIENT_CONNECTED
+18/11/2020 21:22:26.835 INFO: [139868602337152] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/spi.cpp:375] (Wed Nov 18 17:25:23 2020 +0300:3b11bea) LifecycleService::LifecycleEvent Client (75121987-12fe-4ede-860d-59222e6d3ef2) is STARTING
+18/11/2020 21:22:26.835 INFO: [139868602337152] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/spi.cpp:379] (Wed Nov 18 17:25:23 2020 +0300:3b11bea) LifecycleService::LifecycleEvent STARTING
+18/11/2020 21:22:26.835 INFO: [139868602337152] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/spi.cpp:387] LifecycleService::LifecycleEvent STARTED
+18/11/2020 21:22:26.837 INFO: [139868602337152] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/network.cpp:587] Trying to connect to Address[10.212.1.117:5701]
+18/11/2020 21:22:26.840 INFO: [139868602337152] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/spi.cpp:411] LifecycleService::LifecycleEvent CLIENT_CONNECTED
+18/11/2020 21:22:26.840 INFO: [139868602337152] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/network.cpp:637] Authenticated with server  Address[:5701]:a27f900e-b1eb-48be-aa46-d7a4922ef704, server version: 4.1, local address: Address[10.212.1.116:37946]
+18/11/2020 21:22:26.841 INFO: [139868341360384] client_1[dev] [4.0-SNAPSHOT] [/home/ihsan/hazelcast-cpp-client/hazelcast/src/hazelcast/client/spi.cpp:881]
+
+Members [1]  {
+        Member[10.212.1.117]:5701 - a27f900e-b1eb-48be-aa46-d7a4922ef704
+}
 Added Sales personnel. Logging all known personnel
 Denise is in Sales department
 Erwing is in Sales department
@@ -643,13 +646,11 @@ Bob is in IT department
 ```
 
 You will see this time we add only the sales employees but we get the list all known employees including the ones in IT.
-That is because our map lives in the cluster and no matter which client we use, we can access the whole map.
+That is because our map lives in the cluster and no matter which client we use, we can access the whole map->
 
 ## 1.6. Code Samples
 
 See the Hazelcast C++ [code samples](https://github.com/hazelcast/hazelcast-cpp-client/tree/master/examples) for more examples.
-
-You can also see the Hazelcast C++ client [API Documentation](https://docs.hazelcast.org/docs/clients/hazelcast/3.10.1/html/).
 
 # 2. Features
 
@@ -659,7 +660,7 @@ Hazelcast C++ client supports the following data structures and features:
 * Queue
 * Set
 * List
-* MultiMap
+* multi_map
 * Replicated Map
 * Ringbuffer
 * Reliable Topic
@@ -674,7 +675,7 @@ Hazelcast C++ client supports the following data structures and features:
 * Distributed Executor Service
 * Entry Processor
 * Transactional Map
-* Transactional MultiMap
+* Transactional multi_map
 * Transactional Queue
 * Transactional List
 * Transactional Set
@@ -711,11 +712,11 @@ desired aspects. An example is shown below.
 
 ```C++
     hazelcast::client::client_config config;
-    config.get_network_config().add_address(hazelcast::client::address("your server ip", 5701 /* your server port*/));
-    hazelcast::client::hazelcast_client hz(config); // Connects to the cluster
+    config.get_network_config().add_address({"your server ip", 5701 /* your server port*/});
+    hazelcast::client::hazelcast_client hz(std::move(config)); // Connects to the cluster
 ```
 
-See the `client_config` class reference at the Hazelcast C++ client [API Documentation](https://docs.hazelcast.org/docs/clients/hazelcast/3.10.1/html/classhazelcast_1_1client_1_1_client_config.html) for details.
+See the `client_config` class reference at the Hazelcast C++ client API Documentation for details.
 
 # 4. Serialization
 
@@ -738,90 +739,75 @@ Hazelcast serializes all your objects before sending them to the server. The `un
 
 Vector of the above types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `long[]` and `string[]` for the Java server side, respectively. 
 
-If you want the serialization to work faster or you use the clients in different languages, Hazelcast offers its own native serialization types, such as [`IdentifiedDataSerializable` Serialization](#41-identifieddataserializable-serialization) and [`Portable` Serialization](#42-portable-serialization).
+If you want the serialization to work faster or you use the clients in different languages, Hazelcast offers its own native serialization types, such as [`identified_data_serializer` serialization](#41-identifieddataserializable-serialization) and [`portable_serializer` serialization](#42-portable-serialization).
 
 On top of all, if you want to use your own serialization type, you can use a [Custom Serialization](#43-custom-serialization).
 
-When Hazelcast serializes an object into Data (byte array):
+Hazelcast serialization is mostly performed at compile time by implementing the specialization of template struct `hz_serializer<>`. The specialized struct should be defined at the `hazelcast::client::serialization` namespace. The serializer should be derived from one of the following marker classes:
 
-1. It first checks whether the object pointer is NULL.
+1. identified_data_serializer
+2. portable_serializer
+3. custom_serializer
+4. json serialization
+5. global_serializer
 
-2. If the above check fails, then the object is serialized using the serializer that matches the object type. The object type is determined using the free function `int32_t getHazelcastTypeId(const T *object);`. This method returns the constant built-int serializer type ID for the built-in types such as `byte`, `char`, `int32_t`, `bool` and `int64_t`, etc. If it does not match any of the built-in types, it may match the types offered by Hazelcast, i.e., IdentifiedDataSerializable, Portable or custom. The matching is done based on method parameter matching. 
+This way of specialization allows us two advantages:
 
-3. If the above check fails, Hazelcast will use the registered Global hz_serializer if one exists.
+1. No need to modify your classes (no extra API interfaces for existing classes).
 
-If all the above fails, then `exception::hazelcast_serialization` is thrown.
+2. The determination of the serializer is at compile time.  
 
-## 4.1. IdentifiedDataSerializable Serialization
+In addition to deriving from these marker classes, certain methods should be implemented in order your code to compile with this serializations. 
 
-For a faster serialization of objects, Hazelcast recommends to implement the `IdentifiedDataSerializable` interface. The following is an example of an object implementing this interface:
+You can also configure a global serializer in case non-of the above serializations are implemented for the user object. If no serializer can be found, then `exception::hazelcast_serialization` is thrown at runtime.
+
+## 4.1. identified_data_serializer Serialization
+
+For a faster serialization of objects, Hazelcast recommends to implement the `identified_data_serializer` interface. The following is an example of a `hz_serializer` implementing this interface:
 
 ```C++
-class Employee : public serialization::IdentifiedDataSerializable {
-public:
-    static const int TYPE_ID = 100;
-
-    virtual int getFactoryId() const {
-        return 1000;
-    }
-
-    virtual int getClassId() const {
-        return TYPE_ID;
-    }
-
-    virtual void writeData(serialization::object_data_output &writer) const {
-        writer.writeInt(id);
-        writer.writeUTF(&name);
-    }
-
-    virtual void readData(serialization::object_data_input &reader) {
-        id = reader.readInt();
-        name = *reader.readUTF();
-    }
-
-private:
-    int id;
+struct Person {
     std::string name;
+    bool male;
+    int32_t age;
 };
-```
-The `IdentifiedDataSerializable` interface uses `getClassId()` and `getFactoryId()` to reconstitute the object. To complete the implementation, `DataSerializableFactory` should also be implemented and registered into `serialization_config` which can be accessed from `clientConfig.get_serialization_config().addDataSerializableFactory`. The factory's responsibility is to return an instance of the right `IdentifiedDataSerializable` object, given the `classId`. 
 
-A sample `DataSerializableFactory` could be implemented as follows:
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<Person> : identified_data_serializer {
+                static int32_t get_factory_id() noexcept {
+                    return 1;
+                }
 
-```C++
-class SampleDataSerializableFactory : public serialization::DataSerializableFactory {
-public:
-    static const int FACTORY_ID = 1000;
+                static int32_t get_class_id() noexcept {
+                    return 3;
+                }
 
-    virtual std::auto_ptr<serialization::IdentifiedDataSerializable> create(int32_t classId) {
-        switch (classId) {
-            case 100:
-                return std::auto_ptr<serialization::IdentifiedDataSerializable>(new Employee());
-            default:
-                return std::auto_ptr<serialization::IdentifiedDataSerializable>();
+                static void write_data(const Person &object, hazelcast::client::serialization::object_data_output &out) {
+                    out.write(object.name);
+                    out.write(object.male);
+                    out.write(object.age);
+                }
+
+                static Person read_data(hazelcast::client::serialization::object_data_input &in) {
+                    return Person{in.read<std::string>(), in.read<bool>(), in.read<int32_t>()};
+                }
+            };
         }
-
     }
-};
+}
 ```
 
-The last step is to register the `IdentifiedDataSerializableFactory` to the `serialization_config`.
+`hz_serializer<Person>` specialization of `hz_serializer` should implement the above four methods, namely `get_factory_id`, `get_class_id`, `write_data`, `read_data`. In case that the object fields are non-public, you can always define struct `hz_serializer<Person>` as friend to your object class. You use the `object_data_output` class methods when serializing the object into binary bytes and you use the `object_data_input` class methods when de-serializing the bytes into the concrete object instance. The factory and class id returned from the associated methods should match the id's defined at the server side (Yes, you need to have the corresponding Java classes at the server side).
 
-```C++
-    client_config clientConfig;
-    clientConfig.get_serialization_config().addDataSerializableFactory(SampleDataSerializableFactory::FACTORY_ID,
-                                                                     boost::shared_ptr<serialization::DataSerializableFactory>(
-                                                                             new SampleDataSerializableFactory()));
-```
+## 4.2. portable_serializer Serialization
 
-Note that the ID that is passed to the `serialization_config` is same as the `factoryId` that the `Employee` object returns.
+If you want to support versioning of the objects, then you can use the portable serialization type. It has the following benefits:
 
-## 4.2. Portable Serialization
-
-As an alternative to the existing serialization methods, Hazelcast offers portable serialization. To use it, you need to implement the `Portable` interface. Portable serialization has the following advantages:
-
-- Supporting multiversion of the same object type.
-- Fetching individual fields without having to rely on the reflection.
+- Support multiversion of the same object type.
+- Fetch individual fields without having to rely on the reflection.
 - Querying and indexing support without deserialization and/or reflection.
 
 In order to support these features, a serialized `Portable` object contains meta information like the version and concrete location of the each field in the binary data. This way Hazelcast is able to navigate in the binary data and deserialize only the required field without actually deserializing the whole object which improves the query performance.
@@ -830,222 +816,154 @@ With multiversion support, you can have two members where each of them having di
 
 Also note that portable serialization is totally language independent and is used as the binary protocol between Hazelcast server and clients.
 
-A sample portable implementation of a `PortableSerializableSample` class looks like the following:
+A sample portable_serializer implementation of a `Person` class looks like the following:
 
 ```C++
-class PortableSerializableSample : public serialization::Portable {
-public:
-    static const int CLASS_ID = 1;
-
-    virtual int getFactoryId() const {
-        return 1;
-    }
-
-    virtual int getClassId() const {
-        return CLASS_ID;
-    }
-
-    virtual void writePortable(serialization::portable_writer &writer) const {
-        writer.writeInt("id", id);
-        writer.writeUTF("name", &name);
-        writer.writeLong("lastOrder", lastOrder);
-    }
-
-    virtual void read_portable(serialization::portable_reader &reader) {
-        id = reader.readInt("id");
-        name = *reader.readUTF("name");
-        lastOrder = reader.readLong("lastOrder");
-    }
-
-private:
+struct Person {
     std::string name;
-    int32_t id;
-    int64_t lastOrder;
+    bool male;
+    int32_t age;
 };
-```
 
-Similar to `IdentifiedDataSerializable`, a `Portable` object must provide `classId` and `factoryId`. The factory object will be used to create the `Portable` object given the `classId`.
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<Person> : portable_serializer {
+                static int32_t get_factory_id() noexcept {
+                    return 1;
+                }
 
-A sample `PortableFactory` could be implemented as follows:
+                static int32_t get_class_id() noexcept {
+                    return 3;
+                }
 
-```C++
-class SamplePortableFactory : public serialization::PortableFactory {
-public:
-    static const int FACTORY_ID = 1;
+                static void write_portable(const Person &object, hazelcast::client::serialization::portable_writer &out) {
+                    out.write("name", object.name);
+                    out.write("gender", object.male);
+                    out.write("age", object.age);
+                }
 
-    virtual std::auto_ptr<serialization::Portable> create(int32_t classId) const {
-        switch (classId) {
-            case 1:
-                return std::auto_ptr<serialization::Portable>(new PortableSerializableSample());
-            default:
-                return std::auto_ptr<serialization::Portable>();
+                static Person read_portable(hazelcast::client::serialization::portable_reader &in) {
+                    return Person{in.read<std::string>("name"), in.read<bool>("gender"), in.read<int32_t>("age")};
+                }
+            };
         }
     }
-};
+}
+
 ```
 
-The last step is to register the `PortableFactory` to the `serialization_config`.
+Note that, this is very similar to `identified_data_serializer` implementation except the method signatures and the derived marker class of `portable_serializer` for the specialized serializer.
 
-```C++
-    client_config clientConfig;
-    clientConfig.get_serialization_config().addPortableFactory(SamplePortableFactory::FACTORY_ID,
-                                                             boost::shared_ptr<serialization::PortableFactory>(
-                                                                     new SamplePortableFactory()));
-```
-
-Note that the ID that is passed to the `serialization_config` is same as the `factoryId` that `PortableSerializableSample` object returns.
+`hz_serializer<Person>` specialization of `hz_serializer` should implement the above four methods, namely `get_factory_id`, `get_class_id`, `write_portable`, `read_portable`. In case that the object fields are non-public, you can always define struct `hz_serializer<Person>` as friend to your object class. You use the `portable_writer` class methods when serializing the object into binary bytes and you use the `portable_reader` class methods when de-serializing the bytes into the concrete object instance. 
 
 ## 4.3. Custom Serialization
 
-Hazelcast lets you plug a custom serializer to be used for serialization of objects. Custom serialization lets you use your existing classes without any modification in code for serialization purposes. They will be serialized/deserialized without any code change to already existing classes.
+Hazelcast lets you plug a custom serializer to be used for serialization of objects. It allows you alsoan integration point for any external serialization frameworks such as protobuf, flatbuffers, etc. 
 
-Let's say you have an object `Musician` and you would like to customize the serialization, since you may want to use an external serializer for your object.
+A sample custom_serializer implementation of a `Person` class looks like the following:
 
 ```C++
-class C++ {
-public:
-    Musician() {}
-
-    Musician(const std::string &name) : name(name) {}
-
-    virtual ~Musician() {
-    }
-
-    const std::string &get_name() const {
-        return name;
-    }
-
-    void setName(const std::string &value) {
-        Musician::name = value;
-    }
-
-private:
+struct Person {
     std::string name;
+    bool male;
+    int32_t age;
 };
-```
 
-Let's say your custom `MusicianSerializer` will serialize `Musician`.
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<Person> : custom_serializer {
+                static constexpr int32_t get_type_id() noexcept {
+                    return 3;
+                }
 
-```C++
-class MusicianSerializer : public serialization::StreamSerializer {
-public:
-    virtual int32_t getHazelcastTypeId() const {
-        return 10;
-    }
+                static void write(const Person &object, hazelcast::client::serialization::object_data_output &out) {
+                    out.write(object.name);
+                    out.write(object.male);
+                    out.write(object.age);
+                }
 
-    virtual void write(serialization::object_data_output &out, const void *object) {
-        const Musician *csObject = static_cast<const Musician *>(object);
-        const std::string &value = csObject->get_name();
-        int length = (int) value.length();
-        std::vector<hazelcast::byte> bytes;
-        for (int i = 0; i < length; ++i) {
-            bytes.push_back((hazelcast::byte) value[i]);
+                static Person read(hazelcast::client::serialization::object_data_input &in) {
+                    return Person{in.read<std::string>(), in.read<bool>(), in.read<int32_t>()};
+                }
+            };
         }
-        out.writeInt((int) length);
-        out.write(bytes);
     }
-
-    virtual void *read(serialization::object_data_input &in) {
-        int32_t len = in.readInt();
-        std::ostringstream value;
-        for (int i = 0; i < len; ++i) {
-            value << (char) in.readByte();
-        }
-
-        return new Musician(value.str());
-    }
-};
+}
 ```
 
-Note that the serializer `getHazelcastTypeId` method must return a unique `id` as Hazelcast will use it to lookup the `MusicianSerializer` while it deserializes the object.
-
-You should provide the free function `int getHazelcastTypeId(const MusicianSerializer *);` in the same namespace to which `MusicianSerializer` class belongs. This function should return the same id with its serializer. This id is used to determine which serializer needs to be used for your classes. 
-
-Now the last required step is to register the `MusicianSerializer` to the configuration.
-
-```C++
-    client_config clientConfig;
-    clientConfig.get_serialization_config().registerSerializer(
-            boost::shared_ptr<serialization::StreamSerializer>(new MusicianSerializer()));
-
-```
-
-From now on, Hazelcast will use `MusicianSerializer` to serialize `Musician` objects.
+`hz_serializer<Person>` specialization of `hz_serializer` should implement the above three methods, namely `get_type_id`, `write`, `read`. In case that the object fields are non-public, you can always define struct `hz_serializer<Person>` as friend to your object class. You use the `object_data_output` class methods when serializing the object into binary bytes and you use the `object_data_input` class methods when de-serializing the bytes into the concrete object instance. 
 
 ## 4.4. JSON Serialization
 
-You can use the JSON formatted strings as objects in Hazelcast cluster. Starting with Hazelcast IMDG 3.12, the JSON serialization is one of the formerly supported serialization methods. Creating JSON objects in the cluster does not require any server side coding and hence you can just send a JSON formatted string object to the cluster and query these objects by fields.
+You can use the JSON formatted strings as objects in Hazelcast cluster. Creating JSON objects in the cluster does not require any server side coding and hence you can just send a JSON formatted string object to the cluster and query these objects by fields.
 
 In order to use JSON serialization, you should use the `hazelcast_json_value` object for the key or value. Here is an example imap usage:
 
 ```C++
-    hazelcast::client::client_config config;
-    hazelcast::client::hazelcast_client hz(config);
+    hazelcast::client::hazelcast_client hz;
 
-    hazelcast::client::imap<std::string, hazelcast_json_value> map = hz.get_map<std::string, hazelcast_json_value>(
-            "map");
+    auto map = hz.get_map("map");
+
+    map->put("item1", hazelcast::client::hazelcast_json_value("{ \"age\": 4 }")).get();
+    map->put("item2", hazelcast::client::hazelcast_json_value("{ \"age\": 20 }")).get();
 ```
 
-We constructed a map in the cluster which has `string` as the key and `hazelcast_json_value` as the value. `hazelcast_json_value` is a simple wrapper and identifier for the JSON formatted strings. You can get the JSON string from the `hazelcast_json_value` object using the `to_string()` method. 
+`hazelcast_json_value` is a simple wrapper and identifier for the JSON formatted strings. You can get the JSON string from the `hazelcast_json_value` object using the `to_string()` method. 
 
 You can construct a `hazelcast_json_value` using one of the constructors. All constructors accept the JSON formatted string as the parameter. No JSON parsing is performed but it is your responsibility to provide correctly formatted JSON strings. The client will not validate the string, and it will send it to the cluster as it is. If you submit incorrectly formatted JSON strings and, later, if you query those objects, it is highly possible that you will get formatting errors since the server will fail to deserialize or find the query fields.
-
-Here is an example of how you can construct a `hazelcast_json_value` and put to the map:
-
-```C++
-    map.put("item1", hazelcast_json_value("{ \"age\": 4 }"));
-    map.put("item2", hazelcast_json_value("{ \"age\": 20 }"));
-```
 
 You can query JSON objects in the cluster using the `predicate`s of your choice. An example JSON query for querying the values whose age is less than 6 is shown below:
 
 ```C++
     // Get the objects whose age is less than 6
-    std::vector<hazelcast_json_value> result = map.values(
-            query::greater_less_predicate<int>("age", 6, false, true));
-
-    std::cout << "Retrieved " << result.size() << " values whose age is less than 6." << std::endl;
-    std::cout << "Entry is:" << result[0].to_string() << std::endl;
+    auto result = map->values<hazelcast::client::hazelcast_json_value>(
+            hazelcast::client::query::greater_less_predicate(hz, "age", 6, false, true)).get();
 ```
 
 ## 4.5. Global Serialization
 
-The global serializer is identical to custom serializers from the implementation perspective. The global serializer is registered as a fallback serializer to handle all other objects if a serializer cannot be located for them.
+The global serializer is registered as a fallback serializer to handle all other objects if a serializer cannot be located for them.
 
-By default, global serializer is used if the object is not `IdentifiedDataSerializable` or `Portable` or there is no custom serializer for it.
+By default, global serializer is used if there are no specialization `hz_serializer<my_class>` for my class `my_class`. 
 
 **Use Cases:**
 
 * Third party serialization frameworks can be integrated using the global serializer.
-* For your custom objects, you can implement a single serializer to handle all of them.
+* For your custom objects, you can implement a single serializer to handle all object serializations.
 
 A sample global serializer that integrates with a third party serializer is shown below.
 
 ```C++
-class GlobalSerializer : public serialization::StreamSerializer {
+class MyGlobalSerializer : public hazelcast::client::serialization::global_serializer {
 public:
-    virtual int32_t getHazelcastTypeId() const {
-        return 20;
+    void write(const boost::any &obj, hazelcast::client::serialization::object_data_output &out) override {
+        auto const &object = boost::any_cast<Person>(obj);
+        out.write(object.name);
+        out.write(object.male);
+        out.write(object.age);
     }
 
-    virtual void write(serialization::object_data_output &out, const void *object) {
-        // out.write(MyFavoriteSerializer.serialize(object))
-    }
-
-    virtual void *read(serialization::object_data_input &in) {
-        // return MyFavoriteSerializer.deserialize(in);
-        return NULL;
+    boost::any read(hazelcast::client::serialization::object_data_input &in) override {
+        return boost::any(Person{in.read<std::string>(), in.read<bool>(), in.read<int32_t>()});
     }
 };
 ```
 
+As you see fromn the sample, the global serializer class should implement the `hazelcast::client::serialization::global_serializer` interface.
+
 You should register the global serializer in the configuration.
 
 ```C++
-    client_config clientConfig;
-    clientConfig.get_serialization_config().setGlobalSerializer(
-            boost::shared_ptr<serialization::StreamSerializer>(new GlobalSerializer()));
+    hazelcast::client::client_config config;
+    config.get_serialization_config().set_global_serializer(std::make_shared<MyGlobalSerializer>());
+    hazelcast::client::hazelcast_client hz(std::move(config));
 ```
+
+You need to utilize the `boost::any_cast` methods tyo actually use the objects provided for serialization and you are expected to return type `boost::any` from the `read` method. 
 
 # 5. Setting Up Client Network
 
@@ -1055,9 +973,8 @@ Here is an example of configuring the network for C++ Client programmatically.
 
 ```C++
     client_config clientConfig;
-    clientConfig.get_network_config().add_address(address("10.1.1.21", 5701));
-    clientConfig.get_network_config().add_address(address("10.1.1.22", 5703));
-    clientConfig.get_network_config().setSmartRouting(true);
+    clientConfig.get_network_config().add_addresses({{"10.1.1.21", 5701}, {"10.1.1.22", 5703}});
+    clientConfig.get_network_config().set_smart_routing(true);
     clientConfig.set_redo_operation(true);
     clientConfig.get_network_config().set_connection_timeout(6000);
     clientConfig.get_network_config().set_connection_attempt_period(5000);
@@ -1072,8 +989,7 @@ list to find an alive member. Although it may be enough to give only one address
 
 ```C++
     client_config clientConfig;
-    clientConfig.get_network_config().add_address(address("10.1.1.21", 5701));
-    clientConfig.get_network_config().add_address(address("10.1.1.22", 5703));
+    clientConfig.get_network_config().add_address(address("10.1.1.21", 5701), address("10.1.1.22", 5703));
 ```
 
 The provided list is shuffled and tried in a random order. If no address is added to the `client_network_config`, then `127.0.0.1:5701` is tried by default.
@@ -1087,14 +1003,14 @@ The following is an example configuration.
 
 ```C++
     client_config clientConfig;
-    clientConfig.get_network_config().setSmartRouting(true);
+    clientConfig.get_network_config().set_smart_routing(true);
 ```
 
 Its default value is `true` (smart client mode).
 
 ## 5.3. Enabling Redo Operation
 
-It enables/disables redo-able operations. While sending the requests to the related members, the operations can fail due to various reasons. Read-only operations are retried by default. If you want to enable retry for the other operations, you can set the `redoOperation` to `true`.
+It enables/disables redo-able operations. While sending the requests to the related members, the operations can fail due to various reasons. Read-only operations are retried by default. If you want to enable retry for the other operations, you can set the `redo_operation` to `true`.
 
 ```C++
     client_config clientConfig;
@@ -1119,7 +1035,7 @@ Its default value is `5000` milliseconds.
 
 ## 5.5. Setting Connection Attempt Limit
 
-While the client is trying to connect initially to one of the members in the `client_network_config::getAddresses()` (and the cluster member list addresses if the cluster member list were loaded at least once during a previous connection to the cluster), that member might not be available at that moment. Instead of giving up, throwing an error and stopping the client, the client will retry as many as `client_network_config::getConnectionAttemptLimit()` times. This is also the case when the previously established connection between the client and that member goes down.
+While the client is trying to connect initially to one of the members in the `client_network_config::get_addresses()` (and the cluster member list addresses if the cluster member list were loaded at least once during a previous connection to the cluster), that member might not be available at that moment. Instead of giving up, throwing an error and stopping the client, the client will retry as many as `client_network_config::getConnectionAttemptLimit()` times. This is also the case when the previously established connection between the client and that member goes down.
 
 The following is an example configuration.
 
@@ -1168,7 +1084,7 @@ The C++ client works the same way as the Java client. For details, see [aws_clie
 
 ## 5.9. Authentication
 
-By default, the client does not use any authentication method and just uses the cluster "dev" to connect to. You can change which cluster to connect by using the configuration API `client_config::setClusterName`. This way, you can have multiple clusters in the network but the client will only be able to connect to the cluster with the correct cluster name (server should also be started with the cluster name configured to the same name).
+By default, the client does not use any authentication method and just uses the cluster "dev" to connect to. You can change which cluster to connect by using the configuration API `client_config::set_cluster_name`. This way, you can have multiple clusters in the network but the client will only be able to connect to the cluster with the correct cluster name (server should also be started with the cluster name configured to the same cluster name).
 
 If you want to enable authentication, then the client can be configured in one of the two different ways to authenticate:
 
@@ -1235,10 +1151,9 @@ To disable backup acknowledgement, you should use the `backup_acks_enabled` conf
 
 Its default value is `true`. This option has no effect for unisocket clients.
 
-You can also fine-tune this feature using entries of the `properties` config option as described below:
+You can also fine-tune this feature using `client_config::set_protperty` API as described below:
 
-- `hazelcast.client.operation.backup.timeout.millis`: Default value is `5000` milliseconds. If an operation has
-backups, this property specifies how long (in milliseconds) the invocation waits for acks from the backup replicas. If acks are not received from some of the backups, there will not be any rollback on the other successful replicas.
+- `hazelcast.client.operation.backup.timeout.millis`: Default value is `5000` milliseconds. If an operation has backups, this property specifies how long (in milliseconds) the invocation waits for acks from the backup replicas. If acks are not received from some of the backups, there will not be any rollback on the other successful replicas.
 
 - `hazelcast.client.operation.fail.on.indeterminate.state`: Default value is `false`. When it is `true`, if an operation has sync backups and acks are not received from backup replicas in time, or the member which owns primary replica of the target partition leaves the cluster, then the invocation fails. However, even if the invocation fails, there will not be any rollback on other successful replicas.
 
@@ -1263,7 +1178,7 @@ Hazelcast allows you to encrypt socket level communication between Hazelcast mem
 
 To use TLS/SSL with your Hazelcast C++ client, you should perform the following:
 
-* Provide the compile flag `-DHZ_BUILD_WITH_SSL` when compiling, since the TLS feature depends on OpenSSL library.
+* Provide the compile flag **`-DHZ_BUILD_WITH_SSL`** when compiling, since the TLS feature depends on OpenSSL library.
 * Install the OpenSSL library to your development environment.
 * Enable the SSL in the client network configuration.
 * Specify the correct path to the CA verification file for the trusted server. This path can be relative to the executable working directory.
@@ -1274,10 +1189,10 @@ You can set the protocol type. If not set, the configuration uses `tlsv12` (TLSv
 The following is an example configuration.
 
 ```C++
-    config.get_network_config(). get_ssl_config ().set_enabled(true).add_verify_file(getCAFilePath());
+    config.get_network_config().get_ssl_config().set_enabled(true).add_verify_file(get_ca_file_path());
 
 //Cipher suite is set using a string which is defined by OpenSSL standard at this page: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html An example usage:
-config.get_network_config(). get_ssl_config ().set_cipher_list("HIGH");
+config.get_network_config().get_ssl_config().set_cipher_list("HIGH");
 ```
 
 The detailed config API is below:
@@ -1350,7 +1265,7 @@ You can set the protocol as one of the following values:
 ```
 sslv2, sslv3, tlsv1, sslv23, tlsv11, tlsv12
 ```
-The `ssl_config .set_enabled` method should be called explicitly to enable the SSL. The path of the certificate should be correctly provided. 
+The `ssl_config.set_enabled` method should be called explicitly to enable the SSL. The path of the certificate should be correctly provided. 
 
 # 7. Using C++ Client with Hazelcast IMDG
 
@@ -1370,8 +1285,8 @@ The following is an example on how to create a `client_config` object and config
 
 ```C++
     client_config clientConfig;
-    clientConfig.getGroupConfig().setName("dev");
-    clientConfig.get_network_config().add_address(address("'10.90.0.1", 5701)).add_address(address("'10.90.0.2", 5702));
+    clientConfig.set_cluster_name("my test cluster");
+    clientConfig.get_network_config().add_addresses({{"'10.90.0.1", 5701}, {"'10.90.0.2", 5702}});
 ```
 
 The second step is initializing the `hazelcast_client` to be connected to the cluster:
@@ -1387,13 +1302,13 @@ Let's create a map and populate it with some data, as shown below.
 
 ```C++
     // Get the Distributed Map from Cluster.
-    imap<std::string, std::string> map = client.get_map<std::string, std::string>("my-distributed-map");
-    //Standard Put and Get.
-    map.put("key", "value");
-    map.get("key");
+    auto map = client.get_map("my-distributed-map");
+    //Standard put and get.
+    map->put<std::string, std::string>("key", "value").get();
+    map->get<std::string, std::string>("key").get();
     //Concurrent Map methods, optimistic updating
-    map.put_if_absent("somekey", "somevalue");
-    map.replace("key", "value", "newvalue");
+    map->put_if_absent<std::string, std::string>("somekey", "somevalue").get();
+    map->replace<std::string, std::string>("key", "value", "newvalue").get();
  ```
 
 As the final step, if you are done with your client, you can shut it down as shown below. This will release all the used resources and close connections to the cluster.
@@ -1422,7 +1337,7 @@ In the unisocket client mode, the client will only connect to one of the configu
 You can set the unisocket client mode in the `client_config` as shown below.
 
 ```C++
-    clientConfig.get_network_config().setSmartRouting(false);
+    clientConfig.get_network_config().set_smart_routing(false);
 ```
 
 ## 7.3. Handling Failures
@@ -1431,23 +1346,23 @@ There are two main failure cases you should be aware of. Below sections explain 
 
 ### 7.3.1. Handling Client Connection Failure
 
-While the client is trying to connect initially to one of the members in the `client_network_config::getAddresses()`, all the members might not be available. Instead of giving up, throwing an error and stopping the client, the client will retry as many as `connectionAttemptLimit` times. 
+While the client is trying to connect initially to one of the members in the `client_network_config::get_addresses()`, all the members might not be available. Instead of giving up, throwing an error and stopping the client, the client will retry as many as `connection_attempt_limit` times. 
 
-You can configure `connectionAttemptLimit` for the number of times you want the client to retry connecting. See the [Setting Connection Attempt Limit section](#55-setting-connection-attempt-limit).
+You can configure `connection_attempt_limit` for the number of times you want the client to retry connecting. See the [Setting Connection Attempt Limit section](#55-setting-connection-attempt-limit).
 
 The client executes each operation through the already established connection to the cluster. If this connection(s) disconnects or drops, the client will try to reconnect as configured.
 
 ### 7.3.2. Handling Retry-able Operation Failure
 
-While sending the requests to the related members, the operations can fail due to various reasons. Read-only operations are retried by default. If you want to enable retrying for the other operations, you can set the `redoOperation` to `true`. See the [Enabling Redo Operation section](#53-enabling-redo-operation).
+While sending the requests to the related members, the operations can fail due to various reasons. Read-only operations are retried by default. If you want to enable retrying for the other operations, you can set the `redo_operation` to `true`. See the [Enabling Redo Operation section](#53-enabling-redo-operation).
 
-You can set a timeout for retrying the operations sent to a member. This can be provided by using the property `hazelcast.client.invocation.timeout.seconds` in `client_config.properties`. The client will retry an operation within this given period, of course, if it is a read-only operation or you enabled the `redoOperation` as stated in the above paragraph. This timeout value is important when there is a failure resulted by either of the following causes:
+You can set a timeout for retrying the operations sent to a member. This can be provided by using the property `hazelcast.client.invocation.timeout.seconds` in `client_config.properties`. The client will retry an operation within this given period, of course, if it is a read-only operation or you enabled the `redo_operation` as stated in the above paragraph. This timeout value is important when there is a failure resulted by either of the following causes:
 
 * Member throws an exception.
 * Connection between the client and member is closed.
 * Client’s heartbeat requests are timed out.
 
-When a connection problem occurs, an operation is retried if it is certain that it has not run on the member yet or if it is idempotent such as a read-only operation, i.e., retrying does not have a side effect. If it is not certain whether the operation has run on the member, then the non-idempotent operations are not retried. However, as explained in the first paragraph of this section, you can force all the client operations to be retried (`redoOperation`) when there is a connection failure between the client and member. But in this case, you should know that some operations may run multiple times causing conflicts. For example, assume that your client sent a `queue.offer` operation to the member and then the connection is lost. Since there will be no response for this operation, you will not know whether it has run on the member or not. If you enabled `redoOperation`, it means this operation may run again, which may cause two instances of the same object in the queue.
+When a connection problem occurs, an operation is retried if it is certain that it has not run on the member yet or if it is idempotent such as a read-only operation, i.e., retrying does not have a side effect. If it is not certain whether the operation has run on the member, then the non-idempotent operations are not retried. However, as explained in the first paragraph of this section, you can force all the client operations to be retried (`redo_operation`) when there is a connection failure between the client and member. But in this case, you should know that some operations may run multiple times causing conflicts. For example, assume that your client sent a `queue->offer` operation to the member and then the connection is lost. Since there will be no response for this operation, you will not know whether it has run on the member or not. If you enabled `redo_operation`, it means this operation may run again, which may cause two instances of the same object in the queue->
 
 When invocation is being retried, the client may wait some time before it retries again. This duration can be configured using the following property:
 
@@ -1458,10 +1373,10 @@ The default retry wait time is 1 second.
 
 ### 7.3.3. Client Backpressure
 
-Hazelcast uses operations to make remote calls. For example, a `map.get` is an operation and a `map.put` is one operation for the primary
-and one operation for each of the backups, i.e., `map.put` is executed for the primary and also for each backup. In most cases, there will be a natural balance between the number of threads performing operations
+Hazelcast uses operations to make remote calls. For example, a `map->get` is an operation and a `map->put` is one operation for the primary
+and one operation for each of the backups, i.e., `map->put` is executed for the primary and also for each backup. In most cases, there will be a natural balance between the number of threads performing operations
 and the number of operations being executed. However, there are two situations where this balance and operations
-can pile up and eventually lead to `OutOfMemoryException` (OOME):
+can pile up and eventually lead to `out_of_memory_exception` (OOME):
 
 - Asynchronous calls: With async calls, the system may be flooded with the requests.
 - Asynchronous backups: The asynchronous backups may be piling up.
@@ -1483,7 +1398,7 @@ For details of backpressure, see the [Back Pressure section](https://docs.hazelc
 Hazelcast client-cluster connection and reconnection strategy can be configured. Sometimes, you may not want your application to wait for the client to connect to the cluster, you may just want to get the client and let the client connect in the background. This is configured as follows:
 
 ```
-client_config::getConnectionStrategyConfig().setAsyncStart(bool);
+client_config::get_connection_strategy_config().set_async_start(bool);
 ```
 
 When this configuration is set to true, the client creation won't wait to connect to cluster. The client instance will throw an exception for any request, until it connects to the cluster and become ready.
@@ -1495,10 +1410,10 @@ If it is set to false (the default case), `hazelcast_client(const client_config)
 You can configure how the client should act when the client disconnects from the cluster for any reason. This is configured as follows:
 
 ```
-client_config::getConnectionStrategyConfig().setReconnectMode(const hazelcast::client::config::client_connection_strategy_config::ReconnectMode &);
+client_config::get_connection_strategy_config().set_reconnect_mode(const hazelcast::client::config::client_connection_strategy_config::reconnect_mode &);
 ```
 
-Possible values for `ReconnectMode` are:
+Possible values for `reconnect_mode` are:
 
 - `OFF`: Prevents reconnection to the cluster after a disconnect.
 - `ON`: Reconnects to the cluster by blocking invocations.
@@ -1510,7 +1425,7 @@ Most of the distributed data structures are supported by the C++ client. In this
 
 ### 7.4.1. Using Map
 
-Hazelcast Map (`imap`) is a distributed map. Through the C++ client, you can perform operations like reading and writing from/to a Hazelcast Map with the well known get and put methods. For details, see the [Map section](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#map) in the Hazelcast IMDG Reference Manual.
+Hazelcast Map (`imap`) is a distributed map-> Through the C++ client, you can perform operations like reading and writing from/to a Hazelcast Map with the well known get and put methods. For details, see the [Map section](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#map) in the Hazelcast IMDG Reference Manual.
 
 A Map usage example is shown below.
 
@@ -1518,74 +1433,12 @@ A Map usage example is shown below.
     // Get the Distributed Map from Cluster.
     auto map = hz.get_map("my-distributed-map");
     //Standard Put and Get.
-    map.put<std::string, std::string>("key", "value");
-    map.get<std::string, std::string>("key");
+    map->put<std::string, std::string>("key", "value").get();
+    map->get<std::string, std::string>("key").get();
     //Concurrent Map methods, optimistic updating
-    map.put_if_absent<std::string, std::string>("somekey", "somevalue");
-    map.replace<std::string, std::string>("key", "value", "newvalue");
+    map->put_if_absent<std::string, std::string>("somekey", "somevalue").get();
+    map->replace<std::string, std::string>("key", "value", "newvalue").get();
 ```
-
-#### 7.4.1.1. Using imap Non-Blocking Async Methods
-Hazelcast imap provides asynchronous methods for more powerful operations like batched writing or batched reading. The asynchronous methods do not block but return immediately with an `ICompletableFuture` interface. You can later query the result of the operation using this interface or you can even provide a callback method to be executed on the user executor threads when the response to the call is received. 
-
-An `Imap::putAsync` usage example is shown below:
-
-```C++
-    // initiate map put in an unblocking way
-    boost::shared_ptr<ICompletableFuture<std::string> > future = map.putAsync("key", "value");
-
-    // do some other work
-    // ----
-    
-    // later on get the result of the put operation
-    boost::shared_ptr<std::string> result = future->get();
-    if (result.get()) {
-        std::cout << "There was a previous value for key. The value was:" << *result << std::endl;
-    } else {
-        std::cout << "There was no previous value for key." << std::endl;
-    }
-```
-The asynchronous methods always return an `ICompletableFuture` pointer. The method does not block on IO thread. You can get the result later with the `ICompletableFuture::get()` method. `ICompletableFuture::get()` blocks until the response is received or an exception occurs.  
-
-Other asynchronous `imap` methods are:
- 
-- `imap::getAsync`
-- `imap::removeAsync`
-- `imap::setAsync`
-- `imap::getAsync`
-
-You can also provide a callback instance to the future using the `andThen` method. The callback is executed upon the reception of the call response or exception, and you can put your code into the callback methods. The callback method will be executed in the user executor thread which is different from the user's main program thread and hence it will not block the user. An example callback usage is shown below:
-
-```C++
-/**
- * This class prints message on receiving the response or prints the exception if exception occurs
- */
-class PrinterCallback : public hazelcast::client::ExecutionCallback<std::string> {
-public:
-    virtual void onResponse(const boost::shared_ptr<std::string> &response) {
-        std::cout << "Response was received. ";
-        if (response.get()) {
-            std::cout << "Received response is : " << *response << std::endl;
-        } else {
-            std::cout << "Received null response" << std::endl;
-        }
-    }
-
-    virtual void onFailure(const boost::shared_ptr<exception::iexception> &e) {
-        std::cerr << "A failure occured. The exception is:" << e << std::endl;
-    }
-};
-
-// .......
-    // add an item in an unblocking way
-    boost::shared_ptr<ICompletableFuture<int64_t> > future = rb->addAsync("new item",
-                                                                          hazelcast::client::ringbuffer<std::string>::OVERWRITE);
-
-    // let the result processed by a callback
-    boost::shared_ptr<ExecutionCallback<int64_t> > callback(new ItemPrinter);
-    future->andThen(callback);
-```
-
 
 ### 7.4.2. Using multi_map
 
@@ -1595,18 +1448,17 @@ A multi_map usage example is shown below.
 
 ```C++
     // Get the Distributed multi_map from Cluster.
-    multi_map<std::string, std::string> multiMap = hz.getMultiMap<std::string, std::string>("my-distributed-multimap");
+    auto multiMap = hz.get_multi_map("my-distributed-multimap");
     // Put values in the map against the same key
-    multiMap.put("my-key", "value1");
-    multiMap.put("my-key", "value2");
-    multiMap.put("my-key", "value3");
+    multiMap->put<std::string, std::string>("my-key", "value1").get();
+    multiMap->put<std::string, std::string>("my-key", "value2").get();
+    multiMap->put<std::string, std::string>("my-key", "value3").get();
     // Print out all the values for associated with key called "my-key"
-    std::vector<std::string> values = multiMap.get("my-key");
-    for (std::vector<std::string>::const_iterator it = values.begin();it != values.end(); ++it) {
-        std::cout << *it << std::endl; // will print value1, value2 and value3 each per line.
+    for (const auto &value : multiMap->get<std::string, std::string>("my-key").get()) {
+        std::cout << value << std::endl; // will print value1, value2 and value3 each per line.
     }
     // remove specific key/value pair
-    multiMap.remove("my-key", "value2");    // Shutdown this Hazelcast Client
+    multiMap->remove<std::string, std::string>("my-key", "value2").get();    // Shutdown this Hazelcast Client
 ```
 
 ### 7.4.3. Using Replicated Map
@@ -1616,10 +1468,10 @@ Hazelcast `replicated_map` is a distributed key-value data structure where the d
 A Replicated Map usage example is shown below.
 
 ```C++
-    boost::shared_ptr<hazelcast::client::replicated_map<int, std::string> > replicatedMap = hz.getReplicatedMap<int, std::string>("myReplicatedMap");
-    replicatedMap->put(1, "Furkan");
-    replicatedMap->put(2, "Ahmet");
-    std::cout << "Replicated map value for key 2 is " << *replicatedMap->get(2) << std::endl; // Replicated map value for key 2 is Ahmet
+    auto replicatedMap = hz.get_replicated_map("myReplicatedMap");
+    replicatedMap->put<int, std::string>(1, "Furkan").get();
+    replicatedMap->put<int, std::string>(2, "Ahmet").get();
+    std::cout << "Replicated map value for key 2 is " << *replicatedMap->get<int, std::string>(2).get() << std::endl; // Replicated map value for key 2 is Ahmet
 ```
 
 ### 7.4.4. Using Queue
@@ -1630,17 +1482,17 @@ A Queue usage example is shown below.
 
 ```C++
     // Get a Blocking Queue called "my-distributed-queue"
-    iqueue<std::string> queue = hz.getQueue<std::string>("my-distributed-queue");
+    auto queue = hz.get_queue("my-distributed-queue");
     // Offer a String into the Distributed Queue
-    queue.offer("item");
+    queue->offer<std::string>("item").get();
     // Poll the Distributed Queue and return the String
-    boost::shared_ptr<std::string> item = queue.poll(); // gets first "item"
+    auto item = queue->poll<std::string>().get(); // gets first "item"
     //Timed blocking Operations
-    queue.offer("anotheritem", 500);
-    boost::shared_ptr<std::string> anotherItem = queue.poll(5 * 1000);
+    queue->offer<std::string>("anotheritem", 500).get();
+    auto anotherItem = queue->poll<std::string>(5 * 1000).get();
     //Indefinitely blocking Operations
-    queue.put("yetanotheritem");
-    std::cout << *queue.take() << std::endl; // Will print yetanotheritem
+    queue->put<std::string>("yetanotheritem").get();
+    std::cout << *queue->take<std::string>().get() << std::endl; // Will print yetanotheritem
 ```
 
 ### 7.4.5. Using Set
@@ -1651,18 +1503,17 @@ A Set usage example is shown below.
 
 ```C++
     // Get the Distributed Set from Cluster.
-    iset<std::string> set = hz.getSet<std::string>("my-distributed-set");
+    auto set = hz.get_set("my-distributed-set");
     // Add items to the set with duplicates
-    set.add("item1");
-    set.add("item1");
-    set.add("item2");
-    set.add("item2");
-    set.add("item2");
-    set.add("item3");
+    set->add<std::string>("item1").get();
+    set->add<std::string>("item1").get();
+    set->add<std::string>("item2").get();
+    set->add<std::string>("item2").get();
+    set->add<std::string>("item2").get();
+    set->add<std::string>("item3").get();
     // Get the items. Note that there are no duplicates.
-    std::vector<std::string> values = set.toArray();
-    for (std::vector<std::string>::const_iterator it=values.begin();it != values.end();++it) {
-        std::cout << (*it) << std::endl;
+    for (const auto &value : set->toArray().get()) {
+        std::cout << value << std::endl;
     }
 ```
 
@@ -1674,17 +1525,17 @@ A List usage example is shown below.
 
 ```C++
     // Get the Distributed List from Cluster.
-    ilist<std::string> list = hz.getList<std::string>("my-distributed-list");
+    auto list = hz.get_list("my-distributed-list");
     // Add elements to the list
-    list.add("item1");
-    list.add("item2");
+    list->add<std::string>("item1").get();
+    list->add<std::string>("item2").get();
 
     // Remove the first element
-    std::cout << "Removed: " << *list.remove(0);
+    std::cout << "Removed: " << *list.remove<std::string>(0).get();
     // There is only one element left
-    std::cout << "Current size is " << list.size() << std::endl;
+    std::cout << "Current size is " << list.size().get() << std::endl;
     // Clear the list
-    list.clear();
+    list.clear().get();
 ```
 
 ### 7.4.7. Using ringbuffer
@@ -1694,59 +1545,17 @@ Hazelcast `ringbuffer` is a replicated but not partitioned data structure that s
 A ringbuffer usage example is shown below.
 
 ```C++
-    boost::shared_ptr<ringbuffer<long> > rb = hz.getRingbuffer<long>("rb");
+    auto rb = hz.get_ring_buffer("rb");
     // add two items into ring buffer
-    rb->add(100);
-    rb->add(200);
+    rb->add(100).get();
+    rb->add(200).get();
     // we start from the oldest item.
     // if you want to start from the next item, call rb.tailSequence()+1
-    int64_t sequence = rb->headSequence();
-    std::cout << *rb->readOne(sequence) << std::endl; //
+    auto sequence = rb->head_sequence().get();
+    std::cout << *rb->read_one<int>(sequence).get() << std::endl; //
     sequence++;
-    std::cout << *rb->readOne(sequence) << std::endl;
+    std::cout << *rb->read_one<int>(sequence).get() << std::endl;
 ```
-
-#### 7.4.7.1. Using ringbuffer Non-Blocking Async Methods
-
-Hazelcast ringbuffer provides asynchronous methods for more powerful operations like batched writing or batched reading with filtering.
-To make these methods synchronous, just call the method `get()` on the returned future.
-
-Please see the following example code.
-
-```C++
-    // add an item in an unblocking way
-    boost::shared_ptr<ICompletableFuture<int64_t> > future = rb->addAsync("new item",
-                                                                          hazelcast::client::ringbuffer<std::string>::OVERWRITE);
-
-    future->get();
-```
-
-However, you can also use `ICompletableFuture` to get notified when the operation has completed. The advantage of `ICompletableFuture` is that the thread used for the call is not blocked till the response is returned. The callback methods are called via the user executor threads.
-
-Please see the below code as an example of when you want to get notified when a batch of reads has completed.
-
-```
-    class ItemsPrinter : public ExecutionCallback<hazelcast::client::rb::read_result_set<std::string> > {
-    public:
-        virtual void onResponse(const boost::optional<rb::read_result_set<std::string> > &response) {
-            DataArray<std::string> &items = response->getItems();
-            for (size_t i = 0; i < items.size(); ++i) {
-                std::cout << "Received " << items.get(i) << std::endl;
-            }
-        }
-    
-        virtual void onFailure(const boost::shared_ptr<exception::iexception> &e) {
-            std::cout << "An error occured " << e << std::endl;
-        }
-    };
-
-    // -----
-    
-    boost::shared_ptr<ICompletableFuture<hazelcast::client::rb::read_result_set<std::string> > > f = rb->readManyAsync<ItemPrinter>(sequence, min, max, someFilter);
-    f->andThen(boost::shared_ptr<hazelcast::client::ExecutionCallback<hazelcast::client::rb::read_result_set<std::string> > >(new ItemsPrinter));
-
-```
-
 
 ### 7.4.8. Using Reliable Topic
 
@@ -1755,71 +1564,69 @@ Hazelcast `reliable_topic` is a distributed topic implementation backed up by th
 A Reliable Topic usage example is shown below.
 
 ```C++
-class MyListener : public hazelcast::client::topic::ReliableMessageListener<std::string> {
-public:
-    MyListener() : startSequence(-1), lastReceivedSequence(-1) {
-    }
+hazelcast::client::topic::reliable_listener make_listener(std::atomic<int> &n_received_messages, int64_t sequence_id = -1) {
+    using namespace hazelcast::client::topic;
 
-    MyListener(int64_t sequence) : startSequence(sequence), lastReceivedSequence(-1) {
-    }
+    return reliable_listener(false, sequence_id)
+        .on_received([&n_received_messages](message &&message){
+            ++n_received_messages;
 
-    virtual ~MyListener() {
-    }
+            auto object = message.get_message_object().get<std::string>();
+            if (object) {
+                std::cout << "[GenericListener::onMessage] Received message: " << *object << " for topic:" << message.get_name();
+            } else {
+                std::cout << "[GenericListener::onMessage] Received message with NULL object for topic:" <<
+                message.get_name();
+            }
+        });
+}
 
-    virtual void onMessage(std::auto_ptr<hazelcast::client::topic::message<std::string> > message) {
+void listen_with_default_config() {
+    hazelcast::client::hazelcast_client client;
 
-        const std::string *object = message->getMessageObject();
-        if (NULL != object) {
-            std::cout << "[GenericListener::onMessage] Received message: " << *message->getMessageObject() <<
-            " for topic:" << message->get_name();
-        } else {
-            std::cout << "[GenericListener::onMessage] Received message with NULL object for topic:" <<
-            message->get_name();
-        }
-    }
-
-    virtual int64_t retrieveInitialSequence() const {
-        return startSequence;
-    }
-
-    virtual void storeSequence(int64_t sequence) {
-        lastReceivedSequence = sequence;
-    }
-
-    virtual bool isLossTolerant() const {
-        return false;
-    }
-
-    virtual bool isTerminal(const hazelcast::client::exception::iexception &failure) const {
-        return false;
-    }
-    
-private:
-    int64_t startSequence;
-    int64_t lastReceivedSequence;
-};
-
-
-int main() {
-    
     std::string topicName("MyReliableTopic");
-    boost::shared_ptr<hazelcast::client::reliable_topic<std::string> > topic = client.getReliableTopic<std::string>(topicName);
-    
-    MyListener listener;
-    const std::string &listenerId = topic->add_message_listener(listener);
+    auto topic = client.get_reliable_topic(topicName);
+
+    std::atomic<int> numberOfMessagesReceived{0};
+    auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
 
     std::cout << "Registered the listener with listener id:" << listenerId << std::endl;
 
-    std::string message("My first message");
-    topic->publish(&message);
-    
-    if (topic->removeMessageListener(listenerId)) {
+    while (numberOfMessagesReceived < 1) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    if (topic->remove_message_listener(listenerId)) {
         std::cout << "Successfully removed the listener " << listenerId << " for topic " << topicName << std::endl;
     } else {
         std::cerr << "Failed to remove the listener " << listenerId << " for topic " << topicName << std::endl;
     }
-    
-    return 0;
+}
+
+void listen_with_config() {
+    hazelcast::client::client_config clientConfig;
+    std::string topicName("MyReliableTopic");
+    hazelcast::client::config::reliable_topic_config reliableTopicConfig(topicName.c_str());
+    reliableTopicConfig.set_read_batch_size(5);
+    clientConfig.add_reliable_topic_config(reliableTopicConfig);
+    hazelcast::client::hazelcast_client client(std::move(clientConfig));
+
+    auto topic = client.get_reliable_topic(topicName);
+
+    std::atomic<int> numberOfMessagesReceived{0};
+    auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
+
+    std::cout << "Registered the listener with listener id:" << listenerId << std::endl;
+
+    while (numberOfMessagesReceived < 1) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    if (topic->remove_message_listener(listenerId)) {
+        std::cout << "Successfully removed the listener " << listenerId << " for topic " << topicName << std::endl;
+    } else {
+        std::cerr << "Failed to remove the listener " << listenerId << " for topic " << topicName << std::endl;
+    }
 }
 ```
 
@@ -1830,17 +1637,19 @@ Hazelcast `pn_counter` (Positive-Negative Counter) is a CRDT positive-negative c
 A PN Counter usage example is shown below.
 
 ```C++
-    boost::shared_ptr<hazelcast::client::crdt::pncounter::pn_counter> pnCounter = hz.getPNCounter("pncounterexample");
+    hazelcast::client::hazelcast_client hz;
 
-    std::cout << "Counter started with value:" << pnCounter->get() << std::endl; // Counter started with value:0
+    auto pnCounter = hz.get_pn_counter("pncounterexample");
 
-    std::cout << "Counter new value after adding is: " << pnCounter->addAndGet(5) << std::endl; // Counter new value after adding is: 5
+    std::cout << "Counter started with value:" << pnCounter->get().get() << std::endl;
 
-    std::cout << "Counter new value before adding is: " << pnCounter->getAndAdd(2) << std::endl; // Counter new value before adding is: 5
+    std::cout << "Counter new value after adding is: " << pnCounter->add_and_get(5).get() << std::endl;
 
-    std::cout << "Counter new value is: " << pnCounter->get() << std::endl; // Counter new value is: 7
+    std::cout << "Counter new value before adding is: " << pnCounter->get_and_add(2).get() << std::endl;
 
-    std::cout << "Decremented counter by one to: " << pnCounter->decrementAndGet() << std::endl; // Decremented counter by one to: 6
+    std::cout << "Counter new value is: " << pnCounter->get().get() << std::endl;
+
+    std::cout << "Decremented counter by one to: " << pnCounter->decrement_and_get().get() << std::endl;
 ```
 
 ### 7.4.10 Using Flake ID Generator
@@ -1850,8 +1659,8 @@ Hazelcast `flake_id_generator` is used to generate cluster-wide unique identifie
 A Flake ID Generator usage example is shown below.
 
 ```C++
-    hazelcast::client::flake_id_generator generator = hz.get_flake_id_generator("flakeIdGenerator");
-    std::cout << "Id : " << generator.newId() << std::endl; // Id : <some unique number>
+    auto generator = hz.get_flake_id_generator("flakeIdGenerator");
+    std::cout << "Id : " << generator->newId().get() << std::endl; // Id : <some unique number>
 ```
 
 ### 7.4.11. CP Subsystem
@@ -2061,35 +1870,35 @@ You can create a `transaction_context` object using the C++ client to begin, com
 
 ```C++
                 // Create a Transaction object and begin the transaction
-                transaction_context context = client->newTransactionContext();
-                context.beginTransaction();
+                auto context = client->new_transaction_context();
+                context.begin_transaction().get();
 
                 // Get transactional distributed data structures
-                transactional_map<std::string, std::string> txnMap = context.get_map<std::string, std::string>("transactional-map");
-                transactional_multi_map<std::string, std::string> txnMultiMap = context.getMultiMap<std::string, std::string>("transactional-multimap");
-                transactional_queue<std::string> txnQueue = context.getQueue<std::string>("transactional-queue");
-                transactional_set<std::string> txnSet = context.getSet<std::string>("transactional-set");
+                auto txnMap = context.get_map("transactional-map");
+                auto txnmulti_map = context.get_multi_map("transactional-multimap");
+                auto txnQueue = context.get_queue("transactional-queue");
+                auto txnSet = context.get_set("transactional-set");
 
                 try {
-                    boost::shared_ptr<std::string> obj = txnQueue.poll();
+                    auto obj = txnQueue->poll<std::string>().get();
                     //process object
-                    txnMap.put( "1", "value1" );
-                    txnMultiMap.put("2", "value2_1");
-                    txnMultiMap.put("2", "value2_2");
-                    txnSet.add( "value" );
+                    txnMap->put<std::string, std::string>( "1", "value1" ).get();
+                    txnmulti_map->put<std::string, std::string>("2", "value2_1").get();
+                    txnmulti_map->put<std::string, std::string>("2", "value2_2").get();
+                    txnSet->add<std::string>( "value" ).get();
                     //do other things
 
                     // Commit the above changes done in the cluster.
-                    context.commitTransaction();
+                    context.commit_transaction().get();
                 } catch (...) {
-                    context.rollbackTransaction();
+                    context.rollback_transaction().get();
                     throw;
                 }
 ```
 
 In a transaction, operations will not be executed immediately. Their changes will be local to the `transaction_context` until committed. However, they will ensure the changes via locks.
 
-For the above example, when `map.put` is executed, no data will be put in the map but the key will be locked against changes. While committing, operations will be executed, the value will be put to the map and the key will be unlocked.
+For the above example, when `map->put` is executed, no data will be put in the map but the key will be locked against changes. While committing, operations will be executed, the value will be put to the map and the key will be unlocked.
 
 The isolation level in Hazelcast Transactions is `READ_COMMITTED` on the level of a single partition. If you are in a transaction, you can read the data in your transaction and the data that is already committed. If you are not in a transaction, you can only read the committed data.
 
@@ -2106,75 +1915,83 @@ You can add event listeners to a Hazelcast C++ client. You can configure the fol
 
 #### 7.5.1.1. Listening for Member Events
 
-You can listen the following types of member events in the `Cluster`.
+You can listen the following types of member events in the `cluster`.
 
-* `memberAdded`: A new member is added to the cluster.
-* `memberRemoved`: An existing member leaves the cluster.
+* `member_added`: A new member is added to the cluster.
+* `member_removed`: An existing member leaves the cluster.
 * `memberAttributeChanged`: An attribute of a member is changed. See the [Defining Member Attributes section](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#defining-member-attributes) in the Hazelcast IMDG Reference Manual to learn about member attributes.
 
-You can use `Cluster` (`hazelcast_client::getCluster()`) object to register for the membership listeners. There are two types of listeners: `InitialMembershipListener` and `membership_listener`. The difference is that `InitialMembershipListener` also gets notified when the client connects to the cluster and retrieves the whole membership list. You need to implement one of these two interfaces and register an instance of the listener to the cluster.
+You can use `cluster` (`hazelcast_client::hazelcast_client::get_cluster()`) object to register for the membership listeners. There are two types of listeners: `InitialMembershipListener` and `membership_listener`. The difference is that `InitialMembershipListener` also gets notified when the client connects to the cluster and retrieves the whole membership list. You need to implement one of these two interfaces and register an instance of the listener to the cluster.
 
 The following example demonstrates both initial and regular membership listener registrations.
 
 ```C++
-        class MyInitialMemberListener : public hazelcast::client::InitialMembershipListener {
-        public:
-            void init(const hazelcast::client::initial_membership_event &event) {
-                std::vector<hazelcast::client::Member> members = event.getMembers();
-                std::cout << "The following are the initial members in the cluster:" << std::endl;
-                for (std::vector<hazelcast::client::Member>::const_iterator it = members.begin(); it != members.end(); ++it) {
-                    std::cout << it->getaddress() << std::endl;
-                }
-            }
-        
-            void memberAdded(const hazelcast::client::membership_event &membershipEvent) {
-                std::cout << "[MyInitialMemberListener::memberAdded] New member joined:" <<
-                membershipEvent.getMember().getaddress() <<
-                std::endl;
-            }
-        
-            void memberRemoved(const hazelcast::client::membership_event &membershipEvent) {
-                std::cout << "[MyInitialMemberListener::memberRemoved] Member left:" <<
-                membershipEvent.getMember().getaddress() << std::endl;
-            }
-        
-            void memberAttributeChanged(const hazelcast::client::MemberAttributeEvent &memberAttributeEvent) {
-                std::cout << "[MyInitialMemberListener::memberAttributeChanged] Member attribute:" <<
-                memberAttributeEvent.getKey()
-                << " changed. Value:" << memberAttributeEvent.getValue() << " for member:" <<
-                memberAttributeEvent.getMember().getaddress() << std::endl;
-            }
-        };
-        
-        class MyMemberListener : public hazelcast::client::membership_listener {
-        public:
-            void memberAdded(const hazelcast::client::membership_event &membershipEvent) {
-                std::cout << "[MyMemberListener::memberAdded] New member joined:" << membershipEvent.getMember().getaddress() <<
-                std::endl;
-            }
-        
-            void memberRemoved(const hazelcast::client::membership_event &membershipEvent) {
-                std::cout << "[MyMemberListener::memberRemoved] Member left:" <<
-                membershipEvent.getMember().getaddress() << std::endl;
-            }
-        
-            void memberAttributeChanged(const hazelcast::client::MemberAttributeEvent &memberAttributeEvent) {
-                std::cout << "[MyMemberListener::memberAttributeChanged] Member attribute:" << memberAttributeEvent.getKey()
-                << " changed. Value:" << memberAttributeEvent.getValue() << " for member:" <<
-                memberAttributeEvent.getMember().getaddress() << std::endl;
-            }
-        };
+membership_listener make_membership_listener() {
+    return membership_listener()
+        .on_joined([](const hazelcast::client::membership_event &membership_event) {
+            std::cout << "New member joined: "
+                << membership_event.get_member().get_address() << std::endl;
+        })
+        .on_left([](const hazelcast::client::membership_event &membership_event) {
+            std::cout << "Member left: " 
+                << membership_event.get_member().get_address() << std::endl;
+        });
+}
 
-     int main() {
-        hazelcast::client::client_config config;
-        hazelcast::client::hazelcast_client hz(config);
-        
-        hz.getCluster().addMembershipListener(boost::shared_ptr<hazelcast::client::membership_listener>(new MyMemberListener()));
-        hz.getCluster().addMembershipListener(boost::shared_ptr<hazelcast::client::InitialMembershipListener>(new MyInitialMemberListener()));
+membership_listener make_initial_membership_listener() {
+    return membership_listener()
+        .on_init([](const hazelcast::client::initial_membership_event &event){
+            auto members = event.get_members();
+            std::cout << "The following are the initial members in the cluster:" << std::endl;
+            for (const auto &member : members) {
+                std::cout << member.get_address() << std::endl;
+            }
+        })
+        .on_joined([](const hazelcast::client::membership_event &membership_event) {
+            std::cout << "New member joined: " <<
+            membership_event.get_member().get_address() << std::endl;
+        })
+        .on_left([](const hazelcast::client::membership_event &membership_event) {
+            std::cout << "Member left: " <<
+            membership_event.get_member().get_address() << std::endl;
+        });
+}
+
+int main() {
+    auto memberListener = make_membership_listener();
+    auto initialMemberListener = make_initial_membership_listener();
+
+    hazelcast::client::cluster *clusterPtr = nullptr;
+    boost::uuids::uuid listenerId, initialListenerId;
+    try {
+        hazelcast::client::hazelcast_client hz;
+
+        hazelcast::client::cluster &cluster = hz.get_cluster();
+        clusterPtr = &cluster;
+        auto members = cluster.get_members();
+        std::cout << "The following are members in the cluster:" << std::endl;
+        for (const auto &member: members) {
+            std::cout << member.get_address() << std::endl;
+        }
+
+        listenerId = cluster.add_membership_listener(std::move(memberListener));
+        initialListenerId = cluster.add_membership_listener(std::move(initialMemberListener));
+
+        // sleep some time for the events to be delivered before exiting
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+
+        cluster.remove_membership_listener(listenerId).get();
+        cluster.remove_membership_listener(initialListenerId).get();
+    } catch (hazelcast::client::exception::iexception &e) {
+        std::cerr << "failed !!! " << e.what() << std::endl;
+        if (nullptr != clusterPtr) {
+            clusterPtr->remove_membership_listener(listenerId).get();
+            clusterPtr->remove_membership_listener(initialListenerId).get();
+        }
+        exit(-1);
+    }
         ...
 ```
-
-The `memberAttributeChanged` has its own type of event named as `MemberAttributeEvent`. When there is an attribute change on the member, this event is fired.
 
 #### 7.5.1.3. Listening for Lifecycle Events
 
@@ -2182,10 +1999,10 @@ The `lifecycle_listener` interface notifies for the following events:
 
 * `starting`: The client is starting.
 * `started`: The client has started.
-* `shuttingDown`: The client is shutting down.
+* `shutting_down`: The client is shutting down.
 * `shutdown`: The client’s shutdown has completed.
-* `clientConnected`: The client is connected to the cluster.
-* `clientDisconnected`: The client is disconnected from the cluster.
+* `client_connected`: The client is connected to the cluster.
+* `client_disconnected`: The client is disconnected from the cluster.
 
 The following is an example of the `lifecycle_listener` that is added to the `client_config` object and its output.
 
@@ -2202,14 +2019,19 @@ public:
 };
 
 int main() {
-    ConnectedListener listener;
-
     hazelcast::client::client_config config;
 
     // Add a lifecycle listener so that we can track when the client is connected/disconnected
-    config.addListener(&listener);
+    config.add_listener(
+        hazelcast::client::lifecycle_listener().
+            on_connected([](){
+                std::cout << "Client connected to the cluster" << std::endl;
+            }).on_disconnected([] () {
+                std::cout << "Client is disconnected from the cluster" << std::endl;                
+            });
+    );
 
-    hazelcast::client::hazelcast_client hz(config);
+    hazelcast::client::hazelcast_client hz(std::move(config));
 
     hz.shutdown();
     return 0;
@@ -2219,22 +2041,23 @@ int main() {
 **Output:**
 
 ```
-24/10/2018 13:54:06.392 INFO: [0x700006a44000] hz.client_1[dev] [3.10.2-SNAPSHOT] Trying to connect to Address[127.0.0.1:5701] as owner member
-24/10/2018 13:54:06.395 INFO: [0x7000069c1000] hz.client_1[dev] [3.10.2-SNAPSHOT] Setting ClientConnection{alive=1, connectionId=1, remoteEndpoint=Address[localhost:5701], lastReadTime=2018-10-24 10:54:06.394000, closedTime=never, connected server version=3.11-SNAPSHOT} as owner with principal uuid: 160e2baf-566b-4cc3-ab25-a1b3e34de320 ownerUuid: 7625eae9-4f8e-4285-82c0-be2f2eee2a50
-24/10/2018 13:54:06.395 INFO: [0x7000069c1000] hz.client_1[dev] [3.10.2-SNAPSHOT] Authenticated with server Address[localhost:5701], server version:3.11-SNAPSHOT Local address: Address[127.0.0.1:56007]
-24/10/2018 13:54:06.495 INFO: [0x700006cd3000] hz.client_1[dev] [3.10.2-SNAPSHOT] 
+20/11/2020 12:26:43.340 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:375] (Fri Nov 20 11:03:59 2020 +0300:f2326084c3) LifecycleService::LifecycleEvent Client (7add62a3-c6ec-4002-a9d8-79ed4639f8e9) is STARTING
+20/11/2020 12:26:43.343 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:379] (Fri Nov 20 11:03:59 2020 +0300:f2326084c3) LifecycleService::LifecycleEvent STARTING
+20/11/2020 12:26:43.343 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:387] LifecycleService::LifecycleEvent STARTED
+20/11/2020 12:26:43.398 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/network.cpp:587] Trying to connect to Address[127.0.0.1:5701]
+20/11/2020 12:26:43.409 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:411] LifecycleService::LifecycleEvent CLIENT_CONNECTED
+20/11/2020 12:26:43.410 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/network.cpp:637] Authenticated with server  Address[:5701]:8324bc53-8190-400c-bcbf-e582834a0542, server version: 4.1, local address: Address[127.0.0.1:63383]
+20/11/2020 12:26:43.412 INFO: [0x7000062b8000] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:881] 
 
-Members [2]  {
-	Member[localhost]:5702 - 44cf4017-5355-4859-9bf5-fd374d7fc69c
-	Member[localhost]:5701 - 7625eae9-4f8e-4285-82c0-be2f2eee2a50
+Members [1]  {
+	Member[localhost]:5701 - 8324bc53-8190-400c-bcbf-e582834a0542
 }
-
-24/10/2018 13:54:06.600 INFO: [0x700006a44000] hz.client_1[dev] [3.10.2-SNAPSHOT] lifecycle_service::lifecycle_event CLIENT_CONNECTED
 Client connected to the cluster
-24/10/2018 13:54:12.269 INFO: [0x7fff97559340] hz.client_1[dev] [3.10.2-SNAPSHOT] lifecycle_service::lifecycle_event SHUTTING_DOWN
-24/10/2018 13:54:12.270 INFO: [0x7fff97559340] hz.client_1[dev] [3.10.2-SNAPSHOT] Removed connection to endpoint: Address[localhost:5701], connection: ClientConnection{alive=0, connectionId=1, remoteEndpoint=Address[localhost:5701], lastReadTime=2018-10-24 10:54:06.711000, closedTime=2018-10-24 10:54:12.269000, connected server version=3.11-SNAPSHOT}
+20/11/2020 12:26:48.700 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:395] LifecycleService::LifecycleEvent SHUTTING_DOWN
+20/11/2020 12:26:48.701 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/network.cpp:545] Removed connection to endpoint: Address[localhost:5701], connection: ClientConnection{alive=0, connectionId=1, remoteEndpoint=Address[localhost:5701], lastReadTime=2020-11-20 12:26:43.-286, closedTime=2020-11-20 12:26:48.000, connected server version=4.1}
+20/11/2020 12:26:48.701 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:419] LifecycleService::LifecycleEvent CLIENT_DISCONNECTED
 Client is disconnected from the cluster
-24/10/2018 13:54:12.268 INFO: [0x7fff97559340] hz.client_1[dev] [3.10.2-SNAPSHOT] lifecycle_service::lifecycle_event SHUTDOWN
+20/11/2020 12:26:48.703 INFO: [0x11a0acdc0] hz.client_1[dev] [4.0-SNAPSHOT] [../hazelcast/src/hazelcast/client/spi.cpp:403] LifecycleService::LifecycleEvent SHUTDOWN
 ```
 
 ### 7.5.2. Distributed Data Structure Events
@@ -2245,7 +2068,7 @@ You can add event listeners to the distributed data structures.
 
 You can listen to map-wide or entry-based events by registering an instance of the `entry_listener` class. You should provide the `entry_listener` instance with function objects for each type of event you want to listen to and then use `imap::add_entry_listener` to register it.
 
-An entry-based event is fired after operations that affect a specific entry. For example, `imap::put()`, `imap::remove()` or `imap::evict()`. The corresponding function that you provided to the listener will be called with an `EntryEvent` when an entry-based event occurs.
+An entry-based event is fired after operations that affect a specific entry. For example, `imap::put()`, `imap::remove()` or `imap::evict()`. The corresponding function that you provided to the listener will be called with an `entry_event` when an entry-based event occurs.
 
 See the following example.
 
@@ -2255,7 +2078,7 @@ int main() {
 
     auto map = hz.get_map("EntryListenerExampleMap");
 
-    auto registrationId = map.add_entry_listener(
+    auto registrationId = map->add_entry_listener(
         entry_listener().
             on_added([](hazelcast::client::EntryEvent &&event) {
                 std::cout << "Entry added:" << event.getKey().get<int>().value() 
@@ -2267,8 +2090,8 @@ int main() {
             })
         , true).get();
     
-    map.put(1, "My new entry").get();
-    map.remove<int, std::string>(1).get();
+    map->put(1, "My new entry").get();
+    map->remove<int, std::string>(1).get();
     
     /* ... */
 
@@ -2276,7 +2099,7 @@ int main() {
 }
 ```
 
-A map-wide event is fired as a result of a map-wide operation (e.g.: `imap::clear()`, `imap::evictAll()`) which can also be listened to via an `entry_listener`. The functions you provided to the listener will be called with a `map_event` when a map-wide event occurs.
+A map-wide event is fired as a result of a map-wide operation (e.g.: `imap::clear()`, `imap::evict_all()`) which can also be listened to via an `entry_listener`. The functions you provided to the listener will be called with a `map_event` when a map-wide event occurs.
 
 See the example below.
 
@@ -2286,17 +2109,17 @@ int main() {
 
     auto map = hz.get_map("EntryListenerExampleMap");
 
-    auto registrationId = map.add_entry_listener(
+    auto registrationId = map->add_entry_listener(
         entry_listener().
             on_map_cleared([](hazelcast::client::map_event &&event) {
                 std::cout << "Map cleared:" << event.getNumberOfEntriesAffected() << std::endl; // Map Cleared: 3
             })    
         , false).get();
 
-    map.put(1, "Mali").get();
-    map.put(2, "Ahmet").get();
-    map.put(3, "Furkan").get();
-    map.clear().get();
+    map->put(1, "Mali").get();
+    map->put(2, "Ahmet").get();
+    map->put(3, "Furkan").get();
+    map->clear().get();
 
     /* ... */
 
@@ -2311,7 +2134,7 @@ This section describes how Hazelcast IMDG's distributed executor service and ent
 ### 7.6.1. Distributed Executor Service
 Hazelcast C++ client allows you to asynchronously execute your tasks (logical units of work) in the cluster, such as database queries, complex calculations and image rendering.
 
-With `iexecutor_service`, you can execute tasks asynchronously and perform other useful tasks. If your task execution takes longer than expected, you can cancel the task execution. Tasks should be `Hazelcast Serializable`, i.e., `IdentifiedDataSerializable`, `Portable`, `Custom`, since they will be distributed in the cluster.
+With `iexecutor_service`, you can execute tasks asynchronously and perform other useful tasks. If your task execution takes longer than expected, you can cancel the task execution. Tasks should be Hazelcast serializable, since they will be distributed in the cluster.
 
 You need to implement the actual task logic at the server side as a Java code. The task should implement Java's `java.util.concurrent.Callable` interface.
 
@@ -2321,41 +2144,50 @@ For more information on the server side configuration, see the [Executor Service
 
 #### 7.6.1.1 Implementing a Callable Task
 
-You implement a C++ class which is `Hazelcast Serializable`. This is the task class to be run on the server side. The client side implementation does not need to have any logic, it is purely for initiating the server side task.
+You implement a C++ class which is hazelcast serializable. This is the task class to be run on the server side. The client side implementation does not need to have any logic, it is purely for initiating the server side task.
 
 On the server side, when you implement the task as `java.util.concurrent.Callable` (a task that returns a value), implement one of the Hazelcast serialization methods for the new class. The serialization type needs to match with that of the client side task class.
 
 An example C++ task class implementation is shown below.
 
 ```C++
-class MessagePrinter : public serialization::IdentifiedDataSerializable {
-public:
-    MessagePrinter(const std::string &message) : message(message) {}
-
-    virtual int getFactoryId() const {
-        return 1;
-    }
-
-    virtual int getClassId() const {
-        return 555;
-    }
-
-    virtual void writeData(serialization::object_data_output &writer) const {
-        writer.writeUTF(&message);
-    }
-
-    virtual void readData(serialization::object_data_input &reader) {
-        // no need to implement since it will not be read by the client in our example
-    }
-
-private:
+struct MessagePrinter {
     std::string message;
 };
+
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<MessagePrinter> : identified_data_serializer {
+                static int32_t get_factory_id() noexcept {
+                    return 1;
+                }
+
+                static int32_t get_class_id() noexcept {
+                    return 555;
+                }
+
+                static void
+                write_data(const MessagePrinter &object, hazelcast::client::serialization::object_data_output &out) {
+                    out.write(object.message);
+                }
+
+                static MessagePrinter read_data(hazelcast::client::serialization::object_data_input &in) {
+                    return MessagePrinter{in.read<std::string>()};
+                }
+            };
+        }
+    }
+}
 ```
 
 An example of a Callable Java task which matches the above C++ class is shown below. `MessagePrinter` prints out the message sent from the C++ client at the cluster members.
 
 ```Java
+// The Java server side example MessagePrinter implementation looks like the following (Please observe that Java class
+// should implement the Callable and the IdentifiedDataSerializable interfaces):
+//
 public class MessagePrinter implements IdentifiedDataSerializable, Callable<String> {
     private String message;
 
@@ -2386,8 +2218,7 @@ public class MessagePrinter implements IdentifiedDataSerializable, Callable<Stri
     }
 
     @Override
-    public String call()
-            throws Exception {
+    public String call() throws Exception {
         System.out.println(message);
         return message;
     }
@@ -2401,23 +2232,22 @@ You need to compile and link the Java class on the server side (add it to the se
 To execute a callable task:
 
 * Retrieve the executor from `hazelcast_client`.
-* Submit a task which returns a `boost::shared_ptr<ICompletableFuture<T> >`.
+* Submit a task which returns a `future`.
 * After executing the task, you do not have to wait for the execution to complete, you can process other things.
-* When ready, use the `ICompletableFuture<T>` object to retrieve the result as shown in the code example below.
+* When ready, use the `future` object to retrieve the result as shown in the code example below.
 
 An example where `MessagePrinter` task is executed is shown below.
 
 ```C++
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-    client_config clientConfig;
-    hazelcast_client hz(clientConfig);
+    hazelcast_client hz;
     // Get the Distributed Executor Service
-    boost::shared_ptr<iexecutor_service> ex = hz.getExecutorService("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
     // Submit the MessagePrinter Runnable to a random Hazelcast Cluster Member
-    boost::shared_ptr<ICompletableFuture<std::string> > future = ex->submit<MessagePrinter, std::string>(MessagePrinter("message to any node"));
+    auto result_future = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"});
     // Wait for the result of the submitted task and print the result
-    boost::shared_ptr<std::string> result = future->get();
-    std::cout << "Server retuned result: " << *result << std::endl;
+    auto result = result_future.get_future().get();
+    std::cout << "Server result: " << *result << std::endl;
 ```
 
 #### 7.6.1.3 Scaling The Executor Service
@@ -2428,102 +2258,89 @@ You can scale the Executor service both vertically (scale up) and horizontally (
 
 The distributed executor service allows you to execute your code in the cluster. In this section, the code examples are based on the `MessagePrinter` class above. The code examples show how Hazelcast can execute your code:
 
-* `printOnTheMember`: On a specific cluster member you choose with the `iexecutor_service::submitToMember` method.
-* `printOnTheMemberOwningTheKey`: On the member owning the key you choose with the `iexecutor_service::submitToKeyOwner` method.
+* `printOnTheMember`: On a specific cluster member you choose with the `iexecutor_service::submit_to_member` method.
+* `printOnTheMemberOwningTheKey`: On the member owning the key you choose with the `iexecutor_service::submit_to_key_owner` method.
 * `printOnSomewhere`: On the member Hazelcast picks with the `iexecutor_service::submit` method.
-* `printOnMembers`: On all or a subset of the cluster members with the `iexecutor_service::submitToMembers` method.
+* `printOnMembers`: On all or a subset of the cluster members with the `iexecutor_service::submit_to_members` method.
 
 ```C++
 void printOnTheMember(const std::string &input, const Member &member) {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-    client_config clientConfig;
-    hazelcast_client hz(clientConfig);
-
+    hazelcast_client hz;
     // Get the Distributed Executor Service
-    boost::shared_ptr<iexecutor_service> ex = hz.getExecutorService("my-distributed-executor");
-    // Submit the MessagePrinter to a the provided Hazelcast Member
-    boost::shared_ptr<ICompletableFuture<std::string> > future = ex->submitToMember<MessagePrinter, std::string>(
-            MessagePrinter(input), member);
-
-    boost::shared_ptr<std::string> taskResult = future->get();
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    // Get the first Hazelcast Cluster Member
+    member firstMember = hz.get_cluster().get_members()[0];
+    // Submit the MessagePrinter Runnable to the first Hazelcast Cluster Member
+    ex->execute_on_member<MessagePrinter>(MessagePrinter{"message to very first member of the cluster"}, firstMember).get();
 ```
 
 ```C++
 void printOnTheMemberOwningTheKey(const std::string &input, const std::string &key) {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-    client_config clientConfig;
-    hazelcast_client hz(clientConfig);
-
+    hazelcast_client hz;
     // Get the Distributed Executor Service
-    boost::shared_ptr<iexecutor_service> ex = hz.getExecutorService("my-distributed-executor");
-    // Submit the MessagePrinter to the cluster member owning the key
-    boost::shared_ptr<ICompletableFuture<std::string> > future = ex->submitToKeyOwner<MessagePrinter, std::string, std::string>(
-            MessagePrinter(input), key);
-
-    boost::shared_ptr<std::string> taskResult = future->get();
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    // Submit the MessagePrinter Runnable to the Hazelcast Cluster Member owning the key called "key"
+    ex->execute_on_key_owner<MessagePrinter, std::string>(
+            MessagePrinter{"message to the member that owns the key"}, "key").get();
 }
 ```
 
 ```C++
 void printOnSomewhere(const std::string &input) {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-    client_config clientConfig;
-    hazelcast_client hz(clientConfig);
-
+    hazelcast_client hz;
     // Get the Distributed Executor Service
-    boost::shared_ptr<iexecutor_service> ex = hz.getExecutorService("my-distributed-executor");
-    // Submit the MessagePrinter to the cluster member owning the key
-    boost::shared_ptr<ICompletableFuture<std::string> > future = ex->submit<MessagePrinter, std::string>(
-            MessagePrinter(input));
-
-    boost::shared_ptr<std::string> taskResult = future->get();
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    // Submit the MessagePrinter Runnable to a random Hazelcast Cluster Member
+    auto result_future = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"}).get();
 }
 ```
 
 ```C++
 void printOnMembers(const std::string input, const std::vector<Member> &members) {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
-    client_config clientConfig;
-    hazelcast_client hz(clientConfig);
-
+    hazelcast_client hz;
     // Get the Distributed Executor Service
-    boost::shared_ptr<iexecutor_service> ex = hz.getExecutorService("my-distributed-executor");
-    // Submit the MessagePrinter to the cluster member owning the key
-    std::map<Member, boost::shared_ptr<ICompletableFuture<std::string> > > futures = ex->submitToMembers<MessagePrinter, std::string>(
-            MessagePrinter(input), members);
-
-    for (std::map<Member, boost::shared_ptr<ICompletableFuture<std::string> > >::const_iterator it=futures.begin();it != futures.end(); ++it) {
-        boost::shared_ptr<std::string> result = it->second->get();
-        std::cout << "Result for member " << it->first << " is " << *result << std::endl;
-        // ...
-    }
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    ex->execute_on_members<MessagePrinter>(MessagePrinter{"message to very first member of the cluster"}, members);
 }
 ```
 
-**NOTE:** You can obtain the set of cluster members via the `hazelcast_client::getCluster()::getMembers()` call.
+**NOTE:** You can obtain the list of cluster members via the `hazelcast_client::get_cluster()::get_bembers()` call.
 
 #### 7.6.1.5 Canceling an Executing Task
 A task in the code that you execute in a cluster might take longer than expected. If you cannot stop/cancel that task, it will keep eating your resources.
 
-To cancel a task, you can use the `ICompletableFuture<T>::cancel()` API. This API encourages us to code and design for cancellations, a highly ignored part of software development.
+To cancel a task, you can use the `executor_promise<T>::cancel()` API. This API lets you to code and design for cancellations, a highly ignored part of software development. Please keep in mind that if the execution already started or finished, the API may not be able to cancel the task. 
 
 #### 7.6.1.5.1 Example Task to Cancel
 The following code waits for the task to be completed in 3 seconds. If it is not finished within this period, a `timeout` is thrown from the `get()` method, and we cancel the task with the `cancel()` method. The remote execution of the task is being cancelled.
 
 ```
-    try {
-        future->get(3, TimeUnit::SECONDS());
-    } catch (exception::timeout &e) {
-        future->cancel(true);
-    }
+                auto service = client->get_executor_service(get_test_name());
+
+                executor::tasks::CancellationAwareTask task{INT64_MAX};
+
+                auto promise = service->submit<executor::tasks::CancellationAwareTask, bool>(task);
+
+                auto future = promise.get_future();
+                if (future.wait_for(boost::chrono::seconds(3) == boost::future_status::timeout) {
+                    std::cout << "Could not get response back in 3 seconds\n";
+                }
+
+                if (promise.cancel(true)) {
+                    std::cout << "Cancelled the submitted task\n";
+                }
 ```
 
 #### 7.6.1.6 Callback When Task Completes
 
-You can use the `ExecutionCallback` interface offered by Hazelcast to asynchronously be notified when the execution is done.
+You can use the `execution_callback` interface offered by Hazelcast to asynchronously be notified when the execution is done.
 
-* To be notified when your task completes without an error, implement the `onResponse` method.
-* To be notified when your task completes with an error, implement the `onFailure` method.
+* To be notified when your task completes without an error, implement the `on_response` method.
+* To be notified when your task completes with an error, implement the `on_failure` method.
 
 #### 7.6.1.6.1 Example Task to Callback
 
@@ -2537,14 +2354,19 @@ The example code below submits the `MessagePrinter` task to `PrinterCallback` an
 The `PrinterCallback` implementation class is as below:
 
 ```C++
-class PrinterCallback : public ExecutionCallback<std::string> {
+class PrinterCallback : public execution_callback<std::string> {
 public:
-    virtual void onResponse(const boost::optional<std::string> &response) {
-        std::cout << "The execution of the task is completed successfully and server returned:" << *response << std::endl;
+    void on_response(const boost::optional<std::string> &response) override {
+        std::cout << "The execution of the task is completed successfully and server returned:" << *response
+                  << std::endl;
     }
 
-    virtual void onFailure(const std::shared_ptr<exception::iexception> &e) {
-        std::cout << "The execution of the task failed with exception:" << e << std::endl;
+    void on_failure(std::exception_ptr e) override {
+        try {
+            std::rethrow_exception(e);
+        } catch (hazelcast::client::exception::iexception &e) {
+            std::cout << "The execution of the task failed with exception:" << e << std::endl;
+        }
     }
 };
 ```
@@ -2559,19 +2381,15 @@ The `bool select(const Member &member)` method is called for every available mem
 In the simple example shown below, we select the cluster members based on the presence of an attribute.
 
 ```C++
-class MyMemberSelector : public hazelcast::client::member_selector {
+class MyMemberSelector : public member_selector {
 public:
-    bool select(const Member &member) const override {
-        auto attribute = member.get_attribute("my.special.executor");
-        if (!attribute) {
+    bool select(const member &member) const override {
+        const std::string *attribute = member.get_attribute("my.special.executor");
+        if (attribute == NULL) {
             return false;
         }
 
         return *attribute == "true";
-    }
-
-    void to_string(std::ostream &os) const override {
-        os << "MyMemberSelector";
     }
 };
 ```
@@ -2579,14 +2397,16 @@ public:
 You can now submit your task using this selector and the task will run on the member whose attribute key "my.special.executor" is set to "true". An example is shown below:
 
 ```
-ex->submit<MessagePrinter, std::string>(MessagePrinter(input), MyMemberSelector());
+    // Choose which member to submit the task to using a member selector
+    ex->submit<MessagePrinter, std::string>(MessagePrinter{"Message when using the member selector"},
+                                            MyMemberSelector());
 ```
 
-### 7.6.2. Using EntryProcessor
+### 7.6.2. Using entry_processor
 
 Hazelcast supports entry processing. An entry processor is a function that executes your code on a map entry in an atomic way.
 
-An entry processor is a good option if you perform bulk processing on an `imap`. Usually you perform a loop of keys -- executing `imap.get(key)`, mutating the value and finally putting the entry back in the map using `imap.put(key,value)`. If you perform this process from a client or from a member where the keys do not exist, you effectively perform two network hops for each update: the first to retrieve the data and the second to update the mutated value.
+An entry processor is a good option if you perform bulk processing on an `imap`. Usually you perform a loop of keys -- executing `imap->get(key)`, mutating the value and finally putting the entry back in the map using `imap->put(key,value)`. If you perform this process from a client or from a member where the keys do not exist, you effectively perform two network hops for each update: the first to retrieve the data and the second to update the mutated value.
 
 If you are doing the process described above, you should consider using entry processors. An entry processor executes a read and updates upon the member where the data resides. This eliminates the costly network hops described above.
 
@@ -2598,83 +2418,83 @@ Hazelcast sends the entry processor to each cluster member and these members app
 
 The `imap` interface provides the following functions for entry processing:
 
-* `executeOnKey` processes an entry mapped by a key.
-* `executeOnKeys` processes entries mapped by a list of keys.
-* `executeOnEntries` can process all entries in a map with a defined predicate. predicate is optional.
+* `execute_on_key` processes an entry mapped by a key.
+* `execute_on_keys` processes entries mapped by a list of keys.
+* `execute_on_entries` can process all entries in a map with a defined predicate. predicate is optional.
 
-In the C++ client, an `EntryProcessor` should be `IdentifiedDataSerializable`, `Portable` or custom serializable, because the server should be able to deserialize it to process.
+In the C++ client, an `entry_processor` should be Hazelcast serializable, because the server should be able to deserialize it to process.
 
-The following is an example for `EntryProcessor` which is `IdentifiedDataSerializable`.
+The following is an example for `entry_processor` which is serialized by `identified_data_serializer`.
 
 ```C++
-class ExampleEntryProcessor : public hazelcast::client::serialization::IdentifiedDataSerializable {
-public:
-    ExampleEntryProcessor() {}
-
-    ExampleEntryProcessor(const std::string &value) : value(value) {}
-
-    int getFactoryId() const {
-        return 5;
-    }
-
-    int getClassId() const {
-        return 1;
-    }
-
-    void writeData(hazelcast::client::serialization::object_data_output &writer) const {
-        writer.writeUTF(&value);
-    }
-
-    void readData(hazelcast::client::serialization::object_data_input &reader) {
-        value = *reader.readUTF();
-    }
-    
-private:
-    std::string value;
+struct IdentifiedEntryProcessor {
+    std::string name;
 };
-```
+
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<IdentifiedEntryProcessor> : identified_data_serializer {
+                static int32_t get_factory_id() noexcept {
+                    return 66;
+                }
+
+                static int32_t get_class_id() noexcept {
+                    return 1;
+                }
+
+                static void
+                write_data(const IdentifiedEntryProcessor &object, hazelcast::client::serialization::object_data_output &out) {
+                    out.write(object.name);
+                }
+
+                static IdentifiedEntryProcessor read_data(hazelcast::client::serialization::object_data_input &in) {
+                    // no-need to implement here, since we do not expect to receive this object but we only send it to server
+                    assert(0);
+                    return IdentifiedEntryProcessor{};
+                }
+            };
+        }
+    }
+}```
 
 Now, you need to make sure that the Hazelcast member recognizes the entry processor. For this, you need to implement the Java equivalent of your entry processor and its factory, and create your own compiled class or JAR files. For adding your own compiled class or JAR files to the server's `CLASSPATH`, see the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
 The following is the Java equivalent of the entry processor in C++ client given above:
 
 ```java
-import com.hazelcast.map.AbstractEntryProcessor;
-import com.hazelcast.nio.object_data_input;
-import com.hazelcast.nio.object_data_output;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import java.io.io;
-import java.util.Map;
+public class IdentifiedEntryProcessor implements EntryProcessor<String, String, String>, IdentifiedDataSerializable {
 
-public class IdentifiedEntryProcessor extends AbstractEntryProcessor<String, String> implements IdentifiedDataSerializable {
-     static final int CLASS_ID = 1;
-     private String value;
-     
+    static final int CLASS_ID = 1;
+
+    private String value;
+
     public IdentifiedEntryProcessor() {
     }
-    
-     @Override
+
+    @Override
     public int getFactoryId() {
         return IdentifiedFactory.FACTORY_ID;
     }
-    
-     @Override
-    public int getId() {
+
+    @Override
+    public int getClassId() {
         return CLASS_ID;
     }
-    
-     @Override
-    public void writeData(object_data_output out) throws io {
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(value);
     }
-    
-     @Override
-    public void readData(object_data_input in) throws io {
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
         value = in.readUTF();
     }
-    
-     @Override
-    public Object process(Map.Entry<String, String> entry) {
+
+    @Override
+    public String process(Map.Entry<String, String> entry) {
         entry.setValue(value);
         return value;
     }
@@ -2684,20 +2504,17 @@ public class IdentifiedEntryProcessor extends AbstractEntryProcessor<String, Str
 You can implement the above processor’s factory as follows:
 
 ```java
-import com.hazelcast.nio.serialization.DataSerializableFactory;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-
 public class IdentifiedFactory implements DataSerializableFactory {
-    public static final int FACTORY_ID = 5;
-    
-     @Override
+    public static final int FACTORY_ID = 66;
+
+    @Override
     public IdentifiedDataSerializable create(int typeId) {
         if (typeId == IdentifiedEntryProcessor.CLASS_ID) {
             return new IdentifiedEntryProcessor();
         }
+        ...
         return null;
-    }
-}
+    }   
 ```
 
 Now you need to configure the `hazelcast.xml` to add your factory as shown below.
@@ -2706,8 +2523,8 @@ Now you need to configure the `hazelcast.xml` to add your factory as shown below
 <hazelcast>
     <serialization>
         <data-serializable-factories>
-            <data-serializable-factory factory-id="5">
-                IdentifiedFactory
+            <data-serializable-factory factory-id="66">
+                com.hazelcast.client.test.IdentifiedFactory
             </data-serializable-factory>
         </data-serializable-factories>
     </serialization>
@@ -2719,9 +2536,9 @@ The code that runs on the entries is implemented in Java on the server side. The
 After the above implementations and configuration are done and you start the server where your library is added to its `CLASSPATH`, you can use the entry processor in the `imap` functions. See the following example.
 
 ```C++
-    hazelcast::client::imap<std::string, std::string> map = hz.get_map<std::string, std::string>("my-distributed-map");
-    map.executeOnKey<std::string, ExampleEntryProcessor>("key", ExampleEntryProcessor("my new name"));
-    std::cout << "Value for 'key' is : '" << *map.get("key") << "'" << std::endl; // value for 'key' is 'my new name'
+    auto map = hz.get_map("my-distributed-map");
+    map->execute_on_key<std::string, IdentifiedEntryProcessor>("key", IdentifiedEntryProcessor("my new name"));
+    std::cout << "Value for 'key' is : '" << *map->get<std::string, std::string>("key").get() << "'" << std::endl; // value for 'key' is 'my new name'
 ```
 
 ## 7.7. Distributed Query
@@ -2732,7 +2549,7 @@ Hazelcast partitions your data and spreads it across cluster of members. You can
 
 1. The requested predicate is sent to each member in the cluster.
 2. Each member looks at its own local entries and filters them according to the predicate. At this stage, key-value pairs of the entries are deserialized and then passed to the predicate.
-3. The predicate requester merges all the results coming from each member into a single set.
+3. The predicate requester merges all the results coming from each member into a single set->
 
 Distributed query is highly scalable. If you add new members to the cluster, the partition count for each member is reduced and thus the time spent by each member on iterating its entries is reduced. In addition, the pool of partition threads evaluates the entries concurrently in each member, and the network traffic is also reduced since only filtered data is sent to the requester.
 
@@ -2762,78 +2579,95 @@ Hazelcast offers the following ways for distributed query purposes:
 * Combining predicates with `and_predicate`, `or_predicate` and `not_predicate`
 * Distributed SQL Query
 
-#### 7.7.1.1. Employee Map Query Example
+#### 7.7.1.1. person Map Query Example
 
-Assume that you have an `employee` map containing the values of `Employee` objects, as coded below. 
+Assume that you have an `person` map containing the values of `person` objects, as coded below. 
 
 ```C++
-class Employee : public serialization::Portable {
-public:
-    static const int TYPE_ID = 100;
+struct person {
+    friend std::ostream &operator<<(std::ostream &os, const person &person);
 
-    Employee() : active(false), salary(0.0) {}
-
-    Employee(int32_t id, const std::string &name, bool active, double salary) : id(id), name(name), active(active),
-                                                                            salary(salary) {}
-
-    virtual int getFactoryId() const {
-        return 1000;
-    }
-
-    virtual int getClassId() const {
-        return TYPE_ID;
-    }
-
-    virtual void writePortable(serialization::portable_writer &writer) const {
-        writer.writeInt(id);
-        writer.writeUTF(&name);
-        writer.writeBoolean(active);
-        writer.writeDouble(salary);
-    }
-
-    virtual void read_portable(serialization::portable_reader &reader) {
-        id = reader.readInt();
-        name = *reader.readUTF();
-        active = reader.readBoolean();
-        salary = reader.readDouble();
-    }
-
-private:
-    int32_t id;
     std::string name;
-    bool active;
-    double salary;
+    bool male;
+    int32_t age;
 };
+
+std::ostream &operator<<(std::ostream &os, const person &obj) {
+    os << "name: " << obj.name << " male: " << obj.male << " age: " << obj.age;
+    return os;
+}
+
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<person> : portable_serializer {
+                static int32_t get_factory_id() noexcept {
+                    return 1;
+                }
+
+                static int32_t get_class_id() noexcept {
+                    return 3;
+                }
+
+                static void write_data(const person &object, hazelcast::client::serialization::portable_writer &out) {
+                    out.write(object.name);
+                    out.write(object.male);
+                    out.write(object.age);
+                }
+
+                static person read_data(hazelcast::client::serialization::portable_reader &in) {
+                    return person{in.read<std::string>(), in.read<bool>(), in.read<int32_t>()};
+                }
+            };
+        }
+    }
+}
 ```
 
-Note that `Employee` is implementing `Portable`. As portable types are not deserialized on the server side for querying, you don't need to implement its Java equivalent on the server side for querying.
+Note that `person` is being serialized with portable_serializer`. As portable types are not deserialized on the server side for querying, you don't need to implement its Java equivalent on the server side for querying.
 
 For the non-portable types, you need to implement its Java equivalent and its serializable factory on the server side for server to reconstitute the objects from binary formats. 
-In this case before starting the server, you need to compile the `Employee` and related factory classes with server's `CLASSPATH` and add them to the `user-lib` directory in the extracted `hazelcast-<version>.zip` (or `tar`). See the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
+In this case before starting the server, you need to compile the `person` and related factory classes with server's `CLASSPATH` and add them to the `user-lib` directory in the extracted `hazelcast-<version>.zip` (or `tar`). See the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
-> **NOTE: Querying with `Portable` object is faster as compared to `IdentifiedDataSerializable`.**
+> **NOTE: Querying with `portable_serializer` is faster as compared to `identified_data_serializer` .**
 
-#### 7.7.1.2. Querying by Combining Predicates with AND, OR, NOT
+#### 7.7.1.2. Querying by Combining Predicates with AND, OR
 
 You can combine predicates by using the `and_predicate`, `or_predicate` and `not_predicate` operators, as shown in the below example.
 
 ```C++
-    query::and_predicate andPredicate;
-    andPredicate.add(std::auto_ptr<query::predicate>(new query::equal_predicate<bool>("active", true))).add(std::auto_ptr<query::predicate>(new query::greater_less_predicate<int>("age", 30, false, true)));
-    std::vector<Employee> activeEmployeesLessThan30 = employees.values(andPredicate);
+    // and_predicate
+    // 5 <= key <= 10 AND Values in {4, 10, 19} = values {4, 10}
+    std::vector<int> inVals{4, 10, 19};
+    values = intMap->values<int>(query::and_predicate(client,
+                                                      query::between_predicate(client,
+                                                                              query::query_constants::KEY_ATTRIBUTE_NAME,
+                                                                              5, 10),
+                                                      query::in_predicate(client,
+                                                                         query::query_constants::THIS_ATTRIBUTE_NAME,
+                                                                         inVals))).get();
+
+    // 5 <= key <= 10 OR Values in {4, 10, 19} = values {4, 10, 12, 14, 16, 18, 20}
+    values = intMap->values<int>(query::or_predicate(client,
+                                                     query::between_predicate(client,
+                                                                             query::query_constants::KEY_ATTRIBUTE_NAME,
+                                                                             5, 10),
+                                                     query::in_predicate(client,
+                                                                        query::query_constants::THIS_ATTRIBUTE_NAME,
+                                                                        inVals))).get();
 ```
-
-In the above example code, `predicate` verifies whether the entry is active and its `age` value is less than 30. This `predicate` is applied to the `employee` map using the `imap::values(const query::predicate &predicate)` method. This method sends the predicate to all cluster members and merges the results coming from them. 
-
-> **NOTE: Predicates can also be applied to `keySet` and `entry_set` of the Hazelcast IMDG's distributed map.**
+See examples/distributed-map/query folder for more examples.
 
 #### 7.7.1.3. Querying with SQL
 
 `sql_predicate` takes the regular SQL `where` clause. See the following example:
 
 ```C++
-    query::sql_predicate sqlPredicate("active AND age < 30");
-    std::vector<Employee> activeEmployeesLessThan30 = employees.values(sqlPredicate);
+    // sql_predicate
+    // __key BETWEEN 4 and 7 : {4, 5, 6, 7} -> {8, 10, 12, 14}
+    auto sql = (boost::format("%1% BETWEEN 4 and 7") % query::query_constants::KEY_ATTRIBUTE_NAME).str();
+    values = intMap->values<int>(query::sql_predicate(client, sql)).get();
 ```
 
 ##### Supported SQL Syntax
@@ -2885,29 +2719,29 @@ ILIKE is similar to the LIKE predicate but in a case-insensitive manner.
 
 ##### Querying Examples with Predicates
 
-You can use the `query::QueryConstants::KEY_ATTRIBUTE_NAME` (`__key`) attribute to perform a predicated search for entry keys. See the following example:
+You can use the `query::query_constants::KEY_ATTRIBUTE_NAME` (`__key`) attribute to perform a predicated search for entry keys. See the following example:
 
 ```C++
-    hazelcast::client::imap<std::string, int> map = hz.get_map<std::string, int>("personMap;");
-    map.put("Mali", 28);
-    map.put("Ahmet", 30);
-    map.put("Furkan", 23);
+    auto map = hz.get_map("personMap;");
+    map->put<std::string, int>("Mali", 28).get();
+    map->put<std::string, int>("Ahmet", 30).get();
+    map->put<std::string, int>("Furkan", 23).get();
     query::sql_predicate sqlPredicate("__key like F%");
-    std::vector<std::pair<std::string, int> > startingWithF = map.entry_set(sqlPredicate);
+    auto startingWithF = map->entry_set<std::string, int>(sqlPredicate).get();
     std::cout << "First person:" << startingWithF[0].first << ", age:" << startingWithF[0].second << std::endl;
 ```
 
 In this example, the code creates a list with the values whose keys start with the letter "F”.
 
-You can use `query::QueryConstants::THIS_ATTRIBUTE_NAME` (`this`) attribute to perform a predicated search for entry values. See the following example:
+You can use `query::query_constants::THIS_ATTRIBUTE_NAME` (`this`) attribute to perform a predicated search for entry values. See the following example:
 
 ```C++
-    hazelcast::client::imap<std::string, int> map = hz.get_map<std::string, int>("personMap;");
-    map.put("Mali", 28);
-    map.put("Ahmet", 30);
-    map.put("Furkan", 23);
-    query::greater_less_predicate<int> greaterThan27Predicate(query::QueryConstants::THIS_ATTRIBUTE_NAME, 27, false, false);
-    std::vector<std::string> olderThan27 = map.keySet(greaterThan27Predicate);
+    auto map = hz.get_map("personMap;");
+    map->put<std::string, int>("Mali", 28).get();
+    map->put<std::string, int>("Ahmet", 30).get();
+    map->put<std::string, int>("Furkan", 23).get();
+    query::greater_less_predicate<int> greaterThan27Predicate(query::query_constants::THIS_ATTRIBUTE_NAME, 27, false, false);
+    std::vector<std::string> olderThan27 = map->keySet<std::string>(greaterThan27Predicate).get();
     std::cout << "First person:" << olderThan27[0] << ", second person:" << olderThan27[1] << std::endl;
 ```
 
@@ -2925,13 +2759,13 @@ possible to query these objects using the Hazelcast query methods explained in t
     std::string person2 = "{ \"name\": \"Jane\", \"age\": 24 }";
     std::string person3 = "{ \"name\": \"Trey\", \"age\": 17 }";
 
-    imap<int, hazelcast_json_value> idPersonMap = hz.get_map<int, hazelcast_json_value>("jsonValues");
+    auto idPersonMap = hz.get_map("jsonValues");
 
-    idPersonMap.put(1, hazelcast_json_value(person1));
-    idPersonMap.put(2, hazelcast_json_value(person2));
-    idPersonMap.put(3, hazelcast_json_value(person3));
+    idPersonMap->put<int, hazelcast_json_value>(1, hazelcast_json_value(person1)).get();
+    idPersonMap->put<int, hazelcast_json_value>(2, hazelcast_json_value(person2)).get();
+    idPersonMap->put<int, hazelcast_json_value>(3, hazelcast_json_value(person3)).get();
 
-    std::vector<hazelcast_json_value> peopleUnder21 = idPersonMap.values(query::greater_less_predicate<int>("age", 21, false, true));
+    auto peopleUnder21 = idPersonMap.values(query::greater_less_predicate<int>("age", 21, false, true)).get();
 ```
 
 When running the queries, Hazelcast treats values extracted from the JSON documents as Java types so they
@@ -2967,7 +2801,7 @@ as querying other Hazelcast objects using the ``predicate``s.
  *
  * The following query finds all the departments that have a person named "Peter" working in them.
  */
-std::vector<hazelcast_json_value> departmentWithPeter = departments.values(query::equal_predicate<std::string>("people[any].name", "Peter"));
+auto departmentWithPeter = departments->values(query::equal_predicate<std::string>("people[any].name", "Peter")).get();
 ```
 
 `hazelcast_json_value` is a lightweight wrapper around your JSON strings. It is used merely as a way to indicate
@@ -2980,25 +2814,28 @@ whether such an entry is going to be returned or not from a query is not defined
 The C++ client provides paging for defined predicates. With its `paging_predicate` object, you can get a list of keys, values, or entries page by page by filtering them with predicates and giving the size of the pages. Also, you can sort the entries by specifying comparators.
 
 ```C++
-    hazelcast::client::imap<std::string, int> map = hz.get_map<std::string, int>("personMap;");
-    query::paging_predicate<std::string, int> pagingPredicate(std::auto_ptr<query::predicate>(new query::greater_less_predicate<int>(query::QueryConstants::THIS_ATTRIBUTE_NAME, 18, false, false)), 5);
+    auto map = hz.get_map("personMap;");
+    // paging_predicate with inner predicate (value < 10)
+    auto predicate = intMap->new_paging_predicate<int, int>(5,
+            query::greater_less_predicate(client, query::query_constants::THIS_ATTRIBUTE_NAME, 10, false, false));
+
     // Set page to retrieve third page
-    pagingPredicate.setPage(3);
-    std::vector<int> values = map.values(pagingPredicate);
+    pagingPredicate.set_page(3);
+    auto values = map->values(pagingPredicate).get();
     //...
 
     // Set up next page
-    pagingPredicate.nextPage();
+    pagingPredicate.next_page();
     
     // Retrieve next page    
-    values = map.values(pagingPredicate);
+    values = map->values(pagingPredicate).get();
     
     //...
 ```
 
-If you want to sort the result before paging, you need to specify a comparator object that implements the `query::entry_comparator` interface. Also, this comparator object should be one of `IdentifiedDataSerializable` or `Portable` or `Custom serializable`. After implementing After implementing this object in C++, you need to implement the Java equivalent of it and its factory. The Java equivalent of the comparator should implement `java.util.Comparator`. Note that the `compare` function of `Comparator` on the Java side is the equivalent of the `sort` function of `Comparator` on the C++ side. When you implement the `Comparator` and its factory, you can add them to the `CLASSPATH` of the server side.  See the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath). 
+If you want to sort the result before paging, you need to specify a comparator object that implements the `query::entry_comparator` interface. Also, this comparator object should be Hazelcast serializable. After implementing After implementing this object in C++, you need to implement the Java equivalent of it and its factory. The Java equivalent of the comparator should implement `java.util.Comparator`. Note that the `compare` function of `Comparator` on the Java side is the equivalent of the `sort` function of `Comparator` on the C++ side. When you implement the `Comparator` and its factory, you can add them to the `CLASSPATH` of the server side.  See the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath). 
 
-Also, you can access a specific page more easily with the help of the `setPage` function. This way, if you make a query for the 100th page, for example, it will get all 100 pages at once instead of reaching the 100th page one by one using the `nextPage` function.
+Also, you can access a specific page more easily with the help of the `set_page` function. This way, if you make a query for the 100th page, for example, it will get all 100 pages at once instead of reaching the 100th page one by one using the `next_page` function.
 
 ## 7.8. Performance
 
@@ -3009,17 +2846,16 @@ Partition Aware ensures that the related entries exist on the same member. If th
 Hazelcast has a standard way of finding out which member owns/manages each key object. The following operations are routed to the same member, since all of them are operating based on the same key `'key1'`.
 
 ```C++
-    hazelcast::client::client_config config;
-    hazelcast::client::hazelcast_client hazelcastInstance(config);
+    hazelcast::client::hazelcast_client hazelcastInstance;
 
-    hazelcast::client::imap<int, int> mapA = hazelcastInstance.get_map<int, int>("mapA");
-    hazelcast::client::imap<int, int> mapB = hazelcastInstance.get_map<int, int>("mapB");
-    hazelcast::client::imap<int, int> mapC = hazelcastInstance.get_map<int, int>("mapC");
+    auto mapA = hazelcastInstance.get_map("mapA");
+    auto mapB = hazelcastInstance.get_map("mapB");
+    auto mapC = hazelcastInstance.get_map("mapC");
 
     // since map names are different, operation will be manipulating
     // different entries, but the operation will take place on the
     // same member since the keys ("key1") are the same
-    mapA.put("key1", value);
+    mapA->put("key1", value);
     mapB.get("key1");
     mapC.remove("key1");
 ```
@@ -3027,71 +2863,67 @@ Hazelcast has a standard way of finding out which member owns/manages each key o
 When the keys are the same, entries are stored on the same member. However, we sometimes want to have the related entries stored on the same member, such as a customer and his/her order entries. We would have a customers map with `customerId` as the key and an orders map with `orderId` as the key. Since `customerId` and `orderId` are different keys, a customer and his/her orders may fall into different members in your cluster. So how can we have them stored on the same member? We create an affinity between the customer and orders. If we make them part of the same partition then these entries will be co-located. We achieve this by making `orderKey` s `partition_aware`.
 
 ```C++
-class OrderKey : public hazelcast::client::partition_aware<int64_t>,
-          public hazelcast::client::serialization::IdentifiedDataSerializable {
-public:
-    static const std::string desiredPartitionString;
+struct OrderKey : public hazelcast::client::partition_aware<std::string> {
+    OrderKey(const std::string &order_id_string) : order_id_string(order_id_string) {}
 
-    OrderKey() {
+    const std::string *get_partition_key() const override {
+        return &customer_id_string;
     }
 
-    OrderKey(int64_t orderId, int64_t customerId) : orderId(orderId), customerId(customerId) {}
-
-    int64_t getOrderId() const {
-        return orderId;
-    }
-
-    virtual const int64_t *getPartitionKey() const {
-        return &customerId;
-    }
-
-    virtual int getFactoryId() const {
-        return 1;
-    }
-
-    virtual int getClassId() const {
-        return 10;
-    }
-
-    virtual void writeData(hazelcast::client::serialization::object_data_output &writer) const {
-        writer.writeLong(orderId);
-        writer.writeLong(customerId);
-    }
-
-    virtual void readData(hazelcast::client::serialization::object_data_input &reader) {
-        orderId = reader.readLong();
-        customerId = reader.readLong();
-    }
-
-private:
-    int64_t orderId;
-    int64_t customerId;
+    std::string order_id_string;
+    static const std::string customer_id_string;
 };
+const std::string OrderKey::customer_id_string = "My customer id 99";
+
+namespace hazelcast {
+    namespace client {
+        namespace serialization {
+            template<>
+            struct hz_serializer<OrderKey> : identified_data_serializer {
+                static int32_t get_factory_id() noexcept {
+                    return 1;
+                }
+
+                static int32_t get_class_id() noexcept {
+                    return 10;
+                }
+
+                static void
+                write_data(const OrderKey &object, hazelcast::client::serialization::object_data_output &out) {
+                    out.write(object.order_id_string);
+                }
+
+                static OrderKey read_data(hazelcast::client::serialization::object_data_input &in) {
+                    return OrderKey{in.read<std::string>()};
+                }
+            };
+        }
+    }
+}
 ```
 
-Notice that `OrderKey` implements `partition_aware` interface and that `getPartitionKey()` returns the `customerId`. This will make sure that the `Customer` entry and its `Order`s will be stored on the same member.
+Notice that `OrderKey` implements `partition_aware` interface and that `get_partition_key()` returns the `OrderKey::customer_id_string`. This will make sure that the `Customer` entry and its `Order`s will be stored on the same member.
 
 ```C++
-    hazelcast::client::client_config config;
-    hazelcast::client::hazelcast_client hazelcastInstance(config);
+    hazelcast::client::hazelcast_client hazelcastInstance;
 
-    hazelcast::client::imap<int64_t, Customer> mapCustomers = hazelcastInstance.get_map<int64_t, Customer>( "customers" );
-    hazelcast::client::imap<OrderKey, Order> mapOrders = hazelcastInstance.get_map<OrderKey, Order>( "orders" );
+    auto mapCustomers = hazelcastInstance.get_map("customers");
+    auto mapOrders = hazelcastInstance.get_map("orders");
 
-    // create the customer entry with customer id = 1
-    mapCustomers.put( 1, customer );
+    // create the customer entry with customer id = "My customer id 99"
+    mapCustomers->put(OrderKey::customer_id_string, customer).get();
 
     // now create the orders for this customer
-    mapOrders.put( new OrderKey( 21, 1 ), order );
-    mapOrders.put( new OrderKey( 22, 1 ), order );
-    mapOrders.put( new OrderKey( 23, 1 ), order );
+    mapOrders>put<OrderKey, Order>(OrderKey{"1"}, order1).get();
+    mapOrders>put<OrderKey, Order>(OrderKey{"2"}, order2).get();
+    mapOrders>put<OrderKey, Order>(OrderKey{"3"}, order3).get();
 ```  
 
 For more details, see the [partition_aware section](https://docs.hazelcast.org/docs/latest/manual/html-single/#partitionaware) in the Hazelcast IMDG Reference Manual.
 
 ### 7.8.2. Near Cache
 
-Map  entries in Hazelcast are partitioned across the cluster members. Hazelcast clients do not have local data at all. Suppose you read the key `k` a number of times from a Hazelcast client or `k` is owned by another member in your cluster. Then each `map.get(k)` will be a remote operation, which creates a lot of network trips. If you have a data structure that is mostly read, then you should consider creating a local Near Cache, so that reads are sped up and less network traffic is created.
+Map  entries in Hazelcast are partitioned across the cluster members. Hazelcast clients do not have local data at all. Suppose you read the key `k` a number of times from a Hazelcast client or `k` is owned by another member in your cluster. Then each `map->get(k)` will be a remote operation, which creates a lot of network trips. If you have a data structure that is mostly read, then you should consider creating a local Near Cache, so that reads are sped up and less network traffic is created.
 
 These benefits do not come for free, please consider the following trade-offs:
 
@@ -3107,68 +2939,68 @@ In a client/server system you must enable the Near Cache separately on the clien
 
 If you are using the Near Cache, you should take into account that your hits to the keys in the Near Cache are not reflected as hits to the original keys on the primary members. This has for example an impact on imap's maximum idle seconds or time-to-live seconds expiration. Therefore, even though there is a hit on a key in the Near Cache, your original key on the primary member may expire.
 
-NOTE: Near Cache works only when you access data via the `map.get(k)` method. Data returned using a predicate is not stored in the Near Cache.
+NOTE: Near Cache works only when you access data via the `map->get(k)` method. Data returned using a predicate is not stored in the Near Cache.
 
 A Near Cache can have its own `in-memory-format` which is independent of the `in-memory-format` of the data structure.
 
 #### 7.8.2.1 Configuring Near Cache
 
-Hazelcast Map can be configured to work with near cache enabled. You can enable the Near Cache on a Hazelcast Map by adding its configuration for that map. An example configuration for `myMap` is shown below.
+Hazelcast Map can be configured to work with near cache enabled. You can enable the Near Cache on a Hazelcast Map by adding its configuration for that map-> An example configuration for `myMap` is shown below.
 
 ```C++
     client_config config;
-    const char *mapName = "myMap";
+    const char *mapName = "EvictionPolicyMap";
     config::near_cache_config nearCacheConfig(mapName, config::OBJECT);
-    nearCacheConfig.setInvalidateOnChange(true);
-    nearCacheConfig.getEvictionConfig()->setEvictionPolicy(config::LRU)
-            .setMaximumSizePolicy(config::eviction_config::ENTRY_COUNT).setSize(100);
-    nearCacheConfig.setTimeToLiveSeconds(1);
-    nearCacheConfig.setMaxIdleSeconds(2);
-    config.addNearCacheConfig(nearCacheConfig);
+    nearCacheConfig.set_invalidate_on_change(false);
+    nearCacheConfig.get_eviction_config().set_eviction_policy(config::LRU)
+            .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT).set_size(100);
+    config.add_near_cache_config(nearCacheConfig);
+    hazelcast_client client(std::move(config));
+
 ```
 
 Following are the descriptions of all configuration elements:
- - `setInMemoryFormat`: Specifies in which format data will be stored in your Near Cache. Note that a map’s in-memory format can be different from that of its Near Cache. Available values are as follows:
+ - `set_in_memory_format`: Specifies in which format data will be stored in your Near Cache. Note that a map’s in-memory format can be different from that of its Near Cache. Available values are as follows:
   - `BINARY`: Data will be stored in serialized binary format (default value).
   - `OBJECT`: Data will be stored in deserialized form.
- - `setInvalidateOnChange`: Specifies whether the cached entries are evicted when the entries are updated or removed in members. Its default value is true.
- - `setTimeToLiveSeconds`: Maximum number of seconds for each entry to stay in the Near Cache. Entries that are older than this period are automatically evicted from the Near Cache. Regardless of the eviction policy used, `timeToLiveSeconds` still applies. Any integer between 0 and `INT32_MAX`. 0 means infinite. Its default value is 0.
- - `setMaxIdleSeconds`: Maximum number of seconds each entry can stay in the Near Cache as untouched (not read). Entries that are not read more than this period are removed from the Near Cache. Any integer between 0 and `INT32_MAX`. 0 means infinite. Its default value is 0. 
- - `setEvictionConfig`: Eviction policy configuration. The following can be set on this config:
-    - `setEviction`: Specifies the eviction behavior when you use High-Density Memory Store for your Near Cache. It has the following attributes:
-        - `setEvictionPolicy`: Eviction policy configuration. Available values are as follows:
+ - `set_invalidate_on_change`: Specifies whether the cached entries are evicted when the entries are updated or removed in members. Its default value is true.
+ - `set_time_to_live_seconds`: Maximum number of seconds for each entry to stay in the Near Cache. Entries that are older than this period are automatically evicted from the Near Cache. Regardless of the eviction policy used, `timeToLiveSeconds` still applies. Any integer between 0 and `INT32_MAX`. 0 means infinite. Its default value is 0.
+ - `set_max_idle_seconds`: Maximum number of seconds each entry can stay in the Near Cache as untouched (not read). Entries that are not read more than this period are removed from the Near Cache. Any integer between 0 and `INT32_MAX`. 0 means infinite. Its default value is 0. 
+ - `set_eviction_config`: Eviction policy configuration. The following can be set on this config:
+    - `set_eviction`: Specifies the eviction behavior when you use High-Density Memory Store for your Near Cache. It has the following attributes:
+        - `set_eviction_policy`: Eviction policy configuration. Available values are as follows:
             - `LRU`: Least Recently Used (default value).
             - `LFU`: Least Frequently Used.
             - `NONE`: No items will be evicted and the property max-size will be ignored. You still can combine it with `time-to-live-seconds` and `max-idle-seconds` to evict items from the Near Cache.
             - `RANDOM`: A random item will be evicted.
-        - `setMaxSizePolicy`: Maximum size policy for eviction of the Near Cache. Available values are as follows:
+        - `set_max_size_policy`: Maximum size policy for eviction of the Near Cache. Available values are as follows:
             - `ENTRY_COUNT`: Maximum size based on the entry count in the Near Cache (default value).
-        - `setSize`: Maximum size of the Near Cache used for `max-size-policy`. When this is reached the Near Cache is evicted based on the policy defined. Any integer between `1` and `INT32_MAX`. Default is `INT32_MAX`.
-- `setLocalUpdatePolicy`: Specifies the update policy of the local Near Cache. It is available on JCache clients. Available values are as follows:
+        - `set_size`: Maximum size of the Near Cache used for `max-size-policy`. When this is reached the Near Cache is evicted based on the policy defined. Any integer between `1` and `INT32_MAX`. Default is `INT32_MAX`.
+- `set_local_update_policy`: Specifies the update policy of the local Near Cache. It is available on JCache clients. Available values are as follows:
     - `INVALIDATE`: Removes the Near Cache entry on mutation. After the mutative call to the member completes but before the operation returns to the caller, the Near Cache entry is removed. Until the mutative operation completes, the readers still continue to read the old value. But as soon as the update completes the Near Cache entry is removed. Any threads reading the key after this point will have a Near Cache miss and call through to the member, obtaining the new entry. This setting provides read-your-writes consistency. This is the default setting.
     - `CACHE_ON_UPDATE`: Updates the Near Cache entry on mutation. After the mutative call to the member completes but before the put returns to the caller, the Near Cache entry is updated. So a remove will remove it and one of the put methods will update it to the new value. Until the update/remove operation completes, the entry's old value can still be read from the Near Cache. But before the call completes the Near Cache entry is updated. Any threads reading the key after this point will read the new entry. If the mutative operation was a remove, the key will no longer exist in the cache, both the Near Cache and the original copy in the member. The member will initiate an invalidate event to any other Near Caches, however the caller Near Cache is not invalidated as it already has the new value. This setting also provides read-your-writes consistency.
 
 #### 7.8.2.2. Near Cache Example for Map
-The following is an example configuration for a Near Cache defined in the `mostlyReadMap` map. According to this configuration, the entries are stored as `OBJECT`'s in this Near Cache and eviction starts when the count of entries reaches `5000`; entries are evicted based on the `LRU` (Least Recently Used) policy. In addition, when an entry is updated or removed on the member side, it is eventually evicted on the client side.
+The following is an example configuration for a Near Cache defined in the `mostlyReadMap` map-> According to this configuration, the entries are stored as `OBJECT`'s in this Near Cache and eviction starts when the count of entries reaches `5000`; entries are evicted based on the `LRU` (Least Recently Used) policy. In addition, when an entry is updated or removed on the member side, it is eventually evicted on the client side.
 ```C++
-    config::near_cache_config nearCacheConfig("mostlyReadMap", config::OBJECT);
-    nearCacheConfig.setInvalidateOnChange(true);
-    nearCacheConfig.getEvictionConfig().setEvictionPolicy(config::LRU).setSize(5000);
-    config.addNearCacheConfig(nearCacheConfig);
+    config::near_cache_config nearCacheConfig(mapName, config::OBJECT);
+    nearCacheConfig.set_invalidate_on_change(false);
+    nearCacheConfig.get_eviction_config().set_eviction_policy(config::LRU)
+            .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT).set_size(100);
 ```
 
 #### 7.8.2.3. Near Cache Eviction
-In the scope of Near Cache, eviction means evicting (clearing) the entries selected according to the given `evictionPolicy` when the specified `size` has been reached.
+In the scope of Near Cache, eviction means evicting (clearing) the entries selected according to the given `eviction_policy` when the specified `size` has been reached.
 
-The `eviction_config::setSize` defines the entry count when the Near Cache is full and determines whether the eviction should be triggered. 
+The `eviction_config::set_size` defines the entry count when the Near Cache is full and determines whether the eviction should be triggered. 
 
-Once the eviction is triggered the configured `evictionPolicy` determines which, if any, entries must be evicted.
+Once the eviction is triggered the configured `eviction_policy` determines which, if any, entries must be evicted.
  
 #### 7.8.2.4. Near Cache Expiration
 Expiration means the eviction of expired records. A record is expired:
 
-- if it is not touched (accessed/read) for `maxIdleSeconds`
-- `timeToLiveSeconds` passed since it is put to Near Cache
+- if it is not touched (accessed/read) for `max_idle_seconds`
+- `time_to_live_seconds` passed since it is put to Near Cache
 
 The actual expiration is performed when a record is accessed: it is checked if the record is expired or not. If it is expired, it is evicted and the value shall be looked up from the cluster.
 
@@ -3176,7 +3008,7 @@ The actual expiration is performed when a record is accessed: it is checked if t
 
 Invalidation is the process of removing an entry from the Near Cache when its value is updated or it is removed from the original map (to prevent stale reads). See the [Near Cache Invalidation section](https://docs.hazelcast.org/docs/latest/manual/html-single/#near-cache-invalidation) in the Hazelcast IMDG Reference Manual.
 
-### 7.8.3. pipelining
+### 7.8.3. Pipelining
 
 With the pipelining, you can send multiple
 requests in parallel using a single thread  and therefore can increase throughput. 
@@ -3187,24 +3019,24 @@ the requests in parallel. For the same example, if we would use 2 threads, then 
 operations/second, to 2000 operations/second.
 
 However, introducing threads for the sake of executing requests isn't always convenient and doesn't always lead to an optimal
-performance; this is where the `pipelining` can be used. Instead of using multiple threads to have concurrent invocations,
-you can use asynchronous method calls such as `imap::getAsync()`. If you would use 2 asynchronous calls from a single thread,
+performance; this is where the `pipelining` can be used. If you would use 2 asynchronous calls from a single thread,
 then the maximum throughput is 2*(1/001) = 2000 operations/second. Therefore, to benefit from the pipelining, asynchronous calls need to
 be made from a single thread. The pipelining is a convenience implementation to provide back pressure, i.e., controlling
 the number of inflight operations, and it provides a convenient way to wait for all the results.
 
 ```C++
-            boost::shared_ptr<pipelining<std::string> > pipelining = pipelining<std::string>::create(depth);
+            constexpr int depth = 10;
+            auto pipelining = pipelining<std::string>::create(depth);
             for (int k = 0; k < 100; ++k) {
                 int key = rand() % keyDomain;
-                pipelining->add(map.getAsync(key));
+                pipelining->add(map->get(key));
             }
 
             // wait for completion
-            std::vector<boost::shared_ptr<std::string> > results = pipelining->results();
+            auto results = pipelining->results();
 ```
 
-In the above example, we make 100 asynchronous `map.getAsync()` calls, but the maximum number of inflight calls is 10.
+In the above example, we make 100 asynchronous `map->get()` calls, but the maximum number of inflight calls is 10.
 
 By increasing the debt of the pipelining, throughput can be increased. The pipelining has its own back pressure, you do not
 need to enable the [Client BackPressure section](#733-client-backpressure) on the client or member to have this feature on the pipelining. However, if you have many
@@ -3282,217 +3114,59 @@ As the callback function is called from multiple threads, it must be thread-safe
 
 Refer to the examples directory and the API documentation for details.
 
-## 7.10. Raw Pointer API
+## 7.10. Mixed Object Types Supporting Hazelcast Client
 
-When using C++ client you can have the ownership of raw pointers for the objects you create and return. This allows you to keep the objects in your library/application without any need for copy.
+Sometimes, you may need to use Hazelcast data structures with objects of different types. For example, you may want to put `int`, `string`, identified data serializable, portable serializable, etc. objects into the same Hazelcast `imap` data structure.
 
-For each container, you can use the adapter classes, whose names start with `RawPointer`, to access the raw pointers of the created objects. These adapter classes are found in the `hazelcast::client::adaptor` namespace and listed below:
+### 7.10.1. typed_data API
 
-- `RawPointerList`
-- `RawPointerQueue`
-- `RawPointerTransactionalMultiMap`
-- `RawPointerMap`
-- `RawPointerSet`
-- `RawPointerTransactionalQueue`
-- `RawPointerMultiMap`
-- `RawPointerTransactionalMap`
-
-These are adapter classes and they do not create new structures. You just provide the legacy containers as parameters and then you can work with these raw capability containers freely. An example usage of `RawPointerMap` is shown below:
-
-```
-hazelcast::client::imap<std::string, std::string> m = hz.get_map<std::string, std::string>("map");
-hazelcast::client::adaptor::RawPointerMap<std::string, std::string> map(m);
-map.put("1", "Tokyo");
-map.put("2", "Paris");
-map.put("3", "New York");
-std::cout << "Finished loading map" << std::endl;
-
-std::auto_ptr<hazelcast::client::DataArray<std::string> > vals = map.values();
-std::auto_ptr<hazelcast::client::EntryArray<std::string, std::string> > entries = map.entry_set();
-
-std::cout << "There are " << vals->size() << " values in the map" << std::endl;
-std::cout << "There are " << entries->size() << " entries in the map" << std::endl;
-
-for (size_t i = 0; i < entries->size(); ++i) {
-   const std::string * key = entries->getKey(i);
-      if ((std::string *) NULL == key) {
-			std::cout << "The key at index " << i << " is NULL" << std::endl;
-        } else {
-            std::auto_ptr<std::string> val = entries->releaseValue(i);
-            std::cout << "(Key, Value) for index " << i << " is: (" << *key << ", " <<
-                (val.get() == NULL ? "NULL" : *val) << ")" << std::endl;
-        }
-    }
-    std::cout << "Finished" << std::endl;
-```
-
-Raw pointer API uses the `DataArray` and `EntryArray` interfaces which allow late deserialization of objects. The entry in the returned array is deserialized only when it is accessed. Please see the example code below:
-
-```
-// No deserialization here
-std::auto_ptr<hazelcast::client::DataArray<std::string> > vals = map.values(); 
-
-// deserializes the item at index 0 assuming that there are at least 1 items in the array
-const std::string *value = vals->get(0);
-
-// no deserialization here since it was already de-serialized
-value = vals->get(0);
-
-// no deserialization here since it was already de-serialized
-value = (*vals)[0];
-
-// releases the value so that you can keep this object pointer in your application at some other place
-std::auto_ptr<std::string> releasedValue = vals->release(0);
-
-// deserialization occurs again since the value was released already
-value = vals->get(0);
-```
-
-Using the raw pointer based API may improve the performance if you are using the API to return multiple values such as `values`, `keySet` and `entry_set`. In this case, the cost of deserialization is delayed until the item is actually accessed.
-
-## 7.11. Mixed Object Types Supporting Hazelcast Client
-
-Sometimes, you may need to use Hazelcast data structures with objects of different types. For example, you may want to put `int`, `string`, `IdentifiedDataSerializable`, etc. objects into the same Hazelcast `imap` data structure.
-
-### 7.11.1. TypedData API
-
-The TypedData class is a wrapper class for the serialized binary data. It presents the following user APIs:
+The typed_data class is a wrapper class for the serialized binary data. It presents the following user APIs:
 ```
             /**
              *
              * @return The type of the underlying object for this binary.
              */
-            const serialization::pimpl::object_type getType() const;
+            serialization::pimpl::object_type get_type() const;
 
             /**
              * Deserializes the underlying binary data and produces the object of type T.
              *
              * <b>CAUTION</b>: The type that you provide should be compatible with what object type is returned with
-             * the getType API, otherwise you will either get an exception of incorrectly try deserialize the binary data.
+             * the get_type API, otherwise you will either get an exception of incorrectly try deserialize the binary data.
              *
              * @tparam T The type to be used for deserialization
              * @return The object instance of type T.
              */
             template <typename T>
-            std::auto_ptr<T> get() const;
+            boost::optional<T> get() const;
+
 ```
 
-TypedData does late deserialization of the data only when the get method is called.
+typed_data does late deserialization of the data only when the get method is called.
 
-This TypedData allows you to retrieve the data type of the underlying binary to be used when being deserialized. This class represents the type of a Hazelcast serializable object. The fields can take the following values:
-1. <b>Primitive types</b>: `factoryId=-1`, `classId=-1`, `typeId` is the type ID for that primitive as listed in
-`SerializationConstants`
-2. <b>Array of primitives</b>: `factoryId=-1`, `classId=-1`, `typeId` is the type ID for that array as listed in
-`SerializationConstants`
-3. <b>IdentifiedDataSerializable</b>: `factoryId`, `classId` and `typeId` are non-negative values as registered by
-the `DataSerializableFactory`.
-4. <b>Portable</b>: `factoryId`, `classId` and `typeId` are non-negative values as registered by the `PortableFactory`.
-5. <b>Custom serialized objects</b>: `factoryId=-1`, `classId=-1`, `typeId` is the non-negative type ID as 
-registered for the custom object. 
+This typed_data allows you to retrieve the data type of the underlying binary to be used when being deserialized. This class represents the type of a Hazelcast serializable object. The fields can take the following values:
+1. <b>Primitive types</b>: `factory_id=-1`, `class_id=-1`, `type_id` is the type ID for that primitive as listed in `serialization_constants`
+2. <b>Array of primitives</b>: `factory_id=-1`, `class_id=-1`, `type_id` is the type ID for that array as listed in `serialization_constants`
+3. <b>IdentifiedDataSerializable</b>: `factory_id`, `class_id` and `type_id` are non-negative values.
+4. <b>Portable</b>: `factory_id`, `class_id` and `type_id` are non-negative values.
+5. <b>Custom serialized objects</b>: `factory_id=-1`, `class_id=-1`, `type_id` is the non-negative type ID. 
 
 # 8. Development and Testing
 
 Hazelcast C++ client is developed using C++. If you want to help with bug fixes, develop new features or
 tweak the implementation to your application's needs, you can follow the steps in this section.
 
-## 8.1. Building and Using Client From Sources
-
-For compiling with SSL support: 
-
-- You need to have the OpenSSL (version 1.0.2) installed in your development environment: (i) add OpenSSL `include` directory to include directories, (ii) add OpenSSL `library` directory to the link directories list (this is the directory named `tls`, e.g., `hazelcast/Linux_64/lib/tls`), and (iii) set the OpenSSL libraries to link.
- 
-- You can provide your OpenSSL installation directory to cmake using the following flags:
-    - -DHZ_OPENSSL_INCLUDE_DIR="Path to OpenSSL installation include directory" 
-    - -DHZ_OPENSSL_LIB_DIR="Path to OpenSSL lib directory"
-
-- Use -DHZ_COMPILE_WITH_SSL=ON
-
-- Check the top level CMakeLists.txt file to see which libraries we link for OpenSSL in which environment. 
-    - For Mac OS and Linux, we link with "ssl" and "crypto".
-    - For Windows, install also the 1.1.x version of the OpenSSL library. An example linkage for 64-bit library and release build: "libeay32MD ssleay32MD libcrypto64MD libSSL64MD".
-
-
-Follow the below steps to build and install Hazelcast C++ client from its source:
-
-1. Clone the project from GitHub using the following command: `git clone --recursive git@github.com:hazelcast/hazelcast-cpp-client.git`.  We use the `--recursive` flag for our dependency on the googletest framework.
-2. Create a build directory, e.g., `build`, from the root of the project. In the build directory, run the cmake command depending on your environment as depicted in the next sections.
-
-### 8.1.1 Mac
-
-**Release:**
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
-	cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
-
-**Code Coverage:**
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug -DHZ_CODE_COVERAGE=ON
-	gcovr -u -e .*external.* -e SimpleMapTest.h --html --html-details -o coverage.html 
-
-**Xcode Development:**
-
-  	cmake .. -G Xcode -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug
-
-	cmake .. -G Xcode -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=archive -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=library
-
-**Valgrind sample run with suppressions:**
-
-        valgrind --leak-check=yes  --gen-suppressions=all --suppressions=../test.sup  ./hazelcast/test/clientTest_STATIC_64.exe  > log.t
-
-### 8.1.2 Linux
-
-**Release:**
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release
-	cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
-	cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
-
-**Building the tests:**
-
-    Add the -DHZ_BUILD_TESTS=ON flag to the cmake flags. e.g.:
-    cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug -DHZ_BUILD_TESTS=ON
-
-**Building the examples:**
-
-    Add the -DHZ_BUILD_EXAMPLES=ON flag to the cmake flags. e.g.:
-    cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug -DHZ_BUILD_EXAMPLES=ON
-
-**Valgrind:**
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug -DHZ_VALGRIND=ON
-
-### 8.1.3 Windows
-
-**Release:**
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release
-	cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Release
-	cmake .. -G "Visual Studio 12 Win64"  -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
-	cmake .. -G "Visual Studio 12 Win64"  -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Release
-
-	MSBuild.exe hazelcast_client.sln /property:Configuration=Release
-
-**Debug:**
-
-	cmake .. -DHZ_LIB_TYPE=STATIC -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Debug
-	cmake .. -DHZ_LIB_TYPE=SHARED -DHZ_BIT=32 -DCMAKE_BUILD_TYPE=Debug
-	cmake .. -G "Visual Studio 12 Win64"  -DHZ_LIB_TYPE=STATIC -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug
-	cmake .. -G "Visual Studio 12 Win64"  -DHZ_LIB_TYPE=SHARED -DHZ_BIT=64 -DCMAKE_BUILD_TYPE=Debug
-
-	MSBuild.exe hazelcast_client.sln /property:TreatWarningsAsErrors=true /property:Configuration=Debug
-
-## 8.2. Testing
+## 8.1. Testing
 
 In order to test Hazelcast C++ client locally, you will need the following:
 
-* Java 6 or newer
+* Java 8 or newer (for server)
 * Maven
 * cmake
 * OpenSSL
+* Boost
 
-You can also pull our test docker images from the docker hub using the following command: `docker pull ihsan/gcc_346_ssl`. These images have all the tools for building the project.
+You can use the docker configs provided in the `docker` folder of the project. The dockers have all the dependencies installed for building the project.
 
 Following command builds and runs the tests:
 
@@ -3500,19 +3174,11 @@ Following command builds and runs the tests:
 * MacOS: `./testLinuxSingleCase.sh 64 SHARED Debug`
 * Windows: `./testWindowsSingleCase.bat 64 SHARED Debug`
 
-### 8.2.1 Tested Platforms
-
-Our CI tests run continuously on the following platforms and compilers:
-
-* Linux: CentOs5 gcc 3.4.6, CentOs5.11 gcc 4.1.2, centos 7 gcc 4.8.2
-* Windows: Visual Studio 12
-* Mac OS: Apple LLVM version 7.3.0 (clang-703.0.31)
-
-## 8.3 Reproducing Released Libraries
+## 8.2 Reproducing Released Libraries
 
 Sometimes you may want to reproduce the released library for your own compiler environment. You need to run the release script and it will produce a release folder named "cpp".
 
-Note: The default release scripts require that you have OpenSSL (version 1.0.2) installed in your development environment.
+Note: The default release scripts for Windows and Mac OS require that you have OpenSSL and Boost installed in your development environment. The linux build script uses docker for compiling, hence you need docker installed.
 
 ## Mac
 

--- a/examples/Org.Website.Samples/EntryProcessorSample.cpp
+++ b/examples/Org.Website.Samples/EntryProcessorSample.cpp
@@ -17,14 +17,15 @@
 
 using namespace hazelcast::client;
 
-class IncEntryProcessor {
+struct IdentifiedEntryProcessor {
+    std::string name;
 };
 
 namespace hazelcast {
     namespace client {
         namespace serialization {
             template<>
-            struct hz_serializer<IncEntryProcessor> : identified_data_serializer {
+            struct hz_serializer<IdentifiedEntryProcessor> : identified_data_serializer {
                 static int32_t get_factory_id() noexcept {
                     return 66;
                 }
@@ -34,11 +35,14 @@ namespace hazelcast {
                 }
 
                 static void
-                write_data(const IncEntryProcessor &object, hazelcast::client::serialization::object_data_output &out) {
+                write_data(const IdentifiedEntryProcessor &object, hazelcast::client::serialization::object_data_output &out) {
+                    out.write(object.name);
                 }
 
-                static IncEntryProcessor read_data(hazelcast::client::serialization::object_data_input &in) {
-                    return IncEntryProcessor{};
+                static IdentifiedEntryProcessor read_data(hazelcast::client::serialization::object_data_input &in) {
+                    // no-need to implement here, since we do not expect to receive this object but we only send it to server
+                    assert(0);
+                    return IdentifiedEntryProcessor{};
                 }
             };
         }
@@ -54,10 +58,10 @@ int main() {
     map->put("key", 0).get();
     // Run the IncEntryProcessor class on the Hazelcast Cluster Member holding the key called "key",
     // The entry processor returns in32_t.
-    auto returnValueFromIncEntryProcessor = map->execute_on_key<std::string, int32_t, IncEntryProcessor>(
-            "key", IncEntryProcessor());
+    auto returnValueFromIncEntryProcessor = map->execute_on_key<std::string, int32_t, IdentifiedEntryProcessor>(
+            "key", IdentifiedEntryProcessor{"my_name"});
     // Show that the IncEntryProcessor updated the value.
-    std::cout << "new value:" << map->get<std::string, int32_t>("key").get();
+    std::cout << "new value:" << *map->get<std::string, std::string>("key").get();
     // Shutdown this Hazelcast Client
     hz.shutdown();
 

--- a/examples/Org.Website.Samples/ExecutorSample.cpp
+++ b/examples/Org.Website.Samples/ExecutorSample.cpp
@@ -116,10 +116,6 @@ public:
 
         return *attribute == "true";
     }
-
-    void to_string(std::ostream &os) const override {
-        os << "MyMemberSelector";
-    }
 };
 
 int main() {
@@ -128,9 +124,9 @@ int main() {
     // Get the Distributed Executor Service
     std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
     // Submit the MessagePrinter Runnable to a random Hazelcast Cluster Member
-    auto promise = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"});
+    auto result_future = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"});
     // Wait for the result of the submitted task and print the result
-    auto result = promise.get_future().get();
+    auto result = result_future.get_future().get();
     std::cout << "Server result: " << *result << std::endl;
     // Get the first Hazelcast Cluster Member
     member firstMember = hz.get_cluster().get_members()[0];

--- a/examples/network-configuration/tcpip/main.cpp
+++ b/examples/network-configuration/tcpip/main.cpp
@@ -20,8 +20,9 @@ int main() {
     const char *serverIp = "127.0.0.1";
     const int port = 5701;
     hazelcast::client::client_config config;
-    hazelcast::client::address addr(serverIp, port);
-    config.get_network_config().add_address(addr);
+    config.get_network_config().add_address({serverIp, port}).add_addresses({{"127.0.0.1", 5702},
+                                                                            {"192.168.1.10", 5701}});
+
     hazelcast::client::hazelcast_client hz(std::move(config));
 
     auto map = hz.get_map("test map");

--- a/examples/serialization/globalserializer/main.cpp
+++ b/examples/serialization/globalserializer/main.cpp
@@ -44,9 +44,7 @@ public:
 
 int main() {
     hazelcast::client::client_config config;
-    hazelcast::client::serialization_config serializationConfig;
-    serializationConfig.set_global_serializer(std::make_shared<MyGlobalSerializer>());
-    config.set_serialization_config(serializationConfig);
+    config.get_serialization_config().set_global_serializer(std::make_shared<MyGlobalSerializer>());
     hazelcast::client::hazelcast_client hz(std::move(config));
 
     auto map = hz.get_map("map");

--- a/hazelcast/include/hazelcast/client/member_selectors.h
+++ b/hazelcast/include/hazelcast/client/member_selectors.h
@@ -24,27 +24,23 @@ namespace hazelcast {
         class member;
 
         /**
- * <p>Implementations of this interface select members
- * that are capable of executing a special kind of task.<br/>
- * The {@link #select(Member)} method is called for every available
- * member in the cluster and it is up to the implementation to decide
- * if the member is going to be used or not.</p>
- * <p>For example, a basic implementation could select members on the
- * existence of a special attribute in the members, like the following
- * example:<br/>
- * <pre>class MyMemberSelector : public member_selector {
- *     public:
- *          bool select(const member &member) override {
- *              auto attribute = member.get_attribute("my.special.executor")
- *              return attribute != nullptr && *attribute == "my.special.executor";
- *          }
- *
- *          void to_string(std::ostream &os) override {
- *              os << "My member selector";
- *          }
- * }</pre>
- * </p>
- */
+         * <p>Implementations of this interface select members
+         * that are capable of executing a special kind of task.<br/>
+         * The {@link #select(Member)} method is called for every available
+         * member in the cluster and it is up to the implementation to decide
+         * if the member is going to be used or not.</p>
+         * <p>For example, a basic implementation could select members on the
+         * existence of a special attribute in the members, like the following
+         * example:<br/>
+         * <pre>class MyMemberSelector : public member_selector {
+         *     public:
+         *          bool select(const member &member) override {
+         *              auto attribute = member.get_attribute("my.special.executor")
+         *              return attribute != nullptr && *attribute == "my.special.executor";
+         *          }
+         * }</pre>
+         * </p>
+         */
         class member_selector {
         public:
             /**
@@ -56,10 +52,6 @@ namespace hazelcast {
             virtual bool select(const member &member) const = 0;
 
             virtual ~member_selector() = default;
-
-            virtual void to_string(std::ostream &os) const = 0;
-
-            friend std::ostream &operator<<(std::ostream &os, const member_selector &a_selector);
         };
 
         /**
@@ -69,8 +61,6 @@ namespace hazelcast {
         public:
             class data_member_selector : public member_selector {
                 bool select(const member &member) const override;
-
-                void to_string(std::ostream &os) const override;
             };
 
             static const std::unique_ptr<member_selector> DATA_MEMBER_SELECTOR;

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -477,9 +477,8 @@ namespace hazelcast {
                 }
             }
             if (selected.empty()) {
-                throw (exception::exception_builder<exception::rejected_execution>(
-                        "IExecutorService::selectMembers") << "No member selected with memberSelector["
-                                                           << member_selector << "]").build();
+                BOOST_THROW_EXCEPTION(exception::rejected_execution("IExecutorService::selectMembers",
+                                                                    "No member could be selected with member selector"));
             }
             return selected;
         }

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -166,11 +166,6 @@ namespace hazelcast {
             return name_;
         }
 
-        std::ostream &operator<<(std::ostream &os, const member_selector &a_selector) {
-            a_selector.to_string(os);
-            return os;
-        }
-
         namespace impl {
             RoundRobinLB::RoundRobinLB() = default;
 
@@ -278,10 +273,6 @@ namespace hazelcast {
 
         bool member_selectors::data_member_selector::select(const member &member) const {
             return !member.is_lite_member();
-        }
-
-        void member_selectors::data_member_selector::to_string(std::ostream &os) const {
-            os << "Default DataMemberSelector";
         }
 
         const std::unique_ptr<member_selector> member_selectors::DATA_MEMBER_SELECTOR(

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -817,16 +817,8 @@ namespace hazelcast {
                         return true;
                     }
 
-                    void SelectAllMembers::to_string(std::ostream &os) const {
-                        os << "SelectAllMembers";
-                    }
-
                     bool SelectNoMembers::select(const hazelcast::client::member &member) const {
                         return false;
-                    }
-
-                    void SelectNoMembers::to_string(std::ostream &os) const {
-                        os << "SelectNoMembers";
                     }
                 }
             }

--- a/hazelcast/test/src/executor/tasks/Tasks.h
+++ b/hazelcast/test/src/executor/tasks/Tasks.h
@@ -73,14 +73,10 @@ namespace hazelcast {
 
                     struct SelectAllMembers : public member_selector {
                         bool select(const member &member) const override;
-
-                        void to_string(std::ostream &os) const override;
                     };
 
                     struct SelectNoMembers : public member_selector {
                         bool select(const member &member) const override;
-
-                        void to_string(std::ostream &os) const override;
                     };
 
                     struct SerializedCounterCallable {


### PR DESCRIPTION
Updated the README doc to update the API changes introduced in 4.0 releaseş

Removed the unneeded methods from the member_selector interface to simplify it. The unneeded methods were:
```
            virtual void to_string(std::ostream &os) const = 0;

            friend std::ostream &operator<<(std::ostream &os, const member_selector &a_selector);
```