### PR TITLE
Mac OSX release verification script failure fix

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -78,6 +78,16 @@ if (NOT("${HAZELCAST_INSTALL_DIR}x" STREQUAL "x"))
 
     message(STATUS "Operating System: ${CMAKE_SYSTEM}")
 
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        # This is a bug in CMake that causes it to prefer the system version over
+        # the one in the specified ROOT folder. see
+        # https://stackoverflow.com/questions/58446253/xcode-11-ld-error-your-binary-is-not-an-allowed-client-of-usr-lib-libcrypto-dy
+        set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/Cellar/openssl@1.1/1.1.1g/)
+        set(OPENSSL_INCLUDE_DIR /usr/local/Cellar/openssl@1.1/1.1.1g/include CACHE FILEPATH "" FORCE)
+        set(OPENSSL_CRYPTO_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib CACHE FILEPATH "" FORCE)
+        set(OPENSSL_SSL_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libssl.dylib CACHE FILEPATH "" FORCE)
+    endif()
+
     if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         if (${CMAKE_BUILD_TYPE} MATCHES "Release")
             set(Boost_USE_STATIC_LIBS        ON)  # only find static libs

--- a/releaseWindows.bat
+++ b/releaseWindows.bat
@@ -12,7 +12,6 @@ mkdir .\cpp\Windows_64\lib\static
 mkdir .\cpp\Windows_64\lib\tls\static
 mkdir .\cpp\Windows_64\lib\shared
 mkdir .\cpp\Windows_64\lib\tls\shared
-mkdir .\cpp\Windows_64\hazelcast\include\hazelcast
 
 xcopy /S /Q hazelcast\include\hazelcast\* cpp\include\hazelcast\
 xcopy /S /Q hazelcast\generated-sources\src\hazelcast\client\protocol\codec\*.h cpp\include\hazelcast\client\protocol\codec\


### PR DESCRIPTION
Fix to mac OSX release verification script failure (The cmake file was missing the ssl library flags).

Also, a minor fix to windows release script.