### PR TITLE
Make proxy get methods async

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,7 +1302,7 @@ Let's create a map and populate it with some data, as shown below.
 
 ```C++
     // Get the Distributed Map from Cluster.
-    auto map = client.get_map("my-distributed-map");
+    auto map = client.get_map("my-distributed-map").get();
     //Standard put and get.
     map->put<std::string, std::string>("key", "value").get();
     map->get<std::string, std::string>("key").get();
@@ -1431,7 +1431,7 @@ A Map usage example is shown below.
 
 ```C++
     // Get the Distributed Map from Cluster.
-    auto map = hz.get_map("my-distributed-map");
+    auto map = hz.get_map("my-distributed-map").get();
     //Standard Put and Get.
     map->put<std::string, std::string>("key", "value").get();
     map->get<std::string, std::string>("key").get();
@@ -1448,7 +1448,7 @@ A multi_map usage example is shown below.
 
 ```C++
     // Get the Distributed multi_map from Cluster.
-    auto multiMap = hz.get_multi_map("my-distributed-multimap");
+    auto multiMap = hz.get_multi_map("my-distributed-multimap").get();
     // Put values in the map against the same key
     multiMap->put<std::string, std::string>("my-key", "value1").get();
     multiMap->put<std::string, std::string>("my-key", "value2").get();
@@ -1482,7 +1482,7 @@ A Queue usage example is shown below.
 
 ```C++
     // Get a Blocking Queue called "my-distributed-queue"
-    auto queue = hz.get_queue("my-distributed-queue");
+    auto queue = hz.get_queue("my-distributed-queue").get();
     // Offer a String into the Distributed Queue
     queue->offer<std::string>("item").get();
     // Poll the Distributed Queue and return the String
@@ -1503,7 +1503,7 @@ A Set usage example is shown below.
 
 ```C++
     // Get the Distributed Set from Cluster.
-    auto set = hz.get_set("my-distributed-set");
+    auto set = hz.get_set("my-distributed-set").get();
     // Add items to the set with duplicates
     set->add<std::string>("item1").get();
     set->add<std::string>("item1").get();
@@ -1525,7 +1525,7 @@ A List usage example is shown below.
 
 ```C++
     // Get the Distributed List from Cluster.
-    auto list = hz.get_list("my-distributed-list");
+    auto list = hz.get_list("my-distributed-list").get();
     // Add elements to the list
     list->add<std::string>("item1").get();
     list->add<std::string>("item2").get();
@@ -1874,7 +1874,7 @@ You can create a `transaction_context` object using the C++ client to begin, com
                 context.begin_transaction().get();
 
                 // Get transactional distributed data structures
-                auto txnMap = context.get_map("transactional-map");
+                auto txnMap = context.get_map("transactional-map").get();
                 auto txnmulti_map = context.get_multi_map("transactional-multimap");
                 auto txnQueue = context.get_queue("transactional-queue");
                 auto txnSet = context.get_set("transactional-set");
@@ -2242,7 +2242,7 @@ An example where `MessagePrinter` task is executed is shown below.
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Executor Service
-    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor").get();
     // Submit the MessagePrinter Runnable to a random Hazelcast Cluster Member
     auto result_future = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"});
     // Wait for the result of the submitted task and print the result
@@ -2268,7 +2268,7 @@ void printOnTheMember(const std::string &input, const Member &member) {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Executor Service
-    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor").get();
     // Get the first Hazelcast Cluster Member
     member firstMember = hz.get_cluster().get_members()[0];
     // Submit the MessagePrinter Runnable to the first Hazelcast Cluster Member
@@ -2280,7 +2280,7 @@ void printOnTheMemberOwningTheKey(const std::string &input, const std::string &k
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Executor Service
-    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor").get();
     // Submit the MessagePrinter Runnable to the Hazelcast Cluster Member owning the key called "key"
     ex->execute_on_key_owner<MessagePrinter, std::string>(
             MessagePrinter{"message to the member that owns the key"}, "key").get();
@@ -2292,7 +2292,7 @@ void printOnSomewhere(const std::string &input) {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Executor Service
-    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor").get();
     // Submit the MessagePrinter Runnable to a random Hazelcast Cluster Member
     auto result_future = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"}).get();
 }
@@ -2303,7 +2303,7 @@ void printOnMembers(const std::string input, const std::vector<Member> &members)
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Executor Service
-    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor").get();
     ex->execute_on_members<MessagePrinter>(MessagePrinter{"message to very first member of the cluster"}, members);
 }
 ```
@@ -2536,7 +2536,7 @@ The code that runs on the entries is implemented in Java on the server side. The
 After the above implementations and configuration are done and you start the server where your library is added to its `CLASSPATH`, you can use the entry processor in the `imap` functions. See the following example.
 
 ```C++
-    auto map = hz.get_map("my-distributed-map");
+    auto map = hz.get_map("my-distributed-map").get();
     map->execute_on_key<std::string, IdentifiedEntryProcessor>("key", IdentifiedEntryProcessor("my new name"));
     std::cout << "Value for 'key' is : '" << *map->get<std::string, std::string>("key").get() << "'" << std::endl; // value for 'key' is 'my new name'
 ```
@@ -2728,7 +2728,7 @@ ILIKE is similar to the LIKE predicate but in a case-insensitive manner.
 You can use the `query::query_constants::KEY_ATTRIBUTE_NAME` (`__key`) attribute to perform a predicated search for entry keys. See the following example:
 
 ```C++
-    auto map = hz.get_map("personMap;");
+    auto map = hz.get_map("personMap").get();
     map->put<std::string, int>("Mali", 28).get();
     map->put<std::string, int>("Ahmet", 30).get();
     map->put<std::string, int>("Furkan", 23).get();
@@ -2742,7 +2742,7 @@ In this example, the code creates a list with the values whose keys start with t
 You can use `query::query_constants::THIS_ATTRIBUTE_NAME` (`this`) attribute to perform a predicated search for entry values. See the following example:
 
 ```C++
-    auto map = hz.get_map("personMap;");
+    auto map = hz.get_map("personMap").get();
     map->put<std::string, int>("Mali", 28).get();
     map->put<std::string, int>("Ahmet", 30).get();
     map->put<std::string, int>("Furkan", 23).get();
@@ -2820,7 +2820,7 @@ whether such an entry is going to be returned or not from a query is not defined
 The C++ client provides paging for defined predicates. With its `paging_predicate` object, you can get a list of keys, values, or entries page by page by filtering them with predicates and giving the size of the pages. Also, you can sort the entries by specifying comparators.
 
 ```C++
-    auto map = hz.get_map("personMap;");
+    auto map = hz.get_map("personMap").get();
     // paging_predicate with inner predicate (value < 10)
     auto predicate = intMap->new_paging_predicate<int, int>(5,
             query::greater_less_predicate(client, query::query_constants::THIS_ATTRIBUTE_NAME, 10, false, false));

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Then, you can run the application using the following command:
 int main() {
     hazelcast::client::hazelcast_client hz; // Connects to the cluster
 
-    auto personnel = hz.get_map("personnel_map");
+    auto personnel = hz.get_map("personnel_map").get();
     personnel->put<std::string, std::string>("Alice", "IT").get();
     personnel->put<std::string, std::string>("Bob", "IT").get();
     personnel->put<std::string, std::string>("Clark", "IT").get();
@@ -608,7 +608,7 @@ Then, you can run the application using the following command:
 int main() {
     hazelcast::client::hazelcast_client hz; // Connects to the cluster
 
-    auto personnel = hz.get_map("personnel_map");
+    auto personnel = hz.get_map("personnel_map").get();
     personnel->put<std::string, std::string>("Denise", "Sales").get();
     personnel->put<std::string, std::string>("Erwing", "Sales").get();
     personnel->put<std::string, std::string>("Fatih", "Sales").get();
@@ -906,7 +906,7 @@ In order to use JSON serialization, you should use the `hazelcast_json_value` ob
 ```C++
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
 
     map->put("item1", hazelcast::client::hazelcast_json_value("{ \"age\": 4 }")).get();
     map->put("item2", hazelcast::client::hazelcast_json_value("{ \"age\": 20 }")).get();
@@ -1468,7 +1468,7 @@ Hazelcast `replicated_map` is a distributed key-value data structure where the d
 A replicated_map usage example is shown below.
 
 ```C++
-    auto replicatedMap = hz.get_replicated_map("myReplicatedMap");
+    auto replicatedMap = hz.get_replicated_map("myReplicatedMap").get();
     replicatedMap->put<int, std::string>(1, "Furkan").get();
     replicatedMap->put<int, std::string>(2, "Ahmet").get();
     std::cout << "Replicated map value for key 2 is " << *replicatedMap->get<int, std::string>(2).get() << std::endl; // Replicated map value for key 2 is Ahmet
@@ -1545,7 +1545,7 @@ Hazelcast `ringbuffer` is a replicated but not partitioned data structure that s
 A ringbuffer usage example is shown below.
 
 ```C++
-    auto rb = hz.get_ring_buffer("rb");
+    auto rb = hz.get_ring_buffer("rb").get();
     // add two items into ring buffer
     rb->add(100).get();
     rb->add(200).get();
@@ -1585,7 +1585,7 @@ void listen_with_default_config() {
     hazelcast::client::hazelcast_client client;
 
     std::string topicName("MyReliableTopic");
-    auto topic = client.get_reliable_topic(topicName);
+    auto topic = client.get_reliable_topic(topicName).get();
 
     std::atomic<int> numberOfMessagesReceived{0};
     auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
@@ -1611,7 +1611,7 @@ void listen_with_config() {
     clientConfig.add_reliable_topic_config(reliableTopicConfig);
     hazelcast::client::hazelcast_client client(std::move(clientConfig));
 
-    auto topic = client.get_reliable_topic(topicName);
+    auto topic = client.get_reliable_topic(topicName).get();
 
     std::atomic<int> numberOfMessagesReceived{0};
     auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
@@ -1639,7 +1639,7 @@ A pn_counter usage example is shown below.
 ```C++
     hazelcast::client::hazelcast_client hz;
 
-    auto pnCounter = hz.get_pn_counter("pncounterexample");
+    auto pnCounter = hz.get_pn_counter("pncounterexample").get();
 
     std::cout << "Counter started with value:" << pnCounter->get().get() << std::endl;
 
@@ -1659,7 +1659,7 @@ Hazelcast `flake_id_generator` is used to generate cluster-wide unique identifie
 A flake_id_generator usage example is shown below.
 
 ```C++
-    auto generator = hz.get_flake_id_generator("flakeIdGenerator");
+    auto generator = hz.get_flake_id_generator("flakeIdGenerator").get();
     std::cout << "Id : " << generator->newId().get() << std::endl; // Id : <some unique number>
 ```
 
@@ -1966,7 +1966,7 @@ int main() {
     try {
         hazelcast::client::hazelcast_client hz;
 
-        hazelcast::client::cluster &cluster = hz.get_cluster();
+        hazelcast::client::cluster &cluster = hz.get_cluster().get();
         clusterPtr = &cluster;
         auto members = cluster.get_members();
         std::cout << "The following are members in the cluster:" << std::endl;
@@ -2076,7 +2076,7 @@ See the following example.
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("EntryListenerExampleMap");
+    auto map = hz.get_map("EntryListenerExampleMap").get();
 
     auto registrationId = map->add_entry_listener(
         entry_listener().
@@ -2107,7 +2107,7 @@ See the example below.
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("EntryListenerExampleMap");
+    auto map = hz.get_map("EntryListenerExampleMap").get();
 
     auto registrationId = map->add_entry_listener(
         entry_listener().
@@ -2319,7 +2319,7 @@ To cancel a task, you can use the `executor_promise<T>::cancel()` API. This API 
 The following code waits for the task to be completed in 3 seconds. If it is not finished within this period, a `timeout` is thrown from the `get()` method, and we cancel the task with the `cancel()` method. The remote execution of the task is being cancelled.
 
 ```
-                auto service = client->get_executor_service(get_test_name());
+                auto service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::CancellationAwareTask task{INT64_MAX};
 
@@ -2765,7 +2765,7 @@ possible to query these objects using the Hazelcast query methods explained in t
     std::string person2 = "{ \"name\": \"Jane\", \"age\": 24 }";
     std::string person3 = "{ \"name\": \"Trey\", \"age\": 17 }";
 
-    auto idPersonMap = hz.get_map("jsonValues");
+    auto idPersonMap = hz.get_map("jsonValues").get();
 
     idPersonMap->put<int, hazelcast_json_value>(1, hazelcast_json_value(person1)).get();
     idPersonMap->put<int, hazelcast_json_value>(2, hazelcast_json_value(person2)).get();

--- a/examples/Org.Website.Samples/CustomSerializerSample.cpp
+++ b/examples/Org.Website.Samples/CustomSerializerSample.cpp
@@ -56,7 +56,7 @@ namespace hazelcast {
 int main() {
     hazelcast_client hz;
 
-    auto map = hz.get_map("customMap");
+    auto map = hz.get_map("customMap").get();
     map->put(1L, Person{"My Person", false, 57}).get();
 
     return 0;

--- a/examples/Org.Website.Samples/EntryProcessorSample.cpp
+++ b/examples/Org.Website.Samples/EntryProcessorSample.cpp
@@ -53,7 +53,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Map from Cluster.
-    auto map = hz.get_map("my-distributed-map");
+    auto map = hz.get_map("my-distributed-map").get();
     // Put the integer value of 0 into the Distributed Map
     map->put("key", 0).get();
     // Run the IncEntryProcessor class on the Hazelcast Cluster Member holding the key called "key",

--- a/examples/Org.Website.Samples/ExecutorSample.cpp
+++ b/examples/Org.Website.Samples/ExecutorSample.cpp
@@ -122,7 +122,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Executor Service
-    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor");
+    std::shared_ptr<iexecutor_service> ex = hz.get_executor_service("my-distributed-executor").get();
     // Submit the MessagePrinter Runnable to a random Hazelcast Cluster Member
     auto result_future = ex->submit<MessagePrinter, std::string>(MessagePrinter{"message to any node"});
     // Wait for the result of the submitted task and print the result

--- a/examples/Org.Website.Samples/ListSample.cpp
+++ b/examples/Org.Website.Samples/ListSample.cpp
@@ -20,7 +20,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed List from Cluster.
-    auto list = hz.get_list("my-distributed-list");
+    auto list = hz.get_list("my-distributed-list").get();
     // Add elements to the list
     list->add("item1").get();
     // Using future continuation here so that the calls are not blocking

--- a/examples/Org.Website.Samples/MapSample.cpp
+++ b/examples/Org.Website.Samples/MapSample.cpp
@@ -20,7 +20,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Map from Cluster.
-    auto map = hz.get_map("my-distributed-map");
+    auto map = hz.get_map("my-distributed-map").get();
     //Standard Put and Get.
     map->put<std::string, std::string>("key", "value").get();
     map->get<std::string, std::string>("key").get();

--- a/examples/Org.Website.Samples/MultiMapSample.cpp
+++ b/examples/Org.Website.Samples/MultiMapSample.cpp
@@ -20,7 +20,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed MultiMap from Cluster.
-    auto multiMap = hz.get_multi_map("my-distributed-multimap");
+    auto multiMap = hz.get_multi_map("my-distributed-multimap").get();
     // Put values in the map against the same key
     multiMap->put("my-key", "value1").get();
     multiMap->put("my-key", "value2").get();

--- a/examples/Org.Website.Samples/QuerySample.cpp
+++ b/examples/Org.Website.Samples/QuerySample.cpp
@@ -66,7 +66,7 @@ void generate_users(std::shared_ptr<imap> users) {
 int main() {
     hazelcast_client hz;
     // Get a Distributed Map called "users"
-    auto users = hz.get_map("users");
+    auto users = hz.get_map("users").get();
     // Add some users to the Distributed Map
     generate_users(users);
     // Create a Predicate from a String (a SQL like Where clause)

--- a/examples/Org.Website.Samples/QueueSample.cpp
+++ b/examples/Org.Website.Samples/QueueSample.cpp
@@ -20,7 +20,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get a Blocking Queue called "my-distributed-queue"
-    auto queue = hz.get_queue("my-distributed-queue");
+    auto queue = hz.get_queue("my-distributed-queue").get();
     // Offer a String into the Distributed Queue
     queue->offer("item").get();
     // Poll the Distributed Queue and return the String

--- a/examples/Org.Website.Samples/ReplicatedMapSample.cpp
+++ b/examples/Org.Website.Samples/ReplicatedMapSample.cpp
@@ -20,7 +20,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get a Replicated Map called "my-replicated-map"
-    auto map = hz.get_replicated_map("my-replicated-map");
+    auto map = hz.get_replicated_map("my-replicated-map").get();
     // Add items to the set with duplicates
     // Put and Get a value from the Replicated Map
     auto replacedValue = map->put<std::string, std::string>("key", "value").get();

--- a/examples/Org.Website.Samples/RingBufferSample.cpp
+++ b/examples/Org.Website.Samples/RingBufferSample.cpp
@@ -19,7 +19,7 @@ using namespace hazelcast::client;
 int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
-    auto rb = hz.get_ringbuffer("rb");
+    auto rb = hz.get_ringbuffer("rb").get();
     // add two items into ring buffer
     rb->add(100).get();
     rb->add(200).get();

--- a/examples/Org.Website.Samples/SetSample.cpp
+++ b/examples/Org.Website.Samples/SetSample.cpp
@@ -20,7 +20,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get the Distributed Set from Cluster.
-    auto set = hz.get_set("my-distributed-set");
+    auto set = hz.get_set("my-distributed-set").get();
     // Add items to the set with duplicates
     set->add("item1").get();
     set->add("item1").get();

--- a/examples/Org.Website.Samples/TopicSample.cpp
+++ b/examples/Org.Website.Samples/TopicSample.cpp
@@ -21,7 +21,7 @@ int main() {
     // Start the Hazelcast Client and connect to an already running Hazelcast Cluster on 127.0.0.1
     hazelcast_client hz;
     // Get a Topic called "my-distributed-topic"
-    auto topic = hz.get_topic("my-distributed-topic");
+    auto topic = hz.get_topic("my-distributed-topic").get();
     // Add a Listener to the Topic
     topic->add_message_listener(
         topic::listener().

--- a/examples/authentication/token_authentication.cpp
+++ b/examples/authentication/token_authentication.cpp
@@ -27,7 +27,7 @@ int main() {
 
     hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
 
     map->put(1, 100).get();
 

--- a/examples/authentication/username_password_authentication.cpp
+++ b/examples/authentication/username_password_authentication.cpp
@@ -25,7 +25,7 @@ int main() {
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(1, 100).get();
 

--- a/examples/aws/AwsClientWithKey.cpp
+++ b/examples/aws/AwsClientWithKey.cpp
@@ -41,7 +41,7 @@ int main() {
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
 
     map->put(1, 100).get();
     map->put(2, 200).get();

--- a/examples/aws/AwsClientWithNoKeyNoIAMRoleInsideAws.cpp
+++ b/examples/aws/AwsClientWithNoKeyNoIAMRoleInsideAws.cpp
@@ -31,7 +31,7 @@ int main() {
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(1, 100).get();
     map->put(2, 200).get();

--- a/examples/aws/AwsClientWithNoKeyWithIAMRoleInsideAws.cpp
+++ b/examples/aws/AwsClientWithNoKeyWithIAMRoleInsideAws.cpp
@@ -31,7 +31,7 @@ int main() {
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(1, 100).get();
     map->put(2, 200).get();

--- a/examples/backpressure/EnableBackPressure.cpp
+++ b/examples/backpressure/EnableBackPressure.cpp
@@ -79,7 +79,7 @@ int main() {
 
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(1, 1).get();
 

--- a/examples/client-statistics/ClientStatistics.cpp
+++ b/examples/client-statistics/ClientStatistics.cpp
@@ -38,7 +38,7 @@ int main() {
     config.add_near_cache_config(config::near_cache_config("MyMap"));
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(2, 500).get();
 

--- a/examples/distributed-collections/blockingqueue/Consumer.cpp
+++ b/examples/distributed-collections/blockingqueue/Consumer.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto queue = hz.get_queue("queue");
+    auto queue = hz.get_queue("queue").get();
 
     while (true) {
         auto item = queue->take<int32_t>().get();

--- a/examples/distributed-collections/blockingqueue/Producer.cpp
+++ b/examples/distributed-collections/blockingqueue/Producer.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto queue = hz.get_queue("queue");
+    auto queue = hz.get_queue("queue").get();
 
     for (int k = 1; k < 100; k++) {
         queue->put(k).get();

--- a/examples/distributed-collections/itemlisteners/CollectionChanger.cpp
+++ b/examples/distributed-collections/itemlisteners/CollectionChanger.cpp
@@ -19,7 +19,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto queue = hz.get_queue("queue");
+    auto queue = hz.get_queue("queue").get();
 
     queue->put("foo").then([=] (boost::future<void> f) {
        f.get();

--- a/examples/distributed-collections/itemlisteners/item_listener.cpp
+++ b/examples/distributed-collections/itemlisteners/item_listener.cpp
@@ -20,7 +20,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto queue = hz.get_queue("queue");
+    auto queue = hz.get_queue("queue").get();
 
     std::atomic<int> numAdded(0);
     std::atomic<int> numRemoved(0);

--- a/examples/distributed-collections/list/Reader.cpp
+++ b/examples/distributed-collections/list/Reader.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto list = hz.get_list("list");
+    auto list = hz.get_list("list").get();
 
     for (auto &item : list->to_array<std::string>().get()) {
         std::cout << item << std::endl;

--- a/examples/distributed-collections/list/Writer.cpp
+++ b/examples/distributed-collections/list/Writer.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto list = hz.get_list("list");
+    auto list = hz.get_list("list").get();
 
     list->add("Tokyo").then(boost::launch::deferred, [=] (boost::future<bool> f) {
        if (f.get()) {

--- a/examples/distributed-collections/ringbuffer/RingbufferExample.cpp
+++ b/examples/distributed-collections/ringbuffer/RingbufferExample.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto rb = hz.get_ringbuffer("myringbuffer");
+    auto rb = hz.get_ringbuffer("myringbuffer").get();
 
     std::cout << "Capacity of the ringbuffer is:" << rb->capacity().get() << std::endl;
 

--- a/examples/distributed-collections/set/Reader.cpp
+++ b/examples/distributed-collections/set/Reader.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto set = hz.get_set("set");
+    auto set = hz.get_set("set").get();
 
     for (auto &item : set->to_array<std::string>().get()) {
         std::cout << item << std::endl;

--- a/examples/distributed-collections/set/Writer.cpp
+++ b/examples/distributed-collections/set/Writer.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto set = hz.get_set("set");
+    auto set = hz.get_set("set").get();
 
     set->add("Tokyo").get();
     set->add("Paris").get();

--- a/examples/distributed-map/basic/FillMap.cpp
+++ b/examples/distributed-map/basic/FillMap.cpp
@@ -18,13 +18,13 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
     map->put<std::string, std::string>("1", "Tokyo").get();
     map->put<std::string, std::string>("2", "Paris").get();
     map->put<std::string, std::string>("3", "New York").get();
     std::cout << "Finished loading map" << std::endl;
 
-    auto binaryMap = hz.get_map("MyBinaryMap");
+    auto binaryMap = hz.get_map("MyBinaryMap").get();
     std::vector<char> value(100);
     binaryMap->put(3, value).get();
     std::cout << "Inserted an entry with key 3 and a binary value to the binary map->" << std::endl;

--- a/examples/distributed-map/basic/PrintAll.cpp
+++ b/examples/distributed-map/basic/PrintAll.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
     auto entries = map->entry_set<std::string, std::string>().get();
     for (auto &entry : map->entry_set<std::string, std::string>().get()) {
         std::cout << entry.first << " " << entry.second << std::endl;

--- a/examples/distributed-map/custom-attributes/CarAttributeDemo.cpp
+++ b/examples/distributed-map/custom-attributes/CarAttributeDemo.cpp
@@ -87,7 +87,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("cars");
+    auto map = hz.get_map("cars").get();
 
     map->put(1, Car("Audi Q7", 250, 22000)).get();
     map->put(2, Car("BMW X5", 312, 34000)).get();

--- a/examples/distributed-map/entry-listener/ModifyMap.cpp
+++ b/examples/distributed-map/entry-listener/ModifyMap.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("somemap");
+    auto map = hz.get_map("somemap").get();
 
     std::string key{"some string key"};
 

--- a/examples/distributed-map/entry-listener/main.cpp
+++ b/examples/distributed-map/entry-listener/main.cpp
@@ -48,7 +48,7 @@ hazelcast::client::entry_listener make_listener() {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("somemap");
+    auto map = hz.get_map("somemap").get();
 
     auto listenerId = map->add_entry_listener(make_listener(), true).get();
 

--- a/examples/distributed-map/entry-processor/main.cpp
+++ b/examples/distributed-map/entry-processor/main.cpp
@@ -20,7 +20,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto employees = hz.get_map("employees");
+    auto employees = hz.get_map("employees").get();
 
     employees->put("John", employee{1000}).get();
     employees->put("Mark", employee{1000}).get();

--- a/examples/distributed-map/eviction/EvictAll.cpp
+++ b/examples/distributed-map/eviction/EvictAll.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("evictiontestmap");
+    auto map = hz.get_map("evictiontestmap").get();
 
     int numberOfKeysToLock = 4;
     int numberOfEntriesToAdd = 1000;

--- a/examples/distributed-map/index/main.cpp
+++ b/examples/distributed-map/index/main.cpp
@@ -51,7 +51,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("personsWithIndex");
+    auto map = hz.get_map("personsWithIndex").get();
 
     map->add_index(config::index_config::index_type::SORTED, "name").get();
 

--- a/examples/distributed-map/locking/AbaProtectedOptimisticUpdate.cpp
+++ b/examples/distributed-map/locking/AbaProtectedOptimisticUpdate.cpp
@@ -49,7 +49,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
 
     map->put("1", Value{});
     std::cout << "Starting" << std::endl;

--- a/examples/distributed-map/locking/OptimisticUpdate.cpp
+++ b/examples/distributed-map/locking/OptimisticUpdate.cpp
@@ -50,7 +50,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
 
     std::string key("1");
     Value v;

--- a/examples/distributed-map/locking/PessimisticUpdate.cpp
+++ b/examples/distributed-map/locking/PessimisticUpdate.cpp
@@ -50,7 +50,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
 
     std::string key("1");
     Value v;

--- a/examples/distributed-map/locking/RacyUpdate.cpp
+++ b/examples/distributed-map/locking/RacyUpdate.cpp
@@ -50,7 +50,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
 
     std::string key("1");
     Value v;

--- a/examples/distributed-map/map-interceptor/main.cpp
+++ b/examples/distributed-map/map-interceptor/main.cpp
@@ -44,7 +44,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("themap");
+    auto map = hz.get_map("themap").get();
 
     map->add_interceptor(MapInterceptor{}).get();
 

--- a/examples/distributed-map/multimap/MultimapPut.cpp
+++ b/examples/distributed-map/multimap/MultimapPut.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_multi_map("map");
+    auto map = hz.get_multi_map("map").get();
 
     map->put("a", "1").get();
     map->put("a", "2").get();

--- a/examples/distributed-map/multimap/PrintValues.cpp
+++ b/examples/distributed-map/multimap/PrintValues.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_multi_map("map");
+    auto map = hz.get_multi_map("map").get();
 
     for (auto &key : map->key_set<std::string>().get()) {
         std::cout << key << " -> (";

--- a/examples/distributed-map/near-cache/NearCacheWithEvictionPolicy.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithEvictionPolicy.cpp
@@ -27,7 +27,7 @@ int main() {
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
 
-    auto map = client.get_map(mapName);
+    auto map = client.get_map(mapName).get();
 
     for (int i = 1; i <= 100; i++) {
         map->put(i, std::string{"foo-"} + std::to_string(i)).get();

--- a/examples/distributed-map/near-cache/NearCacheWithInvalidation.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithInvalidation.cpp
@@ -29,8 +29,8 @@ int main() {
 
     hazelcast_client noNearCacheclient;
 
-    auto map = client.get_map(mapName);
-    auto noNearCacheMap = noNearCacheclient.get_map(mapName);
+    auto map = client.get_map(mapName).get();
+    auto noNearCacheMap = noNearCacheclient.get_map(mapName).get();
 
     noNearCacheMap->put<int, std::string>(1, "foo").get();
     NearCacheSupport::print_near_cache_stats(map, "The noNearCacheMap->put(key, \"foo\")) call has no effect on the Near Cache of map");

--- a/examples/distributed-map/near-cache/NearCacheWithMaxIdle.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithMaxIdle.cpp
@@ -32,7 +32,7 @@ int main() {
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
 
-    auto map = client.get_map(mapName);
+    auto map = client.get_map(mapName).get();
 
     map->put<int, std::string>(1, "foo").get();
     NearCacheSupport::print_near_cache_stats(map, "The put(1, article) call has no effect on the empty Near Cache");

--- a/examples/distributed-map/near-cache/NearCacheWithMemoryFormatBinary.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithMemoryFormatBinary.cpp
@@ -31,7 +31,7 @@ int main() {
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
 
-    auto map = client.get_map(mapName);
+    auto map = client.get_map(mapName).get();
 
     // the first get() will populate the Near Cache
     auto firstGet = map->get<int, std::string>(1).get();

--- a/examples/distributed-map/near-cache/NearCacheWithMemoryFormatObject.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithMemoryFormatObject.cpp
@@ -29,7 +29,7 @@ int main() {
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
 
-    auto map = client.get_map(mapName);
+    auto map = client.get_map(mapName).get();
 
     auto firstGet = map->get<int, std::string>(1).get();
     // the second and third get() will be served from the Near Cache

--- a/examples/distributed-map/near-cache/NearCacheWithTTL.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithTTL.cpp
@@ -30,7 +30,7 @@ int main() {
     config.add_near_cache_config(nearCacheConfig);
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map(mapName);
+    auto map = hz.get_map(mapName).get();
 
     map->put<int, std::string>(1, "myValue");
     NearCacheSupport::print_near_cache_stats(map, "The put(1, article) call has no effect on the empty Near Cache");

--- a/examples/distributed-map/partitionaware/partitionAwarePutGet.cpp
+++ b/examples/distributed-map/partitionaware/partitionAwarePutGet.cpp
@@ -61,7 +61,7 @@ int main() {
 
     PartitionAwareString partitionKey{"MyString"};
 
-    auto map = hz.get_map("paritionawaremap");
+    auto map = hz.get_map("paritionawaremap").get();
 
     // Puts the key, value tokyo at the partition for "desiredKeyString" rather than the partition for "MyString"
     map->put<PartitionAwareString, std::string>(partitionKey, "Tokyo").get();

--- a/examples/distributed-map/query/queryExample.cpp
+++ b/examples/distributed-map/query/queryExample.cpp
@@ -80,7 +80,7 @@ public:
     void run() {
         hazelcast::client::hazelcast_client hz;
 
-        auto personMap = hz.get_map("personMap");
+        auto personMap = hz.get_map("personMap").get();
 
         personMap->put_all<std::string, Person>({{"1", Person{"Peter", true, 36}},
                                                 {"2", Person{"John", true, 50}},
@@ -89,7 +89,7 @@ public:
                                                 {"5", Person{"Rob", true, 60}},
                                                 {"6", Person{"Jane", false, 43}}}).get();
 
-        auto s = hz.get_set("foo");
+        auto s = hz.get_set("foo").get();
         s->add(Person{"Peter", true, 37});
         auto personsInSet = s->to_array<Person>().get();
 
@@ -118,7 +118,7 @@ public:
 void query_map_using_paging_predicate() {
     hazelcast::client::hazelcast_client client;
 
-    auto intMap = client.get_map("testIntMapValuesWithpaging_predicate");
+    auto intMap = client.get_map("testIntMapValuesWithpaging_predicate").get();
 
     int predSize = 5;
     const int totalEntries = 25;
@@ -155,7 +155,7 @@ void query_map_using_paging_predicate() {
     values = intMap->values<int>(predicate2).get();
 
     // test paging predicate with comparator
-    auto employees = client.get_map("testComplexObjectWithpaging_predicate");
+    auto employees = client.get_map("testComplexObjectWithpaging_predicate").get();
     employees->put_all<int32_t, employee>({
                                                  {3, employee("ahmet", 35)},
                                                  {4, employee("mehmet", 21)},
@@ -177,7 +177,7 @@ void query_map_using_paging_predicate() {
 void query_map_using_different_predicates() {
     hazelcast::client::hazelcast_client client;
 
-    auto intMap = client.get_map("testValuesWithPredicateIntMap");
+    auto intMap = client.get_map("testValuesWithPredicateIntMap").get();
 
     const int numItems = 20;
     for (int i = 0; i < numItems; ++i) {
@@ -273,7 +273,7 @@ void query_map_using_different_predicates() {
                                                                         query::query_constants::THIS_ATTRIBUTE_NAME,
                                                                         inVals))).get();
 
-    auto imap = client.get_map("StringMap");
+    auto imap = client.get_map("StringMap").get();
 
     // like_predicate
     // value LIKE "value1" : {"value1"}

--- a/examples/distributed-map/removeAll/removeAllExample.cpp
+++ b/examples/distributed-map/removeAll/removeAllExample.cpp
@@ -60,7 +60,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto personMap = hz.get_map("personMap");
+    auto personMap = hz.get_map("personMap").get();
     personMap->put_all<std::string, Person>({{"1", Person{"Peter", true, 36}},
                        {"2", Person{"John", true, 50}},
                        {"3", Person{"Marry", false, 20}},

--- a/examples/distributed-primitives/crdt-pncounter/CrdtPNCounter.cpp
+++ b/examples/distributed-primitives/crdt-pncounter/CrdtPNCounter.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto pnCounter = hz.get_pn_counter("pncounterexample");
+    auto pnCounter = hz.get_pn_counter("pncounterexample").get();
 
     std::cout << "Counter started with value:" << pnCounter->get().get() << std::endl;
 

--- a/examples/distributed-topic/basic-pub-sub/Publisher.cpp
+++ b/examples/distributed-topic/basic-pub-sub/Publisher.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto topic = hz.get_topic("testtopic");
+    auto topic = hz.get_topic("testtopic").get();
     topic->publish("first message").get();
     std::cout << "Published: Published the message." << std::endl;
 

--- a/examples/distributed-topic/basic-pub-sub/Subscriber.cpp
+++ b/examples/distributed-topic/basic-pub-sub/Subscriber.cpp
@@ -20,7 +20,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto topic = hz.get_topic("testtopic");
+    auto topic = hz.get_topic("testtopic").get();
 
     topic->add_message_listener(
         hazelcast::client::topic::listener().

--- a/examples/distributed-topic/reliabletopic/Publisher.cpp
+++ b/examples/distributed-topic/reliabletopic/Publisher.cpp
@@ -18,7 +18,7 @@
 void publish_with_default_config() {
     hazelcast::client::hazelcast_client client;
 
-    auto topic = client.get_reliable_topic("MyReliableTopic");
+    auto topic = client.get_reliable_topic("MyReliableTopic").get();
     topic->publish(std::string("My first message")).get();
 }
 
@@ -30,7 +30,7 @@ void publish_with_non_default_config() {
     clientConfig.add_reliable_topic_config(reliableTopicConfig);
     hazelcast::client::hazelcast_client client(std::move(clientConfig));
 
-    auto topic = client.get_reliable_topic(topicName);
+    auto topic = client.get_reliable_topic(topicName).get();
 
     topic->publish(std::string("My first message")).get();
 }

--- a/examples/distributed-topic/reliabletopic/Subscriber.cpp
+++ b/examples/distributed-topic/reliabletopic/Subscriber.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <hazelcast/client/hazelcast_client.h>
+#include <hazelcast/client/topic/reliable_listener.h>
 
 hazelcast::client::topic::reliable_listener make_listener(std::atomic<int> &n_received_messages, int64_t sequence_id = -1) {
     using namespace hazelcast::client::topic;
@@ -36,7 +37,7 @@ void listen_with_default_config() {
     hazelcast::client::hazelcast_client client;
 
     std::string topicName("MyReliableTopic");
-    auto topic = client.get_reliable_topic(topicName);
+    auto topic = client.get_reliable_topic(topicName).get();
 
     std::atomic<int> numberOfMessagesReceived{0};
     auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
@@ -62,7 +63,7 @@ void listen_with_config() {
     clientConfig.add_reliable_topic_config(reliableTopicConfig);
     hazelcast::client::hazelcast_client client(std::move(clientConfig));
 
-    auto topic = client.get_reliable_topic(topicName);
+    auto topic = client.get_reliable_topic(topicName).get();
 
     std::atomic<int> numberOfMessagesReceived{0};
     auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));

--- a/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
+++ b/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
@@ -38,7 +38,7 @@ int main() {
 
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
 
     hazelcast::client::entry_listener listener;
 

--- a/examples/invocation-timeouts/SetInvocationTimeouts.cpp
+++ b/examples/invocation-timeouts/SetInvocationTimeouts.cpp
@@ -41,7 +41,7 @@ int main() {
 
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(1, 100).get();
 

--- a/examples/learning-basics/destroying-instances/main.cpp
+++ b/examples/learning-basics/destroying-instances/main.cpp
@@ -18,8 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto q1 = hz.get_queue("q");
-    auto q2 = hz.get_queue("q");
+    auto q1 = hz.get_queue("q").get();
+    auto q2 = hz.get_queue("q").get();
 
     q1->put("foo").get();
     std::cout << "q1->size:" << q1->size().get() << "  q2->size:" << q2->size().get() << std::endl;

--- a/examples/learning-basics/unique-names/main.cpp
+++ b/examples/learning-basics/unique-names/main.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto flakeIdGenerator = hz.get_flake_id_generator("idGenerator");
+    auto flakeIdGenerator = hz.get_flake_id_generator("idGenerator").get();
     std::ostringstream out("somemap");
     out << flakeIdGenerator->new_id().get();
     auto map = hz.get_map(out.str());

--- a/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
+++ b/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
@@ -36,7 +36,7 @@ int main() {
 
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
 
     map->put(1, 100);
 

--- a/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
+++ b/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
@@ -46,7 +46,7 @@ int main() {
 
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
 
     map->put(1, 100);
 

--- a/examples/pipeline/PipeliningDemo.cpp
+++ b/examples/pipeline/PipeliningDemo.cpp
@@ -30,7 +30,7 @@ using namespace hazelcast::util;
 
 class PipeliningDemo {
 public:
-    PipeliningDemo() : client_(), map_(client_.get_map("map")), gen_(rd_()) {}
+    PipeliningDemo() : client_(), map_(client_.get_map("map").get()), gen_(rd_()) {}
 
     void init() {
         for (int l = 0; l < keyDomain; l++) {

--- a/examples/replicated-map/basics/FillReplicatedMap.cpp
+++ b/examples/replicated-map/basics/FillReplicatedMap.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_replicated_map("map");
+    auto map = hz.get_replicated_map("map").get();
 
     map->put<std::string, std::string>("1", "Tokyo").get();
     map->put<std::string, std::string>("2", "Paris").get();

--- a/examples/replicated-map/basics/PrintAllReplicatedMap.cpp
+++ b/examples/replicated-map/basics/PrintAllReplicatedMap.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_replicated_map("map");
+    auto map = hz.get_replicated_map("map").get();
     for (auto &entry : map->entry_set<std::string, std::string>().get()) {
         std::cout << entry.first << " " << entry.second << std::endl;
     }

--- a/examples/replicated-map/entry-listener/ListeningReplicatedMap.cpp
+++ b/examples/replicated-map/entry-listener/ListeningReplicatedMap.cpp
@@ -19,7 +19,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_replicated_map("map");
+    auto map = hz.get_replicated_map("map").get();
 
     auto listenerId = map->add_entry_listener(
         hazelcast::client::entry_listener()

--- a/examples/replicated-map/entry-listener/ModifyReplicatedMap.cpp
+++ b/examples/replicated-map/entry-listener/ModifyReplicatedMap.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_replicated_map("somemap");
+    auto map = hz.get_replicated_map("somemap").get();
 
     std::ostringstream out;
     out << time(NULL);

--- a/examples/serialization/custom/main.cpp
+++ b/examples/serialization/custom/main.cpp
@@ -55,7 +55,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
     map->put("foo", Person{"bar", true, 40}).get();
     std::cout << *(map->get<std::string, Person>("foo").get()) << std::endl;
     std::cout << "Finished" << std::endl;

--- a/examples/serialization/globalserializer/main.cpp
+++ b/examples/serialization/globalserializer/main.cpp
@@ -47,7 +47,7 @@ int main() {
     config.get_serialization_config().set_global_serializer(std::make_shared<MyGlobalSerializer>());
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
     map->put("foo", Person{"first last name", false, 19}).get();
     std::cout << "Got value \"" << *(map->get<std::string, Person>("foo").get()) << "\" from the map->" << std::endl;
     std::cout << "Finished" << std::endl;

--- a/examples/serialization/identified-data-serializable/main.cpp
+++ b/examples/serialization/identified-data-serializable/main.cpp
@@ -58,7 +58,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
     map->put("foo", Person{"bar", true, 40}).get();
     std::cout << *(map->get<std::string, Person>("foo").get()) << std::endl;
 

--- a/examples/serialization/json/main.cpp
+++ b/examples/serialization/json/main.cpp
@@ -20,7 +20,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
 
     map->put("item1", hazelcast::client::hazelcast_json_value("{ \"age\": 4 }")).get();
     map->put("item2", hazelcast::client::hazelcast_json_value("{ \"age\": 20 }")).get();

--- a/examples/serialization/portable/main.cpp
+++ b/examples/serialization/portable/main.cpp
@@ -59,7 +59,7 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map");
+    auto map = hz.get_map("map").get();
     map->put("foo", Person{"bar", true, 40}).get();
     std::cout << *(map->get<std::string, Person>("foo").get()) << std::endl;
 

--- a/examples/soak-test/soak_test.cpp
+++ b/examples/soak-test/soak_test.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *args[]) {
     hazelcast_client hz(std::move(config));
     spi::ClientContext context(hz);
     auto &logger_ = context.get_logger();
-    auto map = hz.get_map("test");
+    auto map = hz.get_map("test").get();
 
     HZ_LOG(logger_, info, (boost::format(
             "Soak test is starting with the following parameters: threadCount = %1% ,  server address = %2%") %

--- a/examples/spi/proxy/main.cpp
+++ b/examples/spi/proxy/main.cpp
@@ -18,7 +18,7 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_distributed_object<hazelcast::client::iqueue>("queue distributed object");
+    auto map = hz.get_distributed_object<hazelcast::client::iqueue>("queue distributed object").get();
 
     std::cout << "Finished" << std::endl;
 

--- a/examples/tls/BasicTLSClient.cpp
+++ b/examples/tls/BasicTLSClient.cpp
@@ -31,7 +31,7 @@ int main() {
     
     hazelcast::client::hazelcast_client hz(std::move(config));
 
-    auto map = hz.get_map("MyMap");
+    auto map = hz.get_map("MyMap").get();
     
     map->put(1, 100).get();
     map->put(2, 200).get();

--- a/hazelcast/include/hazelcast/client/hazelcast_client.h
+++ b/hazelcast/include/hazelcast/client/hazelcast_client.h
@@ -75,7 +75,7 @@ namespace hazelcast {
             * @returns distributed object
             */
             template<typename T>
-            std::shared_ptr<T> get_distributed_object(const std::string& name) {
+            boost::shared_future<std::shared_ptr<T>> get_distributed_object(const std::string& name) {
                 return client_impl_->get_distributed_object<T>(name);
             }
 
@@ -88,7 +88,7 @@ namespace hazelcast {
             * @param name name of the distributed map
             * @return distributed map instance with the specified name
             */
-            std::shared_ptr<imap> get_map(const std::string &name) {
+            boost::shared_future<std::shared_ptr<imap>> get_map(const std::string &name) {
                 return client_impl_->get_distributed_object<imap>(name);
             }
 
@@ -98,11 +98,11 @@ namespace hazelcast {
             * @param name name of the distributed multimap
             * @return distributed multimap instance with the specified name
             */
-            std::shared_ptr<multi_map> get_multi_map(const std::string& name) {
+            boost::shared_future<std::shared_ptr<multi_map>> get_multi_map(const std::string& name) {
                 return client_impl_->get_distributed_object<multi_map>(name);
             }
 
-            std::shared_ptr<replicated_map> get_replicated_map(const std::string &name) {
+            boost::shared_future<std::shared_ptr<replicated_map>> get_replicated_map(const std::string &name) {
                 return client_impl_->get_distributed_object<replicated_map>(name);
             }
 
@@ -112,7 +112,7 @@ namespace hazelcast {
             * @param name name of the distributed queue
             * @return distributed queue instance with the specified name
             */
-            std::shared_ptr<iqueue> get_queue(const std::string& name) {
+            boost::shared_future<std::shared_ptr<iqueue>> get_queue(const std::string& name) {
                 return client_impl_->get_distributed_object<iqueue>(name);
             }
 
@@ -123,7 +123,7 @@ namespace hazelcast {
             * @param name name of the distributed set
             * @return distributed set instance with the specified name
             */
-            std::shared_ptr<iset> get_set(const std::string& name) {
+            boost::shared_future<std::shared_ptr<iset>> get_set(const std::string& name) {
                 return client_impl_->get_distributed_object<iset>(name);
             }
 
@@ -134,7 +134,7 @@ namespace hazelcast {
             * @param name name of the distributed list
             * @return distributed list instance with the specified name
             */
-            std::shared_ptr<ilist> get_list(const std::string& name) {
+            boost::shared_future<std::shared_ptr<ilist>> get_list(const std::string& name) {
                 return client_impl_->get_distributed_object<ilist>(name);
             }
 
@@ -144,7 +144,7 @@ namespace hazelcast {
             * @param name name of the distributed topic
             * @return distributed topic instance with the specified name
             */
-            std::shared_ptr<itopic> get_topic(const std::string& name) {
+            boost::shared_future<std::shared_ptr<itopic>> get_topic(const std::string& name) {
                 return client_impl_->get_distributed_object<itopic>(name);
             };
 
@@ -154,8 +154,12 @@ namespace hazelcast {
             * @param name name of the distributed topic
             * @return distributed topic instance with the specified name
             */
-            std::shared_ptr<reliable_topic> get_reliable_topic(const std::string& name) {
-                return client_impl_->get_distributed_object<reliable_topic>(name);
+            boost::shared_future<std::shared_ptr<reliable_topic>> get_reliable_topic(const std::string &name) {
+                return get_distributed_object<ringbuffer>(std::string(reliable_topic::TOPIC_RB_PREFIX) + name).then(
+                        boost::launch::deferred, [=](boost::shared_future<std::shared_ptr<ringbuffer>> f) {
+                            auto rb = f.get();
+                            return std::shared_ptr<reliable_topic>(new reliable_topic(rb, name, &rb->get_context()));
+                        });
             }
 
             /**
@@ -174,7 +178,7 @@ namespace hazelcast {
              * @param name name of the {@link flake_id_generator}
              * @return flake_id_generator for the given name
              */
-            std::shared_ptr<flake_id_generator> get_flake_id_generator(const std::string& name) {
+            boost::shared_future<std::shared_ptr<flake_id_generator>> get_flake_id_generator(const std::string& name) {
                 return client_impl_->get_distributed_object<flake_id_generator>(name);
             }
 
@@ -190,7 +194,7 @@ namespace hazelcast {
              * @param name the name of the PN counter
              * @return a {@link pn_counter}
              */
-            std::shared_ptr<pn_counter> get_pn_counter(const std::string& name) {
+            boost::shared_future<std::shared_ptr<pn_counter>> get_pn_counter(const std::string& name) {
                 return client_impl_->get_distributed_object<pn_counter>(name);
             }
 
@@ -200,7 +204,7 @@ namespace hazelcast {
              * @param name name of the distributed ringbuffer
              * @return distributed ringbuffer instance with the specified name
              */
-            std::shared_ptr<ringbuffer> get_ringbuffer(const std::string& name) {
+            boost::shared_future<std::shared_ptr<ringbuffer>> get_ringbuffer(const std::string& name) {
                 return client_impl_->get_distributed_object<ringbuffer>(name);
             }
 
@@ -215,7 +219,7 @@ namespace hazelcast {
              * @param name name of the executor service
              * @return the distributed executor service for the given name
              */
-            std::shared_ptr<iexecutor_service> get_executor_service(const std::string &name) {
+            boost::shared_future<std::shared_ptr<iexecutor_service>> get_executor_service(const std::string &name) {
                 return client_impl_->get_distributed_object<iexecutor_service>(name);
             }
 

--- a/hazelcast/include/hazelcast/client/impl/hazelcast_client_instance_impl.h
+++ b/hazelcast/include/hazelcast/client/impl/hazelcast_client_instance_impl.h
@@ -129,7 +129,7 @@ namespace hazelcast {
                 * @returns distributed object
                 */
                 template<typename T>
-                std::shared_ptr<T> get_distributed_object(const std::string& name) {
+                boost::shared_future<std::shared_ptr<T>> get_distributed_object(const std::string& name) {
                     return proxy_manager_.get_or_create_proxy<T>(T::SERVICE_NAME, name);
                 }
 
@@ -252,13 +252,11 @@ namespace hazelcast {
 
                 std::vector<std::shared_ptr<connection::AddressProvider> > create_address_providers();
 
-                void start_logger();
-
                 void initalize_near_cache_manager();
             };
 
             template<>
-            std::shared_ptr<imap> HAZELCAST_API hazelcast_client_instance_impl::get_distributed_object(const std::string& name);
+            boost::shared_future<std::shared_ptr<imap>> HAZELCAST_API hazelcast_client_instance_impl::get_distributed_object(const std::string& name);
         }
     }
 }

--- a/hazelcast/include/hazelcast/client/impl/statistics/Statistics.h
+++ b/hazelcast/include/hazelcast/client/impl/statistics/Statistics.h
@@ -102,7 +102,6 @@ namespace hazelcast {
                     logger &logger_;
                     bool enabled_;
                     PeriodicStatistics periodic_stats_;
-                    util::Sync<std::shared_ptr<address> > cached_owner_address_;
                     std::shared_ptr<boost::asio::steady_timer> send_task_timer_;
                 };
 

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
@@ -184,7 +184,7 @@ namespace hazelcast {
                             }
                         }
 
-                        const std::string &name_;
+                        std::string name_;
                         const client::config::near_cache_config &near_cache_config_;
                         std::shared_ptr<spi::impl::ClientExecutionServiceImpl> execution_service_;
                         serialization::pimpl::SerializationService &serialization_service_;

--- a/hazelcast/include/hazelcast/client/proxy/ReliableTopicImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReliableTopicImpl.h
@@ -13,24 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 #pragma once
 
 #include "hazelcast/client/proxy/ProxyImpl.h"
-#include "hazelcast/client/topic/impl/reliable/ReliableTopicMessage.h"
 #include "hazelcast/client/ringbuffer.h"
-#include "hazelcast/client/topic/reliable_listener.h"
-#include "hazelcast/client/protocol/ClientProtocolErrorCodes.h"
-#include "hazelcast/client/execution_callback.h"
-#include "hazelcast/client/topic/impl/reliable/ReliableTopicExecutor.h"
 #include "hazelcast/client/config/reliable_topic_config.h"
 #include "hazelcast/logger.h"
-
-#include <memory>
-
-#include <string>
-#include <stdint.h>
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -42,12 +30,12 @@ namespace hazelcast {
         namespace proxy {
             class HAZELCAST_API ReliableTopicImpl : public proxy::ProxyImpl {
             protected:
-                static constexpr const char * TOPIC_RB_PREFIX = "_hz_rb_";
-
-                ReliableTopicImpl(const std::string &instance_name, spi::ClientContext *context);
+                static constexpr const char *TOPIC_RB_PREFIX = "_hz_rb_";
+                ReliableTopicImpl(std::shared_ptr<ringbuffer> rb, const std::string &instance_name,
+                                  spi::ClientContext *context);
 
                 boost::future<void> publish(serialization::pimpl::data &&data);
-            protected:
+
                 std::shared_ptr<ringbuffer> ringbuffer_;
                 logger &logger_;
                 const config::reliable_topic_config config_;

--- a/hazelcast/include/hazelcast/client/spi/ProxyManager.h
+++ b/hazelcast/include/hazelcast/client/spi/ProxyManager.h
@@ -38,16 +38,16 @@ namespace hazelcast {
 
             class HAZELCAST_API ProxyManager {
             public:
-                typedef std::unordered_map<DefaultObjectNamespace, std::shared_future<std::shared_ptr<ClientProxy>>> proxy_map;
+                typedef std::unordered_map<DefaultObjectNamespace, boost::shared_future<std::shared_ptr<ClientProxy>>> proxy_map;
 
                 explicit ProxyManager(ClientContext &context);
 
                 template<typename T>
-                std::shared_ptr<T> get_or_create_proxy(const std::string &service, const std::string &id) {
+                boost::shared_future<std::shared_ptr<T>> get_or_create_proxy(const std::string &service, const std::string &id) {
                     DefaultObjectNamespace ns(service, id);
 
-                    std::shared_future<std::shared_ptr<ClientProxy>> proxyFuture;
-                    std::promise<std::shared_ptr<ClientProxy>> promise;
+                    boost::shared_future<std::shared_ptr<ClientProxy>> proxyFuture;
+                    boost::promise<std::shared_ptr<ClientProxy>> promise;
                     bool insertedEntry = false;
                     {
                         std::lock_guard<std::mutex> guard(lock_);
@@ -61,22 +61,24 @@ namespace hazelcast {
                     }
 
                     if (proxyFuture.valid()) {
-                        return std::static_pointer_cast<T>(proxyFuture.get());
+                        return proxyFuture.then(boost::launch::deferred, [] (boost::shared_future<std::shared_ptr<ClientProxy>> f) {
+                            return std::static_pointer_cast<T>(f.get());
+                        });
                     }
 
-                    try {
-                        auto clientProxy = std::shared_ptr<T>(new T(id, &client_));
-                        initialize(std::static_pointer_cast<ClientProxy>(clientProxy));
-                        promise.set_value(std::static_pointer_cast<ClientProxy>(clientProxy));
-                        return clientProxy;
-                    } catch (exception::iexception &) {
-                        promise.set_exception(std::current_exception());
-                        std::lock_guard<std::mutex> guard(lock_);
-                        if (insertedEntry) {
-                            proxies_.erase(ns);
+                    auto clientProxy = std::shared_ptr<T>(new T(id, &client_));
+                    return initialize(std::static_pointer_cast<ClientProxy>(clientProxy)).then(boost::launch::deferred, [=] (boost::future<void> f) {
+                        try {
+                            f.get();
+                            return clientProxy;
+                        } catch (...) {
+                            std::lock_guard<std::mutex> guard(lock_);
+                            if (insertedEntry) {
+                                proxies_.erase(ns);
+                            }
+                            throw;
                         }
-                        throw;
-                    }
+                    });
                 }
 
                 /**
@@ -100,7 +102,7 @@ namespace hazelcast {
                 void destroy();
 
             private:
-                void initialize(const std::shared_ptr<ClientProxy> &client_proxy);
+                boost::future<void> initialize(const std::shared_ptr<ClientProxy> &client_proxy);
 
                 proxy_map proxies_;
                 std::mutex lock_;

--- a/hazelcast/include/hazelcast/client/topic/reliable_listener.h
+++ b/hazelcast/include/hazelcast/client/topic/reliable_listener.h
@@ -15,16 +15,16 @@
  */
 #pragma once
 
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-#pragma warning(push)
-#pragma warning(disable: 4251) //for dll export
-#endif
-
 #include <cstdint>
 
 #include "hazelcast/client/exception/iexception.h"
 #include "hazelcast/util/noop.h"
 #include "hazelcast/util/type_traits.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export
+#endif
 
 namespace hazelcast {
     namespace client {
@@ -33,27 +33,27 @@ namespace hazelcast {
             class message;
 
             /**
-             * Listen to messages from a ReliableTopic
+             * Listen to messages from a reliable_topic
              *             
              * <h1>Durable Subscription</h1>
-             * ReliableListener allows you to control where you want to start processing a message when the listener is
+             * reliable_listener allows you to control where you want to start processing a message when the listener is
              * registered. This makes it possible to create a durable subscription by storing the sequence-id of the last message and
              * using this id as the id to start from.
              *
              * <h1>Exception handling</h1>
-             * ReliableListener also gives the ability to deal with exceptions via the method ReliableListener::terminate_on_exception.
+             * reliable_listener also gives the ability to deal with exceptions via the method reliable_listener::terminate_on_exception.
              *
              * <h1>Global order</h1>
-             * The ReliableListener will always get all events in order (global order). It will not get duplicates and
+             * The reliable_listener will always get all events in order (global order). It will not get duplicates and
              * there will only be gaps if it is too slow. For more information see {@link #isLossTolerant()}.
              *
              * <h1>Delivery guarantees</h1>
-             * Because the ReliableListener controls which item it wants to continue from upon restart, it is very easy to provide
-             * an at-least-once or at-most-once delivery guarantee. The function set via ReliableListener::on_store_sequence_id is always 
+             * Because the reliable_listener controls which item it wants to continue from upon restart, it is very easy to provide
+             * an at-least-once or at-most-once delivery guarantee. The function set via reliable_listener::on_store_sequence_id is always 
              * called before a message is processed; so the id can be persisted on some non-volatile storage. When the the stored
-             * sequence-id is then passed to ReliableListener::ReliableListener, an at-least-once delivery is implemented since the same 
+             * sequence-id is then passed to reliable_listener::reliable_listener, an at-least-once delivery is implemented since the same 
              * item is now being processed twice. To implement an at-most-once delivery guarantee, add 1 to the stored sequence-id before 
-             * passing it to ReliableListener::ReliableListener.
+             * passing it to reliable_listener::reliable_listener.
              */
             class HAZELCAST_API reliable_listener final {
                 friend class client::reliable_topic;
@@ -61,16 +61,14 @@ namespace hazelcast {
                 /**
                  * \param loss_tolerant true if this listener is able to deal with message loss. Even though the reliable topic 
                  * promises to be reliable, it can be that the listener is too slow. Eventually the message won't be 
-                 * available anymore. If the ReliableListener is not loss tolerant and the topic detects that there are
-                 * missing messages, it will terminate the ReliableListener.
+                 * available anymore. If the reliable_listener is not loss tolerant and the topic detects that there are
+                 * missing messages, it will terminate the reliable_listener.
                  * \param initial_sequence_id the initial sequence-id from which this listener should start. -1 if there is 
                  * no initial sequence-id and you want to start from the next published message. If you intent to create a 
                  * durable subscriber so you continue from where you stopped the previous time, load the previous 
                  * sequence-id and add 1. If you don't add one, then you will be receiving the same message twice.
                  */
-                reliable_listener(bool loss_tolerant, int64_t initial_sequence_id = -1)
-                    : loss_tolerant_(loss_tolerant)
-                    , initial_sequence_id_(initial_sequence_id) {}
+                explicit reliable_listener(bool loss_tolerant, int64_t initial_sequence_id = -1);
 
                 /**
                  * Set an handler function to be invoked when a message is received for the added topic. 
@@ -89,7 +87,7 @@ namespace hazelcast {
                 }
 
                 /**
-                 * \copydoc ReliableListener::on_received
+                 * \copydoc reliable_listener::on_received
                  */
                 template<typename Handler,
                          typename = util::enable_if_rvalue_ref_t<Handler &&>>
@@ -113,7 +111,7 @@ namespace hazelcast {
                 }
 
                 /**
-                 * \copydoc ReliableListener::on_store_sequence
+                 * \copydoc reliable_listener::on_store_sequence
                  */
                 template<typename Handler,
                          typename = util::enable_if_rvalue_ref_t<Handler &&>>
@@ -124,7 +122,7 @@ namespace hazelcast {
 
                 /**
                  * Set an handler function that checks if the listener should be terminated based on an exception
-                 * thrown while calling the function set by ReliableListener::on_received.
+                 * thrown while calling the function set by reliable_listener::on_received.
                  *
                  * \param h a `void` function object that is callable with a single parameter of type `const IException &`
                  * \return `*this`
@@ -137,7 +135,7 @@ namespace hazelcast {
                 }
 
                 /**
-                 * \copydoc ReliableListener::terminate_on_exception
+                 * \copydoc reliable_listener::terminate_on_exception
                  */
                 template<typename Handler,
                          typename = util::enable_if_rvalue_ref_t<Handler &&>>

--- a/hazelcast/src/hazelcast/client/stats.cpp
+++ b/hazelcast/src/hazelcast/client/stats.cpp
@@ -165,7 +165,7 @@ namespace hazelcast {
                 }
 
                 void Statistics::PeriodicStatistics::add_near_cache_stats(std::ostringstream &stats) {
-                    for (const std::shared_ptr<internal::nearcache::BaseNearCache> &nearCache : statistics_.client_context_.get_near_cache_manager().list_all_near_caches()) {
+                    for (auto nearCache : statistics_.client_context_.get_near_cache_manager().list_all_near_caches()) {
                         std::string nearCacheName = nearCache->get_name();
                         std::ostringstream nearCacheNameWithPrefix;
                         get_name_with_prefix(nearCacheName, nearCacheNameWithPrefix);

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -182,7 +182,7 @@ namespace hazelcast {
                 }
 
                 void produce_some_stats(hazelcast_client &client) {
-                    auto map = client.get_map(get_test_name());
+                    auto map = client.get_map(get_test_name()).get();
                     produce_some_stats(map);
                 }
 
@@ -266,7 +266,7 @@ namespace hazelcast {
                 hazelcast_client client(std::move(clientConfig));
 
                 // initialize near cache
-                client.get_map(mapName);
+                client.get_map(mapName).get();
 
                 // sleep twice the collection period
                 sleep_seconds(2);
@@ -373,7 +373,7 @@ namespace hazelcast {
                                             << "lastStatisticsCollectionTime value is not in correct (" << stats << ")";
 
                 // this creates empty map statistics
-                auto map = client->get_map(get_test_name());
+                auto map = client->get_map(get_test_name()).get();
 
                 statsMap = get_stats();
                 lastStatisticsCollectionTimeString = statsMap["lastStatisticsCollectionTime"];
@@ -467,8 +467,8 @@ namespace hazelcast {
                 protected:
                     void SetUp() override {
                         std::string testName = get_test_name();
-                        client_ringbuffer_ = client->get_ringbuffer(testName);
-                        client2_ringbuffer_ = client2->get_ringbuffer(testName);
+                        client_ringbuffer_ = client->get_ringbuffer(testName).get();
+                        client2_ringbuffer_ = client2->get_ringbuffer(testName).get();
                     }
 
                     void TearDown() override {
@@ -513,7 +513,7 @@ namespace hazelcast {
                 hazelcast_client *RingbufferTest::client2 = nullptr;
 
                 TEST_F(RingbufferTest, testAPI) {
-                    std::shared_ptr<ringbuffer> rb = client->get_ringbuffer(get_test_name() + "2");
+                    std::shared_ptr<ringbuffer> rb = client->get_ringbuffer(get_test_name() + "2").get();
                     ASSERT_EQ(CAPACITY, rb->capacity().get());
                     ASSERT_EQ(0, rb->head_sequence().get());
                     ASSERT_EQ(-1, rb->tail_sequence().get());
@@ -1248,25 +1248,25 @@ namespace hazelcast {
 
                     TEST_F(BasicPnCounterAPITest, testGetStart) {
                         std::shared_ptr<pn_counter> pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(0, pnCounter->get().get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testGetAndAdd) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(0, pnCounter->get_and_add(5).get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testAddAndGet) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(5, pnCounter->add_and_get(5).get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testGetAndAddExisting) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
 
                         ASSERT_EQ(0, pnCounter->get_and_add(2).get());
                         ASSERT_EQ(2, pnCounter->get_and_add(3).get());
@@ -1275,7 +1275,7 @@ namespace hazelcast {
 
                     TEST_F(BasicPnCounterAPITest, testGetAndIncrement) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(0, pnCounter->get_and_increment().get());
                         ASSERT_EQ(1, pnCounter->get_and_increment().get());
                         ASSERT_EQ(2, pnCounter->get().get());
@@ -1283,21 +1283,21 @@ namespace hazelcast {
 
                     TEST_F(BasicPnCounterAPITest, testIncrementAndGet) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(1, pnCounter->increment_and_get().get());
                         ASSERT_EQ(1, pnCounter->get().get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testGetAndDecrementFromDefault) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(0, pnCounter->get_and_decrement().get());
                         ASSERT_EQ(-1, pnCounter->get().get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testGetAndDecrement) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(1, pnCounter->increment_and_get().get());
                         ASSERT_EQ(1, pnCounter->get_and_decrement().get());
                         ASSERT_EQ(0, pnCounter->get().get());
@@ -1305,20 +1305,20 @@ namespace hazelcast {
 
                     TEST_F(BasicPnCounterAPITest, testGetAndSubtract) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(0, pnCounter->get_and_subtract(2).get());
                         ASSERT_EQ(-2, pnCounter->get().get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testSubtractAndGet) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         ASSERT_EQ(-3, pnCounter->subtract_and_get(3).get());
                     }
 
                     TEST_F(BasicPnCounterAPITest, testReset) {
                         auto pnCounter = client->get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                         pnCounter->reset().get();
                     }
 
@@ -1347,8 +1347,8 @@ namespace hazelcast {
 
                     TEST_F(PnCounterFunctionalityTest, testSimpleReplication) {
                         const char *name = testing::UnitTest::GetInstance()->current_test_info()->name();
-                        std::shared_ptr<pn_counter> counter1 = client->get_pn_counter(name);
-                        std::shared_ptr<pn_counter> counter2 = client->get_pn_counter(name);
+                        std::shared_ptr<pn_counter> counter1 = client->get_pn_counter(name).get();
+                        std::shared_ptr<pn_counter> counter2 = client->get_pn_counter(name).get();
 
                         ASSERT_EQ(5, counter1->add_and_get(5).get());
 
@@ -1358,8 +1358,8 @@ namespace hazelcast {
 
                     TEST_F(PnCounterFunctionalityTest, testParallelism) {
                         const char *name = testing::UnitTest::GetInstance()->current_test_info()->name();
-                        std::shared_ptr<pn_counter> counter1 = client->get_pn_counter(name);
-                        std::shared_ptr<pn_counter> counter2 = client->get_pn_counter(name);
+                        std::shared_ptr<pn_counter> counter1 = client->get_pn_counter(name).get();
+                        std::shared_ptr<pn_counter> counter2 = client->get_pn_counter(name).get();
 
                         int parallelism = 5;
                         int loopsPerThread = 100;
@@ -1396,7 +1396,7 @@ namespace hazelcast {
                         hazelcast_client client(std::move(config));
 
                         auto pnCounter = client.get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
 
                         ASSERT_THROW(pnCounter->add_and_get(5).get(), exception::no_data_member_in_cluster);
                     }
@@ -1435,7 +1435,7 @@ namespace hazelcast {
                         hazelcast_client client(std::move(config));
 
                         auto pnCounter = client.get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
 
                         pnCounter->add_and_get(5).get();
 
@@ -1459,7 +1459,7 @@ namespace hazelcast {
                         hazelcast_client client(std::move(config));
 
                         auto pnCounter = client.get_pn_counter(
-                                testing::UnitTest::GetInstance()->current_test_info()->name());
+                                testing::UnitTest::GetInstance()->current_test_info()->name()).get();
 
                         pnCounter->add_and_get(5).get();
 
@@ -1611,7 +1611,7 @@ namespace hazelcast {
                 client_config clientConfig = GetParam()();
                 hazelcast_client hazelcastClient(std::move(clientConfig));
 
-                auto map = hazelcastClient.get_map("testDeregisterListener");
+                auto map = hazelcastClient.get_map("testDeregisterListener").get();
 
                 ASSERT_FALSE(map->remove_entry_listener(spi::ClientContext(hazelcastClient).random_uuid()).get());
 
@@ -1641,7 +1641,7 @@ namespace hazelcast {
                 HazelcastServer instance(*g_srvFactory);
                 hazelcast_client hazelcastClient(GetParam()());
 
-                auto map = hazelcastClient.get_map("testEmptyListener");
+                auto map = hazelcastClient.get_map("testEmptyListener").get();
 
                 // empty listener with no handlers
                 entry_listener listener;
@@ -1679,7 +1679,7 @@ namespace hazelcast {
             protected:
                 virtual void SetUp() {
                     ASSERT_TRUE(client);
-                    flake_id_generator_ = client->get_flake_id_generator(testing::UnitTest::GetInstance()->current_test_info()->name());
+                    flake_id_generator_ = client->get_flake_id_generator(testing::UnitTest::GetInstance()->current_test_info()->name()).get();
                 }
 
                 static void SetUpTestCase() {
@@ -1776,12 +1776,12 @@ namespace hazelcast {
 
                 ASSERT_FALSE((map->put<std::string, std::string>("key1", "value1").get().has_value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
-                auto val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                auto val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 context.commit_transaction().get();
 
-                ASSERT_EQ("value1", (client_.get_map(name)->get<std::string, std::string>("key1").get().value()));
+                ASSERT_EQ("value1", (client_.get_map(name).get()->get<std::string, std::string>("key1").get().value()));
             }
 
             TEST_F(ClientTxnMapTest, testRemove) {
@@ -1794,7 +1794,7 @@ namespace hazelcast {
 
                 ASSERT_FALSE((map->put<std::string, std::string>("key1", "value1").get().has_value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
-                auto val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                auto val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 ASSERT_FALSE((map->remove<std::string, std::string>("key2").get().has_value()));
@@ -1804,7 +1804,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto regularMap = client_.get_map(name);
+                auto regularMap = client_.get_map(name).get();
                 ASSERT_TRUE(regularMap->is_empty().get());
             }
 
@@ -1819,7 +1819,7 @@ namespace hazelcast {
                 ASSERT_FALSE((map->put<std::string, std::string>("key1", "value1").get().has_value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
-                auto val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                auto val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 ASSERT_FALSE((map->remove<std::string, std::string>("key2").get().has_value()));;
@@ -1827,7 +1827,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto regularMap = client_.get_map(name);
+                auto regularMap = client_.get_map(name).get();
                 ASSERT_TRUE(regularMap->is_empty().get());
             }
 
@@ -1843,7 +1843,7 @@ namespace hazelcast {
 
                 ASSERT_FALSE((map->put<std::string, std::string>("key1", "value1").get().has_value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
-                auto val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                auto val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 ASSERT_NO_THROW(map->delete_entry("key1").get());
@@ -1852,7 +1852,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto regularMap = client_.get_map(name);
+                auto regularMap = client_.get_map(name).get();
                 ASSERT_TRUE(regularMap->is_empty().get());
             }
 
@@ -1866,14 +1866,14 @@ namespace hazelcast {
 
                 ASSERT_FALSE((map->put<std::string, std::string>("key1", "value1").get().has_value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
-                auto val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                auto val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 ASSERT_EQ("value1", (map->replace<std::string, std::string>("key1", "myNewValue").get().value()));
 
                 context.commit_transaction().get();
 
-                ASSERT_EQ("myNewValue", (client_.get_map(name)->get<std::string, std::string>("key1").get().value()));
+                ASSERT_EQ("myNewValue", (client_.get_map(name).get()->get<std::string, std::string>("key1").get().value()));
             }
 
             TEST_F(ClientTxnMapTest, testSet) {
@@ -1890,7 +1890,7 @@ namespace hazelcast {
                 ASSERT_TRUE(val.has_value());
                 ASSERT_EQ("value1", val.value());
 
-                val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 ASSERT_NO_THROW(map->set("key1", "myNewValue").get());
@@ -1901,7 +1901,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_TRUE(val.has_value());
                 ASSERT_EQ("myNewValue", val.value());
             }
@@ -1926,7 +1926,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto regularMap = client_.get_map(name);
+                auto regularMap = client_.get_map(name).get();
                 ASSERT_TRUE(regularMap->contains_key("key1").get());
             }
 
@@ -1940,7 +1940,7 @@ namespace hazelcast {
 
                 ASSERT_FALSE((map->put<std::string, std::string>("key1", "value1").get().has_value()));
                 ASSERT_EQ("value1", (map->get<std::string, std::string>("key1").get().value()));
-                auto val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                auto val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 ASSERT_FALSE(map->replace("key1", "valueNonExistent", "myNewValue").get());
@@ -1948,7 +1948,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                ASSERT_EQ("myNewValue", (client_.get_map(name)->get<std::string, std::string>("key1").get().value()));
+                ASSERT_EQ("myNewValue", (client_.get_map(name).get()->get<std::string, std::string>("key1").get().value()));
             }
 
             TEST_F(ClientTxnMapTest, testPutIfSame) {
@@ -1964,7 +1964,7 @@ namespace hazelcast {
                 val = map->get<std::string, std::string>("key1").get();
                 ASSERT_TRUE(val.has_value());
                 ASSERT_EQ("value1", val.value());
-                val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_FALSE(val.has_value());
 
                 val = map->put_if_absent<std::string, std::string>("key1", "value1").get();
@@ -1973,7 +1973,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                val = client_.get_map(name)->get<std::string, std::string>("key1").get();
+                val = client_.get_map(name).get()->get<std::string, std::string>("key1").get();
                 ASSERT_TRUE(val.has_value());
                 ASSERT_EQ("value1", val.value());
             }
@@ -2017,7 +2017,7 @@ namespace hazelcast {
 
             TEST_F(ClientTxnMapTest, testKeySetValues) {
                 std::string name = "testKeySetValues";
-                auto map = client_.get_map(name);
+                auto map = client_.get_map(name).get();
                 map->put<std::string, std::string>("key1", "value1").get();
                 map->put<std::string, std::string>("key2", "value2").get();
 
@@ -2040,7 +2040,7 @@ namespace hazelcast {
 
             TEST_F(ClientTxnMapTest, testKeySetAndValuesWithPredicates) {
                 std::string name = "testKeysetAndValuesWithPredicates";
-                auto map = client_.get_map(name);
+                auto map = client_.get_map(name).get();
 
                 employee emp1("abc-123-xvz", 34);
                 employee emp2("abc-123-xvz", 20);
@@ -2085,7 +2085,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto regularMap = client_.get_map(name);
+                auto regularMap = client_.get_map(name).get();
                 ASSERT_FALSE(regularMap->is_empty().get());
             }
         }
@@ -2112,7 +2112,7 @@ namespace hazelcast {
             ClientTxnSetTest::~ClientTxnSetTest() = default;
 
             TEST_F(ClientTxnSetTest, testAddRemove) {
-                auto s = client_.get_set("testAddRemove");
+                auto s = client_.get_set("testAddRemove").get();
                 s->add<std::string>("item1").get();
 
                 transaction_context context = client_.new_transaction_context();
@@ -2216,7 +2216,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto q = client_->get_queue(queueName);
+                auto q = client_->get_queue(queueName).get();
                 auto  retrievedElement = q->poll<std::string>().get();
                 ASSERT_TRUE(retrievedElement.has_value());
                 ASSERT_EQ(value, retrievedElement.value());
@@ -2237,7 +2237,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto q = uniSocketClient.get_queue(queueName);
+                auto q = uniSocketClient.get_queue(queueName).get();
                 auto  retrievedElement = q->poll<std::string>().get();
                 ASSERT_TRUE(retrievedElement.has_value());
                 ASSERT_EQ(value, retrievedElement.value());
@@ -2259,7 +2259,7 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto q = client_->get_queue(queueName);
+                auto q = client_->get_queue(queueName).get();
                 auto  retrievedElement = q->poll<std::string>().get();
                 ASSERT_TRUE(retrievedElement.has_value());
                 ASSERT_EQ(value, retrievedElement.value());
@@ -2305,7 +2305,7 @@ namespace hazelcast {
                 ASSERT_OPEN_EVENTUALLY(txnRollbackLatch);
                 ASSERT_OPEN_EVENTUALLY(memberRemovedLatch);
 
-                auto q = client_->get_queue(queueName);
+                auto q = client_->get_queue(queueName).get();
                 ASSERT_FALSE(q->poll<std::string>().get().has_value())
                                             << "Poll result should be null since it is rolled back";
                 ASSERT_EQ(0, q->size().get());
@@ -2335,7 +2335,7 @@ namespace hazelcast {
                 ASSERT_OPEN_EVENTUALLY(txnRollbackLatch);
                 ASSERT_OPEN_EVENTUALLY(memberRemovedLatch);
 
-                auto q = client_->get_queue(queueName);
+                auto q = client_->get_queue(queueName).get();
                 ASSERT_FALSE(q->poll<std::string>().get().has_value()) << "queue poll should return null";
                 ASSERT_EQ(0, q->size().get());
             }
@@ -2363,7 +2363,7 @@ namespace hazelcast {
             ClientTxnListTest::~ClientTxnListTest() = default;
 
             TEST_F(ClientTxnListTest, testAddRemove) {
-                auto l = client_.get_list("testAddRemove");
+                auto l = client_.get_list("testAddRemove").get();
                 l->add<std::string>("item1").get();
 
                 transaction_context context = client_.new_transaction_context();
@@ -2418,12 +2418,12 @@ namespace hazelcast {
 
                 context.commit_transaction().get();
 
-                auto mm = client_.get_multi_map("testRemoveIfExists");
+                auto mm = client_.get_multi_map("testRemoveIfExists").get();
                 ASSERT_EQ(2, (int) (mm->get<std::string, std::string>(key).get().size()));
             }
 
             TEST_F(ClientTxnMultiMapTest, testPutGetRemove) {
-                auto mm = client_.get_multi_map("testPutGetRemove");
+                auto mm = client_.get_multi_map("testPutGetRemove").get();
                 constexpr int n = 10;
 
                 std::array<boost::future<void>, n> futures;
@@ -2431,10 +2431,10 @@ namespace hazelcast {
                     futures[i] = boost::async(std::packaged_task<void()>([&]() {
                         std::string key = std::to_string(hazelcast::util::get_current_thread_id());
                         std::string key2 = key + "2";
-                        client_.get_multi_map("testPutGetRemove")->put(key, "value").get();
+                        client_.get_multi_map("testPutGetRemove").get()->put(key, "value").get();
                         transaction_context context = client_.new_transaction_context();
                         context.begin_transaction().get();
-                        auto multiMap = context.get_multi_map("testPutGetRemove");
+                        auto multiMap = context.get_multi_map("testPutGetRemove").get();
                         ASSERT_FALSE(multiMap->put(key, "value").get());
                         ASSERT_TRUE(multiMap->put(key, "value1").get());
                         ASSERT_TRUE(multiMap->put(key, "value2").get());
@@ -2485,7 +2485,7 @@ namespace hazelcast {
                 ASSERT_EQ("ali", q->poll<std::string>().get().value());
                 ASSERT_EQ(0, q->size().get());
                 context.commit_transaction().get();
-                ASSERT_EQ(0, client_.get_queue(name)->size().get());
+                ASSERT_EQ(0, client_.get_queue(name).get()->size().get());
             }
 
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPollByteVector) {
@@ -2500,14 +2500,14 @@ namespace hazelcast {
                 ASSERT_EQ(value, q->poll<std::vector<byte>>().get().value());
                 ASSERT_EQ(0, q->size().get());
                 context.commit_transaction().get();
-                ASSERT_EQ(0, client_.get_queue(name)->size().get());
+                ASSERT_EQ(0, client_.get_queue(name).get()->size().get());
             }
 
             void test_transactional_offer_poll2_thread(hazelcast::util::ThreadArgs &args) {
                 boost::latch *latch1 = (boost::latch *) args.arg0;
                 hazelcast_client *client = (hazelcast_client *) args.arg1;
                 latch1->wait();
-                client->get_queue("defQueue0")->offer("item0").get();
+                client->get_queue("defQueue0").get()->offer("item0").get();
             }
 
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPoll2) {
@@ -2525,8 +2525,8 @@ namespace hazelcast {
 
                 ASSERT_NO_THROW(context.commit_transaction().get());
 
-                ASSERT_EQ(0, client_.get_queue("defQueue0")->size().get());
-                ASSERT_EQ("item0", client_.get_queue("defQueue1")->poll<std::string>().get().value());
+                ASSERT_EQ(0, client_.get_queue("defQueue0").get()->size().get());
+                ASSERT_EQ("item0", client_.get_queue("defQueue1").get()->poll<std::string>().get().value());
             }
         }
     }

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -622,7 +622,7 @@ namespace hazelcast {
 
                     ASSERT_OPEN_EVENTUALLY(connectedLatch);
 
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->size().get();
 
                     client.shutdown();
@@ -643,7 +643,7 @@ namespace hazelcast {
                     );
 
                     // no exception at this point
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->put(1, 5).get();
 
                     hazelcastInstance.shutdown();
@@ -670,7 +670,7 @@ namespace hazelcast {
                     );
 
                     // no exception at this point
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->put(1, 5).get();
 
                     server1.shutdown();
@@ -697,7 +697,7 @@ namespace hazelcast {
                     );
 
 // no exception at this point
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->put(1, 5).get();
 
                     hazelcastInstance.shutdown();
@@ -725,7 +725,7 @@ namespace hazelcast {
                     ASSERT_TRUE(client.get_lifecycle_service().is_running());
                     ASSERT_OPEN_EVENTUALLY(connectedLatch);
 
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->size().get();
 
                     client.shutdown();
@@ -764,7 +764,7 @@ namespace hazelcast {
                     ASSERT_TRUE(client.get_lifecycle_service().is_running());
                     ASSERT_OPEN_EVENTUALLY(reconnectedLatch);
 
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->size().get();
 
                     client.shutdown();
@@ -791,7 +791,7 @@ namespace hazelcast {
 
                     ASSERT_OPEN_EVENTUALLY(connectedLatch);
 
-                    auto map = client.get_map(random_map_name());
+                    auto map = client.get_map(random_map_name()).get();
                     map->put(1, 5).get();
 
                     client.add_lifecycle_listener(
@@ -835,7 +835,7 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(client_config());
 
-                    map = client->get_map(MAP_NAME);
+                    map = client->get_map(MAP_NAME).get();
                     expected = new std::vector<int>;
                     for (int k = 0; k < MAP_SIZE; ++k) {
                         int item = rand();

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -584,7 +584,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_async_start(true);
                     hazelcast_client client(std::move(client_config_));
 
-                    ASSERT_THROW((client.get_map(random_map_name())),
+                    ASSERT_THROW((client.get_map(random_map_name()).get()),
                                  exception::hazelcast_client_offline);
 
                     client.shutdown();
@@ -594,7 +594,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_async_start(true);
                     hazelcast_client client(std::move(client_config_));
                     client.shutdown();
-                    ASSERT_THROW((client.get_map(random_map_name())), exception::hazelcast_client_not_active);
+                    ASSERT_THROW((client.get_map(random_map_name()).get()), exception::hazelcast_client_not_active);
 
                     client.shutdown();
                 }
@@ -794,16 +794,12 @@ namespace hazelcast {
                     auto map = client.get_map(random_map_name()).get();
                     map->put(1, 5).get();
 
-                    client.add_lifecycle_listener(
-                        lifecycle_listener()
-                            .on_disconnected([&disconnectedLatch](){
+                    client.add_lifecycle_listener(lifecycle_listener().on_disconnected([&disconnectedLatch](){
                                 disconnectedLatch.try_count_down();
                             })
                     );
 
-                    client.add_lifecycle_listener(
-                        lifecycle_listener()
-                            .on_connected([&reconnectedLatch](){
+                    client.add_lifecycle_listener(lifecycle_listener().on_connected([&reconnectedLatch](){
                                 reconnectedLatch.try_count_down();
                             })
                     );

--- a/hazelcast/test/src/HazelcastTests3.cpp
+++ b/hazelcast/test/src/HazelcastTests3.cpp
@@ -273,19 +273,19 @@ namespace hazelcast {
             constexpr size_t ClientReplicatedMapTest::OPERATION_COUNT;
 
             TEST_F(ClientReplicatedMapTest, testEmptyMapIsEmpty) {
-                std::shared_ptr<replicated_map> map = client->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map = client->get_replicated_map(get_test_name()).get();
                 ASSERT_TRUE(map->is_empty().get()) << "map should be empty";
             }
 
             TEST_F(ClientReplicatedMapTest, testNonEmptyMapIsNotEmpty) {
-                auto map = client->get_replicated_map(get_test_name());
+                auto map = client->get_replicated_map(get_test_name()).get();
                 map->put(1, 1).get();
                 ASSERT_FALSE(map->is_empty().get()) << "map should not be empty";
             }
 
             TEST_F(ClientReplicatedMapTest, testPutAll) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 put_all_entries_into_map(map1);
                 verify_entries_in_map(map1);
@@ -295,20 +295,20 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testGet) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
                 put_entries_into_map(map1);
                 get_and_verify_entries_in_map(map1);
                 get_and_verify_entries_in_map(map2);
             }
 
             TEST_F(ClientReplicatedMapTest, testPutNullReturnValueDeserialization) {
-                auto map = client->get_replicated_map(get_test_name());
+                auto map = client->get_replicated_map(get_test_name()).get();
                 ASSERT_FALSE(map->put(1, 2).get().has_value()) << "Put should return null";
             }
 
             TEST_F(ClientReplicatedMapTest, testPutReturnValueDeserialization) {
-                auto map = client->get_replicated_map(get_test_name());
+                auto map = client->get_replicated_map(get_test_name()).get();
                 map->put(1, 2).get();
                 auto value = map->put(1, 3).get();
                 ASSERT_TRUE(value.has_value());
@@ -316,8 +316,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testAdd) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 put_entries_into_map(map1);
                 ASSERT_EQ(OPERATION_COUNT, map2->size().get());
@@ -327,8 +327,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testClear) {
-                std::shared_ptr<replicated_map> map1 =client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 =client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 =client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 =client2->get_replicated_map(get_test_name()).get();
 
                 put_entries_into_map(map1);
                 ASSERT_EQ(OPERATION_COUNT, map2->size().get());
@@ -342,8 +342,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testUpdate) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 put_entries_into_map(map1);
                 ASSERT_EQ(OPERATION_COUNT, map2->size().get());
@@ -358,8 +358,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testRemove) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 put_entries_into_map(map1);
                 ASSERT_EQ(OPERATION_COUNT, map2->size().get());
@@ -383,8 +383,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testSize) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 TEST_VALUES_TYPE testValues = build_test_values();
                 size_t half = testValues.size() / 2;
@@ -399,8 +399,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testContainsKey) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 put_entries_into_map(map1);
 
@@ -414,8 +414,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testContainsValue) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 TEST_VALUES_TYPE testValues = build_test_values();
                 size_t half = testValues.size() / 2;
@@ -435,8 +435,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testValues) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 TEST_VALUES_TYPE testValues = build_test_values();
                 size_t half = testValues.size() / 2;
@@ -455,8 +455,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testKeySet) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 TEST_VALUES_TYPE testValues = build_test_values();
                 size_t half = testValues.size() / 2;
@@ -476,8 +476,8 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testEntrySet) {
-                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name());
-                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map1 = client->get_replicated_map(get_test_name()).get();
+                std::shared_ptr<replicated_map> map2 = client2->get_replicated_map(get_test_name()).get();
 
                 TEST_VALUES_TYPE testValues = build_test_values();
                 size_t half = testValues.size() / 2;
@@ -504,7 +504,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testRetrieveUnknownValue) {
-                std::shared_ptr<replicated_map> map = client->get_replicated_map(get_test_name());
+                std::shared_ptr<replicated_map> map = client->get_replicated_map(get_test_name()).get();
                 auto value = map->get<std::string, std::string>("foo").get();
                 ASSERT_FALSE(value.has_value()) << "No entry with key foo should exist";
             }
@@ -515,13 +515,13 @@ namespace hazelcast {
                 hazelcast_client client1(get_client_config_with_near_cache_invalidation_enabled());
                 hazelcast_client client2(get_client_config_with_near_cache_invalidation_enabled());
 
-                auto replicatedMap1 = client1.get_replicated_map(mapName);
+                auto replicatedMap1 = client1.get_replicated_map(mapName).get();
 
                 replicatedMap1->put(1, 1).get();
 // puts key 1 to Near Cache
                 replicatedMap1->get<int, int>(1).get();
 
-                auto replicatedMap2 = client2.get_replicated_map(mapName);
+                auto replicatedMap2 = client2.get_replicated_map(mapName).get();
 // this should invalidate Near Cache of replicatedMap1
                 replicatedMap2->clear().get();
 
@@ -529,7 +529,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapTest, testClientPortableWithoutRegisteringToNode) {
-                auto sampleMap = client->get_replicated_map(get_test_name());
+                auto sampleMap = client->get_replicated_map(get_test_name()).get();
                 sampleMap->put(1, SamplePortable{666});
                 auto samplePortable = sampleMap->get<int, SamplePortable>(1).get();
                 ASSERT_TRUE(samplePortable.has_value());
@@ -635,14 +635,14 @@ namespace hazelcast {
             hazelcast_client *ClientReplicatedMapListenerTest::client2 = nullptr;
 
             TEST_F(ClientReplicatedMapListenerTest, testEntryAdded) {
-                auto replicatedMap = client->get_replicated_map(get_test_name());
+                auto replicatedMap = client->get_replicated_map(get_test_name()).get();
                 replicatedMap->add_entry_listener(make_event_counting_listener(state_)).get();
                 replicatedMap->put(1, 1).get();
                 ASSERT_EQ_EVENTUALLY(1, state_.add_count.load());
             }
 
             TEST_F(ClientReplicatedMapListenerTest, testEntryUpdated) {
-                auto replicatedMap = client->get_replicated_map(get_test_name());
+                auto replicatedMap = client->get_replicated_map(get_test_name()).get();
                 replicatedMap->add_entry_listener(make_event_counting_listener(state_)).get();
                 replicatedMap->put(1, 1).get();
                 replicatedMap->put(1, 2).get();
@@ -650,7 +650,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapListenerTest, testEntryRemoved) {
-                auto replicatedMap = client->get_replicated_map(get_test_name());
+                auto replicatedMap = client->get_replicated_map(get_test_name()).get();
                 replicatedMap->add_entry_listener(make_event_counting_listener(state_)).get();
                 replicatedMap->put(1, 1).get();
                 replicatedMap->remove<int, int>(1).get();
@@ -658,7 +658,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapListenerTest, testMapClear) {
-                auto replicatedMap = client->get_replicated_map(get_test_name());
+                auto replicatedMap = client->get_replicated_map(get_test_name()).get();
                 replicatedMap->add_entry_listener(make_event_counting_listener(state_)).get();
                 replicatedMap->put(1, 1).get();
                 replicatedMap->clear().get();
@@ -666,7 +666,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapListenerTest, testListenToKeyForEntryAdded) {
-                auto replicatedMap = client->get_replicated_map(get_test_name());
+                auto replicatedMap = client->get_replicated_map(get_test_name()).get();
                 replicatedMap->add_entry_listener(make_event_counting_listener(state_), 1).get();
                 replicatedMap->put(1, 1).get();
                 replicatedMap->put(2, 2).get();
@@ -675,7 +675,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientReplicatedMapListenerTest, testListenWithPredicate) {
-                auto replicatedMap = client->get_replicated_map(get_test_name());
+                auto replicatedMap = client->get_replicated_map(get_test_name()).get();
                 replicatedMap->add_entry_listener(make_event_counting_listener(state_), query::false_predicate(*client)).get();
                 replicatedMap->put(2, 2).get();
                 ASSERT_TRUE_ALL_THE_TIME((state_.add_count.load() == 0), 1);
@@ -821,7 +821,7 @@ namespace hazelcast {
 
                 void create_no_near_cache_context() {
                     client_ = std::unique_ptr<hazelcast_client>(new hazelcast_client(get_config()));
-                    no_near_cache_map_ = client_->get_replicated_map(get_test_name());
+                    no_near_cache_map_ = client_->get_replicated_map(get_test_name()).get();
                 }
 
                 void create_near_cache_context() {
@@ -829,7 +829,7 @@ namespace hazelcast {
                     nearCachedClientConfig.add_near_cache_config(near_cache_config_);
                     near_cached_client_ = std::unique_ptr<hazelcast_client>(
                             new hazelcast_client(std::move(nearCachedClientConfig)));
-                    near_cached_map_ = near_cached_client_->get_replicated_map(get_test_name());
+                    near_cached_map_ = near_cached_client_->get_replicated_map(get_test_name()).get();
                     spi::ClientContext clientContext(*near_cached_client_);
                     near_cache_manager_ = &clientContext.get_near_cache_manager();
                     near_cache_ = near_cache_manager_->
@@ -1257,7 +1257,7 @@ namespace hazelcast {
                     client_config_->add_near_cache_config(config);
 
                     client_ = std::unique_ptr<hazelcast_client>(new hazelcast_client(std::move(*client_config_)));
-                    map_ = client_->get_replicated_map(mapName);
+                    map_ = client_->get_replicated_map(mapName).get();
                     return map_;
                 }
 
@@ -1361,7 +1361,7 @@ namespace hazelcast {
             };
 
             ClientTopicTest::ClientTopicTest() : instance_(*g_srvFactory), client_(get_new_client()),
-                                                 topic_(client_.get_topic("ClientTopicTest")) {}
+                                                 topic_(client_.get_topic("ClientTopicTest").get()) {}
 
             TEST_F(ClientTopicTest, testTopicListeners) {
                 boost::latch latch1(10);

--- a/hazelcast/test/src/HazelcastTests5.cpp
+++ b/hazelcast/test/src/HazelcastTests5.cpp
@@ -395,7 +395,7 @@ namespace hazelcast {
                     clientConfig.get_serialization_config().set_global_serializer(
                             std::make_shared<WriteReadIntGlobalSerializer>());
                     client = new hazelcast_client(std::move(clientConfig));
-                    unknown_object_map = client->get_map("UnknownObject");
+                    unknown_object_map = client->get_map("UnknownObject").get();
                 }
 
                 static void TearDownTestCase() {
@@ -443,7 +443,7 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
-                    int_map = client->get_map("IntMap");
+                    int_map = client->get_map("IntMap").get();
                 }
 
                 static void TearDownTestCase() {
@@ -510,7 +510,7 @@ namespace hazelcast {
                     client_config clientConfig(get_config());
                     clientConfig.set_property(client_properties::PROP_HEARTBEAT_TIMEOUT, "20");
                     client = new hazelcast_client(std::move(clientConfig));
-                    map = client->get_map("map");
+                    map = client->get_map("map").get();
                 }
 
                 static void TearDownTestSuite() {
@@ -690,9 +690,9 @@ namespace hazelcast {
                 }
 
                 ClientMapTest() : client_(hazelcast_client(GetParam()())),
-                                  imap_(client_.get_map(imapName)),
-                                  int_map_(client_.get_map(intMapName)),
-                                  employees_(client_.get_map(employeesMapName)) {
+                                  imap_(client_.get_map(imapName).get()),
+                                  int_map_(client_.get_map(intMapName).get()),
+                                  employees_(client_.get_map(employeesMapName).get()) {
                 }
 
                 static void SetUpTestCase() {
@@ -737,8 +737,8 @@ namespace hazelcast {
                     employees_->destroy().get();
                     int_map_->destroy().get();
                     imap_->destroy().get();
-                    client_.get_map(ONE_SECOND_MAP_NAME)->destroy().get();
-                    client_.get_map("tradeMap")->destroy().get();
+                    client_.get_map(ONE_SECOND_MAP_NAME).get()->destroy().get();
+                    client_.get_map("tradeMap").get()->destroy().get();
                 }
 
                 void fill_map() {
@@ -947,7 +947,7 @@ namespace hazelcast {
             TEST_P(ClientMapTest, testPartitionAwareKey) {
                 int partitionKey = 5;
                 int value = 25;
-                std::shared_ptr<imap> map = client_.get_map(intMapName);
+                std::shared_ptr<imap> map = client_.get_map(intMapName).get();
                 PartitionAwareInt partitionAwareInt(partitionKey, 7);
                 map->put(partitionAwareInt, value).get();
                 boost::optional<int> val = map->get<PartitionAwareInt, int>(partitionAwareInt).get();
@@ -1049,7 +1049,7 @@ namespace hazelcast {
             }
 
             TEST_P(ClientMapTest, testPutConfigTtl) {
-                std::shared_ptr<imap> map = client_.get_map(ONE_SECOND_MAP_NAME);
+                std::shared_ptr<imap> map = client_.get_map(ONE_SECOND_MAP_NAME).get();
                 validate_expiry_invalidations(map, [=] () { map->put<std::string, std::string>("key1", "value1").get(); });
             }
 
@@ -1080,7 +1080,7 @@ namespace hazelcast {
             }
 
             TEST_P(ClientMapTest, testSetConfigTtl) {
-                std::shared_ptr<imap> map = client_.get_map(ONE_SECOND_MAP_NAME);
+                std::shared_ptr<imap> map = client_.get_map(ONE_SECOND_MAP_NAME).get();
                 validate_expiry_invalidations(map, [=] () { map->set("key1", "value1").get(); });
             }
 
@@ -2372,7 +2372,7 @@ namespace hazelcast {
             }
 
             TEST_P(ClientMapTest, testListenerWithPortableKey) {
-                std::shared_ptr<imap> tradeMap = client_.get_map("tradeMap");
+                std::shared_ptr<imap> tradeMap = client_.get_map("tradeMap").get();
                 boost::latch countDownLatch(1);
                 std::atomic<int> atomicInteger(0);
 
@@ -3328,7 +3328,7 @@ namespace hazelcast {
             }
 
             TEST_P(ClientMapTest, testJsonPutGet) {
-                std::shared_ptr<imap> map = client_.get_map(get_test_name());
+                std::shared_ptr<imap> map = client_.get_map(get_test_name()).get();
                 hazelcast_json_value value("{ \"age\": 4 }");
                 map->put("item1", value).get();
                 boost::optional<hazelcast_json_value> retrieved = map->get<std::string, hazelcast_json_value>("item1").get();
@@ -3338,7 +3338,7 @@ namespace hazelcast {
             }
 
             TEST_P(ClientMapTest, testQueryOverJsonObject) {
-                std::shared_ptr<imap> map = client_.get_map(get_test_name());
+                std::shared_ptr<imap> map = client_.get_map(get_test_name()).get();
                 hazelcast_json_value young("{ \"age\": 4 }");
                 hazelcast_json_value old("{ \"age\": 20 }");
                 map->put("item1", young).get();

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -141,7 +141,7 @@ namespace hazelcast {
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
-                    mm = client->get_multi_map("MyMultiMap");
+                    mm = client->get_multi_map("MyMultiMap").get();
                 }
 
                 static void TearDownTestCase() {
@@ -372,7 +372,7 @@ namespace hazelcast {
                     client_config clientConfig = get_config();
 #endif // HZ_BUILD_WITH_SSL
                     client = new hazelcast_client(std::move(clientConfig));
-                    list = client->get_list("MyList");
+                    list = client->get_list("MyList").get();
                 }
 
                 static void TearDownTestCase() {
@@ -572,7 +572,7 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(std::move(get_config().backup_acks_enabled(false)));
-                    q = client->get_queue("MyQueue");
+                    q = client->get_queue("MyQueue").get();
                 }
 
                 static void TearDownTestCase() {
@@ -995,19 +995,19 @@ namespace hazelcast {
             const size_t ClientExecutorServiceTest::numberOfMembers = 4;
 
             TEST_F(ClientExecutorServiceTest, testIsTerminated) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 ASSERT_FALSE(service->is_terminated().get());
             }
 
             TEST_F(ClientExecutorServiceTest, testIsShutdown) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 ASSERT_FALSE(service->is_shutdown().get());
             }
 
             TEST_F(ClientExecutorServiceTest, testShutdown) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 service->shutdown();
 
@@ -1015,7 +1015,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testShutdownMultipleTimes) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 service->shutdown();
                 service->shutdown();
@@ -1024,7 +1024,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testCancellationAwareTask_whenTimeOut) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::CancellationAwareTask task{INT64_MAX};
 
@@ -1034,7 +1034,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testFutureAfterCancellationAwareTaskTimeOut) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::CancellationAwareTask task{INT64_MAX};
 
@@ -1047,7 +1047,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testGetFutureAfterCancel) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::CancellationAwareTask task{INT64_MAX};
 
@@ -1062,7 +1062,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitFailingCallableException) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::FailingCallable task;
 
@@ -1072,7 +1072,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitFailingCallableException_withExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::shared_ptr<boost::latch> latch1(new boost::latch(1));
 
@@ -1085,7 +1085,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitFailingCallableReasonExceptionCause) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 auto failingFuture = service->submit<executor::tasks::FailingCallable, std::string>(
                         executor::tasks::FailingCallable()).get_future();
@@ -1094,7 +1094,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testExecute_withNoMemberSelected) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string mapName = random_map_name();
 
@@ -1109,7 +1109,7 @@ namespace hazelcast {
             TEST_F(ClientExecutorServiceTest, testCallableSerializedOnce) {
                 std::string name = get_test_name();
 
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name).get();
 
                 executor::tasks::SerializedCounterCallable counterCallable{0};
 
@@ -1123,7 +1123,7 @@ namespace hazelcast {
             TEST_F(ClientExecutorServiceTest, testCallableSerializedOnce_submitToAddress) {
                 std::string name = get_test_name();
 
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name).get();
 
                 executor::tasks::SerializedCounterCallable counterCallable{0};
 
@@ -1139,7 +1139,7 @@ namespace hazelcast {
             TEST_F(ClientExecutorServiceTest, testUnserializableResponse_exceptionPropagatesToClient) {
                 std::string name = get_test_name();
 
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name).get();
 
                 executor::tasks::TaskWithUnserializableResponse taskWithUnserializableResponse;
 
@@ -1152,7 +1152,7 @@ namespace hazelcast {
             TEST_F(ClientExecutorServiceTest, testUnserializableResponse_exceptionPropagatesToClientCallback) {
                 std::string name = get_test_name();
 
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(name).get();
 
                 executor::tasks::TaskWithUnserializableResponse taskWithUnserializableResponse;
 
@@ -1170,7 +1170,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitCallableToMember) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::GetMemberUuidTask task;
 
@@ -1186,7 +1186,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitCallableToMembers) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::GetMemberUuidTask task;
 
@@ -1207,7 +1207,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitCallable_withMemberSelector) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1221,7 +1221,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitCallableToMembers_withMemberSelector) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 executor::tasks::GetMemberUuidTask task;
                 executor::tasks::SelectAllMembers selectAll;
@@ -1240,7 +1240,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableToAllMembers) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1258,7 +1258,7 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, submitCallableToMember_withExecutionCallback) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
                 executor::tasks::MapPutPartitionAwareCallable<boost::uuids::uuid> callable(testName, spi::ClientContext(*client).random_uuid());
 
@@ -1271,14 +1271,14 @@ namespace hazelcast {
                 service->submit_to_member<executor::tasks::MapPutPartitionAwareCallable<boost::uuids::uuid>, boost::uuids::uuid>(callable, members[0],
                                                                                                     callback);
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 ASSERT_OPEN_EVENTUALLY(*latch1);
                 ASSERT_EQ(1, map->size().get());
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableToMember_withMultiExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::shared_ptr<boost::latch> responseLatch(new boost::latch(numberOfMembers));
                 std::shared_ptr<boost::latch> completeLatch(new boost::latch(numberOfMembers));
@@ -1298,7 +1298,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallable_withExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1317,7 +1317,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableToMembers_withExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::shared_ptr<boost::latch> responseLatch(
                         new boost::latch(numberOfMembers));
@@ -1338,7 +1338,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableToAllMembers_withMultiExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::shared_ptr<boost::latch> responseLatch(
                         new boost::latch(numberOfMembers));
@@ -1358,7 +1358,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableWithNullResultToAllMembers_withMultiExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::shared_ptr<boost::latch> responseLatch(new boost::latch(numberOfMembers));
                 std::shared_ptr<boost::latch> completeLatch(new boost::latch(numberOfMembers));
@@ -1375,7 +1375,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitCallable) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1388,7 +1388,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, testSubmitCallable_withExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1406,7 +1406,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableToKeyOwner) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1419,7 +1419,7 @@ namespace hazelcast {
             }
 
             TEST_F(ClientExecutorServiceTest, submitCallableToKeyOwner_withExecutionCallback) {
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name());
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(get_test_name()).get();
 
                 std::string msg = random_string();
                 executor::tasks::AppendCallable callable{msg};
@@ -1439,9 +1439,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, submitCallablePartitionAware) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 std::vector<member> members = client->get_cluster().get_members();
                 spi::ClientContext clientContext(*client);
@@ -1461,9 +1461,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, submitCallablePartitionAware_WithExecutionCallback) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 std::vector<member> members = client->get_cluster().get_members();
                 spi::ClientContext clientContext(*client);
@@ -1486,33 +1486,33 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, testExecute) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
                 service->execute(
                         executor::tasks::MapPutPartitionAwareCallable<std::string>(testName, "key"));
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 assertSizeEventually(1, map);
             }
 
             TEST_F(ClientExecutorServiceTest, testExecute_withMemberSelector) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
                 executor::tasks::SelectAllMembers selector;
 
                 service->execute(
                         executor::tasks::MapPutPartitionAwareCallable<std::string>(testName, "key"), selector);
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 assertSizeEventually(1, map);
             }
 
             TEST_F(ClientExecutorServiceTest, testExecuteOnKeyOwner) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
                 map->put(1, 1).get();
 
                 std::vector<member> members = client->get_cluster().get_members();
@@ -1530,9 +1530,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, testExecuteOnMember) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 std::vector<member> members = client->get_cluster().get_members();
                 member &member = members[0];
@@ -1547,9 +1547,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, testExecuteOnMembers) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 std::vector<member> allMembers = client->get_cluster().get_members();
                 std::vector<member> members(allMembers.begin(), allMembers.begin() + 2);
@@ -1563,9 +1563,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, testExecuteOnMembers_withEmptyCollection) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-               auto map = client->get_map(testName);
+               auto map = client->get_map(testName).get();
 
                 executor::tasks::MapPutPartitionAwareCallable<std::string> callable(testName, "key");
 
@@ -1576,9 +1576,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, testExecuteOnMembers_withSelector) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 executor::tasks::MapPutPartitionAwareCallable<std::string> callable(testName, "key");
 
@@ -1591,9 +1591,9 @@ namespace hazelcast {
 
             TEST_F(ClientExecutorServiceTest, testExecuteOnAllMembers) {
                 std::string testName = get_test_name();
-                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName);
+                std::shared_ptr<iexecutor_service> service = client->get_executor_service(testName).get();
 
-                auto map = client->get_map(testName);
+                auto map = client->get_map(testName).get();
 
                 executor::tasks::MapPutPartitionAwareCallable<std::string> callable(testName, "key");
 
@@ -1721,7 +1721,7 @@ namespace hazelcast {
                     clientConfig.get_network_config().get_aws_config().set_inside_aws(false);
 #endif
                     hazelcast_client hazelcastClient(std::move(clientConfig));
-                    auto map = hazelcastClient.get_map("myMap");
+                    auto map = hazelcastClient.get_map("myMap").get();
                     map->put(5, 20).get();
                     auto val = map->get<int, int>(5).get();
                     ASSERT_TRUE(val.has_value());
@@ -1743,7 +1743,7 @@ namespace hazelcast {
 #endif
 
                     hazelcast_client hazelcastClient(std::move(clientConfig));
-                    auto map = hazelcastClient.get_map("myMap");
+                    auto map = hazelcastClient.get_map("myMap").get();
                     map->put(5, 20).get();
                     auto val = map->get<int, int>(5).get();
                     ASSERT_TRUE(val.has_value());
@@ -1770,7 +1770,7 @@ namespace hazelcast {
                     FIPS_mode_set(1);
 
                     hazelcast_client hazelcastClient(std::move(clientConfig));
-                    auto map = hazelcastClient.get_map("myMap");
+                    auto map = hazelcastClient.get_map("myMap").get();
                     map->put(5, 20);
                     auto val = map->get<int, int>(5).get();
                     ASSERT_TRUE(val);

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -102,6 +102,7 @@
 #include "hazelcast/client/aws/utility/cloud_utility.h"
 #include "hazelcast/client/iset.h"
 #include "hazelcast/client/reliable_topic.h"
+#include "hazelcast/client/topic/reliable_listener.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -248,7 +249,7 @@ namespace hazelcast {
 
                 void create_no_near_cache_context() {
                     client_ = std::unique_ptr<hazelcast_client>(new hazelcast_client(get_config()));
-                    no_near_cache_map_ = client_->get_map(get_test_name());
+                    no_near_cache_map_ = client_->get_map(get_test_name()).get();
                 }
 
                 void create_near_cache_context() {
@@ -256,7 +257,7 @@ namespace hazelcast {
                     near_cached_client_config_.add_near_cache_config(near_cache_config_);
                     near_cached_client_ = std::unique_ptr<hazelcast_client>(
                             new hazelcast_client(std::move(near_cached_client_config_)));
-                    near_cached_map_ = near_cached_client_->get_map(get_test_name());
+                    near_cached_map_ = near_cached_client_->get_map(get_test_name()).get();
                     spi::ClientContext clientContext(*near_cached_client_);
                     near_cache_manager_ = &clientContext.get_near_cache_manager();
                     near_cache_ = near_cache_manager_->
@@ -695,7 +696,7 @@ namespace hazelcast {
                     client_config_->add_near_cache_config(config);
 
                     client_.reset(new hazelcast_client(std::move(*client_config_)));
-                    map_ = client_->get_map(mapName);
+                    map_ = client_->get_map(mapName).get();
                     return map_;
                 }
 
@@ -799,7 +800,7 @@ namespace hazelcast {
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
-                    set = client->get_set("MySet");
+                    set = client->get_set("MySet").get();
                 }
 
                 static void TearDownTestCase() {
@@ -987,7 +988,7 @@ namespace hazelcast {
             hazelcast_client *ReliableTopicTest::client = nullptr;
 
             TEST_F(ReliableTopicTest, testBasics) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testBasics"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testBasics").get());
                 ASSERT_EQ("testBasics", topic_->get_name());
 
                 auto state = std::make_shared<ListenerState>(1);
@@ -1008,7 +1009,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, testListenerSequence) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testListenerSequence"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testListenerSequence").get());
 
                 employee empl1("first", 10);
                 employee empl2("second", 20);
@@ -1030,7 +1031,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, removeMessageListener_whenExisting) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("removeMessageListener_whenExisting"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("removeMessageListener_whenExisting").get());
 
                 employee empl1("first", 10);
 
@@ -1047,14 +1048,14 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, removeMessageListener_whenNonExisting) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("removeMessageListener_whenNonExisting"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("removeMessageListener_whenNonExisting").get());
 
                 // remove listener
                 ASSERT_FALSE(topic_->remove_message_listener("abc"));
             }
 
             TEST_F(ReliableTopicTest, publishMultiple) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("publishMultiple"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("publishMultiple").get());
 
                 auto state = std::make_shared<ListenerState>(5);
                 ASSERT_NO_THROW(listener_id_ = topic_->add_message_listener(make_listener(state)));
@@ -1086,7 +1087,7 @@ namespace hazelcast {
                 clientConfig.add_reliable_topic_config(relConfig);
                 hazelcast_client configClient(std::move(clientConfig));
 
-                ASSERT_NO_THROW(topic_ = configClient.get_reliable_topic("testConfig"));
+                ASSERT_NO_THROW(topic_ = configClient.get_reliable_topic("testConfig").get());
 
                 auto state = std::make_shared<ListenerState>(5);
                 ASSERT_NO_THROW(listener_id_ = topic_->add_message_listener(make_listener(state)));
@@ -1111,7 +1112,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, testMessageFieldSetCorrectly) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testMessageFieldSetCorrectly"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testMessageFieldSetCorrectly").get());
 
                 auto state = std::make_shared<ListenerState>(1);
                 ASSERT_NO_THROW(listener_id_ = topic_->add_message_listener(make_listener(state)));
@@ -1136,7 +1137,7 @@ namespace hazelcast {
             }
 
             TEST_F(ReliableTopicTest, testAlwaysStartAfterTail) {
-                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testAlwaysStartAfterTail"));
+                ASSERT_NO_THROW(topic_ = client->get_reliable_topic("testAlwaysStartAfterTail").get());
                 ASSERT_NO_THROW(topic_->publish(1).get());
                 ASSERT_NO_THROW(topic_->publish(2).get());
                 ASSERT_NO_THROW(topic_->publish(3).get());
@@ -1337,7 +1338,7 @@ namespace hazelcast {
 
                         hazelcast_client hazelcastClient(std::move(clientConfig));
 
-                        auto map = hazelcastClient.get_map("cppDefault");
+                        auto map = hazelcastClient.get_map("cppDefault").get();
 
                         std::vector<std::future<void>> futures;
                         for (int i = 0; i < THREAD_COUNT; i++) {
@@ -1404,7 +1405,7 @@ namespace hazelcast {
 
                 hazelcast_client client(std::move(clientConfig));
 
-                auto map = client.get_map("m");
+                auto map = client.get_map("m").get();
                 int expected = 1000;
                 std::thread t;
                 for (int i = 0; i < expected; i++) {
@@ -1429,7 +1430,7 @@ namespace hazelcast {
                 hazelcast_client client(std::move(clientConfig));
 
                 // 3. Get a map
-                auto map = client.get_map("IssueTest_map");
+                auto map = client.get_map("IssueTest_map").get();
 
                 // 4. Subscribe client to entry added event
                 map->add_entry_listener(std::move(issue864_map_listener_), true).get();
@@ -1462,7 +1463,7 @@ namespace hazelcast {
                 // start a client
                 hazelcast_client client(get_config());
 
-                auto map = client.get_map("Issue221_test_map");
+                auto map = client.get_map("Issue221_test_map").get();
 
                 server.shutdown();
 


### PR DESCRIPTION
All proxy getters are made async by returning boost::future. This PR does not include the cp subsystem related proxies. I will send another PR for them.

    A minor fix to `DefaultNearCache` where the name was not cached correctly and an invalid reference was being kept, which caused the address sanitizer fail during the tests on llvm (mac OS). May be related to https://github.com/hazelcast/hazelcast-cpp-client/issues/676

