### PR TITLE
[windows] Prevent thread leakage in `hz_thread_pool` during shutdown

### DIFF
--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -1028,6 +1028,10 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
             // needed due to bug https://github.com/chriskohlhoff/asio/issues/431
             boost::asio::use_service<boost::asio::detail::win_iocp_io_context>(*pool_).stop();
+            // We need the following line so that the windows threads can be terminated. Otherwise,
+            // the threads stay dangling and cause resource leakage. Normally, the pool_ is destructed on client
+            // destruction but somehow it needs to be triggered at this point.
+            pool_.reset();
 #endif
         }
 


### PR DESCRIPTION
On windows, we need to destroy the thread pool on `hz_thread_pool` shutdown so that the windows thread can be closed, otherwise the threads stayt dangling at https://github.com/chriskohlhoff/asio/blob/asio-1-18-0/asio/include/asio/detail/impl/win_thread.ipp#L130.

This is really a work around and I do not know why it does not close the windows threads if the pool_ is destructed later when the client object is destroyed.

This fix is only needed for windows.

fixes #702
fixes #730