### PR TITLE
cpp-linux-nightly-release build failed due to missing permissions for docker 

### DIFF
--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -12,6 +12,6 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel.i686
 
 RUN dnf install -y wget bzip2
-RUN dnf install -y wget bzip2 && wget https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN dnf install -y wget bzip2 && wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
 
 

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel
 
 # install boost
-RUN dnf install -y wget bzip2 && wget https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN dnf install -y wget bzip2 && wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
 
 RUN ssh-keygen -A
 

--- a/docker/hazelcast-fedora22-x86_64.dockerfile
+++ b/docker/hazelcast-fedora22-x86_64.dockerfile
@@ -1,10 +1,10 @@
 FROM fedora:22
 
 RUN dnf groups install -y "Development Tools"
-RUN dnf install -y gcc-c++ openssl-devel cmake tar wget bzip2
+RUN dnf install -y gcc-c++ openssl-devel cmake tar wget bzip2 java-1.8.0-openjdk
 
 # install boost
-RUN wget https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN wget --quiet https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
 
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh && \
     chmod +x ./cmake-3.19.0-Linux-x86_64.sh && \

--- a/releaseLinux.sh
+++ b/releaseLinux.sh
@@ -47,10 +47,10 @@ docker stop linux_64_bit_release_build
 docker rm linux_64_bit_release_build
 
 echo "Starting the docker build for 32-bit"
-docker run -d --name linux_32_bit_release_build -v `pwd`:/hazelcast-cpp-client -w /hazelcast-cpp-client fedora_32 /bin/bash -l -c "scripts/build_linux_release_libraries.sh 32 ${relative_install_dir}"
+docker run -d --privileged --name linux_32_bit_release_build -v `pwd`:/hazelcast-cpp-client -w /hazelcast-cpp-client fedora_32 /bin/bash -l -c "scripts/build_linux_release_libraries.sh 32 ${relative_install_dir}"
 
 echo "Starting the docker build for 64-bit"
-docker run -d --name linux_64_bit_release_build -v `pwd`:/hazelcast-cpp-client -w /hazelcast-cpp-client fedora22_64 /bin/bash -l -c "scripts/build_linux_release_libraries.sh 64 ${relative_install_dir}"
+docker run -d --privileged --name linux_64_bit_release_build -v `pwd`:/hazelcast-cpp-client -w /hazelcast-cpp-client fedora22_64 /bin/bash -l -c "scripts/build_linux_release_libraries.sh 64 ${relative_install_dir}"
 
 echo "Waiting for 32-bit docker build to finish"
 result=`docker wait linux_32_bit_release_build`


### PR DESCRIPTION
The following is an example of the reason for failure in the nightly build:

```
Inside examples directory:
/hazelcast-cpp-client/examples
Created examples build directory 32_SHARED
ls: cannot access '.': Operation not permitted
ls: cannot access '..': Operation not permitted
ls: cannot access 'CMakeLists.txt': Operation not permitted
```

**Solution:** Added the `--privileged` permission while running docker for build linux release builds.

For the fedora22 builds to succeed, changed the boost version for fedora22 since the Boost started to require a minimum of OpenSSL 1.0.2 starting with version 1.73(https://www.boost.org/users/history/version_1_73_0.html) and fedora 22 only has openssl 1.0.1k available as the openssl-devel package.
    
Also added quiet mode for wget not to show the progress lines for download.

Added a new build cpp-fedora22-64-SHARED-Debug which only builds the release libraries without running any tests on fedora22.

Added a test build http://jenkins.hazelcast.com/job/ihsan-fedora22/9 for testing that the fix works.
