### PR TITLE
Client Exponential Connection Retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,14 @@
   * [5.1. Providing Member Addresses](#51-providing-member-addresses)
   * [5.2. Setting Smart Routing](#52-setting-smart-routing)
   * [5.3. Enabling Redo Operation](#53-enabling-redo-operation)
-  * [5.4. Setting Connection Timeout](#54-setting-connection-timeout)
-  * [5.5. Setting Connection Attempt Limit](#55-setting-connection-attempt-limit)
-  * [5.6. Setting Connection Attempt Period](#56-setting-connection-attempt-period)
-  * [5.7. Enabling Client TLS/SSL](#57-enabling-client-tlsssl)
-  * [5.8. Enabling Hazelcast AWS Cloud Discovery](#58-enabling-hazelcast-aws-cloud-discovery)
-  * [5.9. Authentication](#59-authentication)
-    * [5.9.1. Username Password Authentication](#591-authentication)
-    * [5.9.2. Token Authentication](#591-authentication)
-  * [5.10. Configuring Backup Acknowledgment](#59-configuring-backup-acknowledgment)    
+  * [5.4. Setting Cluster Connection Timeout](#54-setting-cluster-connection-timeout)
+  * [5.5. Advanced Cluster Connection Retry Configuration](#55-advanced-cluster-connection-retry-configuration)
+  * [5.6. Enabling Client TLS/SSL](#56-enabling-client-tlsssl)
+  * [5.7. Enabling Hazelcast AWS Cloud Discovery](#57-enabling-hazelcast-aws-cloud-discovery)
+  * [5.8. Authentication](#58-authentication)
+    * [5.8.1. Username Password Authentication](#581-authentication)
+    * [5.8.2. Token Authentication](#581-authentication)
+  * [5.9. Configuring Backup Acknowledgment](#59-configuring-backup-acknowledgment)    
 * [6. Securing Client Connection](#6-securing-client-connection)
   * [6.1. TLS/SSL](#61-tlsssl)
     * [6.1.1. TLS/SSL for Hazelcast Members](#611-tlsssl-for-hazelcast-members)
@@ -976,9 +975,8 @@ Here is an example of configuring the network for C++ Client programmatically.
     clientConfig.get_network_config().add_addresses({{"10.1.1.21", 5701}, {"10.1.1.22", 5703}});
     clientConfig.get_network_config().set_smart_routing(true);
     clientConfig.set_redo_operation(true);
-    clientConfig.get_network_config().set_connection_timeout(6000);
-    clientConfig.get_network_config().set_connection_attempt_period(5000);
-    clientConfig.get_network_config().set_connection_attempt_limit(5);
+    clientConfig.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+            std::chrono::seconds(30));
 ```
 
 ## 5.1. Providing Member Addresses
@@ -1019,54 +1017,44 @@ It enables/disables redo-able operations. While sending the requests to the rela
 
 Its default value is `false` (disabled).
 
-## 5.4. Setting Connection Timeout
-
-Connection timeout is the timeout value in milliseconds for the members to accept the client connection requests.
-If the member does not respond within the timeout, the client will retry to connect as many as `client_network_config::getConnectionAttemptLimit()` times.
+## 5.4. Setting Cluster Connection Timeout
+Cluster connection timeout is the timeout value for which the client tries to connect to the cluster. If the client can not connect to cluster during this timeout duration, the client shuts down itself and it can not be re-used (you need to obtain a new client).
  
-The following is an example configuration.
+The following example shows how yopu can set the cluster connection timeout to 30 seconds.
 
 ```C++
-    client_config clientConfig;
-    clientConfig.get_network_config().set_connection_timeout(6000);
+    client_config().get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(std::chrono::seconds(30));
 ```
 
-Its default value is `5000` milliseconds.
+## 5.5. Advanced Cluster Connection Retry Configuration
 
-## 5.5. Setting Connection Attempt Limit
-
-While the client is trying to connect initially to one of the members in the `client_network_config::get_addresses()` (and the cluster member list addresses if the cluster member list were loaded at least once during a previous connection to the cluster), that member might not be available at that moment. Instead of giving up, throwing an error and stopping the client, the client will retry as many as `client_network_config::getConnectionAttemptLimit()` times. This is also the case when the previously established connection between the client and that member goes down.
-
+When client is disconnected from the cluster, it searches for new connections to reconnect. You can configure the frequency of the reconnection attempts and client shutdown behavior using `connection_retry_config`.
 The following is an example configuration.
 
-```C++
-    client_config clientConfig;
-    clientConfig.get_network_config().set_connection_attempt_limit(5);
-```
-
-Its default value is `2`.
-
-## 5.6. Setting Connection Attempt Period
-
-Connection attempt period is the duration in milliseconds between the connection attempts defined by `client_network_config::getConnectionAttemptPeriod()`.
- 
-The following is an example configuration.
+Below is an example configuration. It configures a total timeout of 30 seconds to connect to a cluster, by initial backoff time being 100 milliseconds and doubling the time before every try with a jitter of 0.8  up to a maximum of 3 seconds backoff between each try..
 
 ```C++
-    client_config clientConfig;
-    clientConfig.get_network_config().set_connection_attempt_period(5000);
+    client_config().get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+            std::chrono::seconds(30)).set_multiplier(2.0).set_jitter(0.8).set_initial_backoff_duration(
+            std::chrono::seconds(100)).set_max_backoff_duration(std::chrono::seconds(3));
 ```
 
-Its default value is `3000` milliseconds.
+The following are configuration element descriptions:
 
-## 5.7. Enabling Client TLS/SSL
+* `initial_backoff_duration`: Specifies how long to wait (backoff) after the first failure before retrying.
+* `max_backoff_duration`: Specifies the upper limit for the backoff between each cluster connect tries.
+* `multiplier`: Factor to multiply the backoff after a failed retry.
+* `cluster_connect)timeout`: Timeout value for the client to give up to connect to the current cluster. If the client can not connect during this time, then it shuts down and it can not be re-used.
+* `jitter`: Specifies by how much to randomize backoffs.
+
+## 5.6. Enabling Client TLS/SSL
 
 You can use TLS/SSL to secure the connection between the clients and members. If you want to enable TLS/SSL
 for the client-cluster connection, you should set an SSL configuration. Please see the [TLS/SSL section](#61-tlsssl).
 
 As explained in the [TLS/SSL section](#61-tlsssl), Hazelcast members have key stores used to identify themselves (to other members) and Hazelcast C++ clients have certificate authorities used to define which members they can trust. 
 
-## 5.8. Enabling Hazelcast AWS Cloud Discovery
+## 5.7. Enabling Hazelcast AWS Cloud Discovery
 
 The C++ client can discover the existing Hazelcast servers in the Amazon AWS environment. The client queries the Amazon AWS environment using the [describe-instances] (http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html) query of AWS. The client finds only the up and running instances and filters them based on the filter config provided at the `client_aws_config` configuration.
  
@@ -1082,7 +1070,7 @@ You need to enable the discovery by calling the `set_enabled(true)`. You can set
  
 The C++ client works the same way as the Java client. For details, see [aws_client Configuration] (https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#awsclient-configuration) and [Hazelcast AWS Plugin] (https://github.com/hazelcast/hazelcast-aws/blob/master/README.md). 
 
-## 5.9. Authentication
+## 5.8. Authentication
 
 By default, the client does not use any authentication method and just uses the cluster "dev" to connect to. You can change which cluster to connect by using the configuration API `client_config::set_cluster_name`. This way, you can have multiple clusters in the network but the client will only be able to connect to the cluster with the correct cluster name (server should also be started with the cluster name configured to the same cluster name).
 
@@ -1091,7 +1079,7 @@ If you want to enable authentication, then the client can be configured in one o
 * Username password based authentication
 * Token based authentication
 
-## 5.9.1. Username Password Authentication
+## 5.8.1. Username Password Authentication
 
 The following is an example configuration where we set the username `test-user` and password `test-pass` to be used while trying to connect to the cluster:
 
@@ -1113,7 +1101,7 @@ Note that the server needs to be configured to use the same username and passwor
     </security>
 ```
 
-## 5.9.2. Token Authentication
+## 5.8.2. Token Authentication
 
 The following is an example configuration where we set the secret token bytes to be used while trying to connect to the cluster:
 
@@ -1137,7 +1125,7 @@ Note that the server needs to be configured to use the same token. An example se
     </security>
 ```
 
-## 5.10. Configuring Backup Acknowledgment
+## 5.9. Configuring Backup Acknowledgment
 
 When an operation with sync backup is sent by a client to the Hazelcast member(s), the acknowledgment of the operation's backup is sent to the client by the backup replica member(s). This improves the performance of the client operations.
 

--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ Its default value is `false` (disabled).
 ## 5.4. Setting Cluster Connection Timeout
 Cluster connection timeout is the timeout value for which the client tries to connect to the cluster. If the client can not connect to cluster during this timeout duration, the client shuts down itself and it can not be re-used (you need to obtain a new client).
  
-The following example shows how yopu can set the cluster connection timeout to 30 seconds.
+The following example shows how you can set the cluster connection timeout to 30 seconds.
 
 ```C++
     client_config().get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(std::chrono::seconds(30));

--- a/examples/network-configuration/connection-strategy/CMakeLists.txt
+++ b/examples/network-configuration/connection-strategy/CMakeLists.txt
@@ -16,4 +16,5 @@
 add_executable(startAsync StartAsync.cpp)
 add_executable(doNotReconnect DoNotReconnectToCluster.cpp)
 add_executable(reconnectAsync ReconnectAsync.cpp)
+add_executable(cluster_connection_retry cluster_connection_retry.cpp)
 

--- a/examples/network-configuration/connection-strategy/cluster_connection_retry.cpp
+++ b/examples/network-configuration/connection-strategy/cluster_connection_retry.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <future>
+#include <chrono>
+
+#include <hazelcast/client/hazelcast_client.h>
+#include <hazelcast/client/config/client_connection_strategy_config.h>
+#include <hazelcast/client/lifecycle_listener.h>
+#include <hazelcast/client/lifecycle_event.h>
+
+hazelcast::client::lifecycle_listener make_connection_listener(std::promise<void> &connected, std::promise<void> &disconnected) {
+    return hazelcast::client::lifecycle_listener()
+        .on_connected([&connected](){
+            connected.set_value();
+        })
+        .on_disconnected([&disconnected](){
+            disconnected.set_value();
+        });
+}
+
+int main() {
+    hazelcast::client::client_config config;
+
+    /**
+     * How a client reconnect to cluster after a disconnect can be configured. The following example configures a
+     * total timeout of 30 seconds to connect to a cluster, by initial backoff time being 100 milliseconds and
+     * doubling the time before every try with a jitter of 0.8 up to a maximum of 3 seconds backoff between each try.
+     */
+    config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+            std::chrono::seconds(30)).set_multiplier(2.0).set_jitter(0.8).set_initial_backoff_duration(
+            std::chrono::milliseconds(100)).set_max_backoff_duration(std::chrono::seconds(3));
+
+    hazelcast::client::hazelcast_client hz(std::move(config));
+
+    auto map = hz.get_map("MyMap").get();
+
+    map->put(1, 100);
+
+    std::promise<void> connected, disconnected;
+    hz.add_lifecycle_listener(make_connection_listener(connected, disconnected));
+
+    // Please shut down the cluster at this point.
+    disconnected.get_future().wait();
+
+    std::cout << "Client is disconnected from the cluster now." << std::endl;
+
+    auto connection_future = connected.get_future();
+    if (connection_future.wait_for(std::chrono::seconds(30)) == std::future_status::ready) {
+        std::cout << "The client is connected to the cluster within 10 seconds after disconnection as expected." << std::endl;
+    }
+
+    hz.shutdown();
+    std::cout << "Finished" << std::endl;
+
+    return 0;
+}
+

--- a/hazelcast/include/hazelcast/client/config/client_connection_strategy_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_connection_strategy_config.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "hazelcast/util/hazelcast_dll.h"
+#include "hazelcast/client/config/connection_retry_config.h"
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -84,10 +85,27 @@ namespace hazelcast {
                  */
                 client_connection_strategy_config &set_reconnect_mode(reconnect_mode reconnect_mode);
 
+                /**
+                 * connection_retry_config controls the period among the retries and when a client should give up
+                 * retrying. Exponential behaviour can be chosen or jitter can be added to wait periods.
+                 *
+                 * @return connection_retry_config the connection retry config to read or modify.
+                 */
+                connection_retry_config &get_retry_config();
+
+                /**
+                 * connection_retry_config controls the period among the retries and when a client should give up
+                 * retrying. Exponential behaviour can be chosen or jitter can be added to wait periods.
+                 *
+                 * @param connection_retry_config the connection retry config to read or modify.
+                 * @return the updated connection_retry_config
+                 */
+                client_connection_strategy_config &set_retry_config(const connection_retry_config &retry_config);
+
             private:
                 bool async_start_;
                 reconnect_mode reconnect_mode_;
-
+                connection_retry_config retry_config_;
             };
 
         }

--- a/hazelcast/include/hazelcast/client/config/client_connection_strategy_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_connection_strategy_config.h
@@ -98,7 +98,7 @@ namespace hazelcast {
                  * retrying. Exponential behaviour can be chosen or jitter can be added to wait periods.
                  *
                  * @param connection_retry_config the connection retry config to read or modify.
-                 * @return the updated connection_retry_config
+                 * @return the updated client_connection_strategy_config
                  */
                 client_connection_strategy_config &set_retry_config(const connection_retry_config &retry_config);
 
@@ -115,5 +115,4 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
 

--- a/hazelcast/include/hazelcast/client/config/client_connection_strategy_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_connection_strategy_config.h
@@ -100,7 +100,7 @@ namespace hazelcast {
                  * @param connection_retry_config the connection retry config to read or modify.
                  * @return the updated client_connection_strategy_config
                  */
-                client_connection_strategy_config &set_retry_config(const connection_retry_config &retry_config);
+                client_connection_strategy_config &set_retry_config(connection_retry_config retry_config);
 
             private:
                 bool async_start_;
@@ -115,4 +115,3 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-

--- a/hazelcast/include/hazelcast/client/config/client_network_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_network_config.h
@@ -115,42 +115,6 @@ namespace hazelcast {
                 client_network_config &set_smart_routing(bool smart_routing);
 
                 /**
-                 * See client_network_config#setConnectionAttemptLimit(int32_t) for details
-                 *
-                 * @return connection attempt Limit
-                 */
-                int32_t get_connection_attempt_limit() const;
-
-                /**
-                 * While client is trying to connect initially to one of the members in the client_network_config#addressList,
-                 * all might be not available. Instead of giving up, throwing Exception and stopping client, it will
-                 * attempt to retry as much as client_network_config#connectionAttemptLimit() times.
-                 *
-                 * @param connectionAttemptLimit number of times to attempt to connect
-                 *                               A zero value means try forever.
-                 *                               A negative value means default value
-                 * @return configured \client_network_config for chaining
-                 */
-                client_network_config &set_connection_attempt_limit(int32_t connection_attempt_limit);
-
-                /**
-                 * Period for the next attempt to find a member to connect.
-                 * <p>
-                 * See \client_network_config::connectionAttemptLimit
-                 *
-                 * @return connection attempt period
-                 */
-                std::chrono::milliseconds get_connection_attempt_period() const;
-
-                /**
-                 * Period for the next attempt to find a member to connect.
-                 *
-                 * @param period time to wait before another attempt. The resolution of time is up to milliseconds.
-                 * @return configured \client_network_config for chaining
-                 */
-                client_network_config &set_connection_attempt_period(const std::chrono::milliseconds &interval);
-
-                /**
                  * Returns the list of candidate addresses that client will use to establish initial connection
                  *
                  * @return list of addresses
@@ -184,16 +148,11 @@ namespace hazelcast {
                 socket_options &get_socket_options();
 
             private:
-                static int32_t CONNECTION_ATTEMPT_PERIOD;
-
                 config::ssl_config ssl_config_;
                 config::client_aws_config client_aws_config_;
 
                 std::chrono::milliseconds connection_timeout_;
                 bool smart_routing_;
-
-                int32_t connection_attempt_limit_;
-                std::chrono::milliseconds connection_attempt_period_;
 
                 std::vector<address> address_list_;
 

--- a/hazelcast/include/hazelcast/client/config/connection_retry_config.h
+++ b/hazelcast/include/hazelcast/client/config/connection_retry_config.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+
+#include "hazelcast/util/hazelcast_dll.h"
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(push)
+#pragma warning(disable: 4251) //for dll export	
+#endif
+
+namespace hazelcast {
+    namespace client {
+        namespace config {
+            /**
+             * Connection Retry Config is controls the period among the retries and when should a client gave up
+             * retrying. Exponential behaviour can be chosen or jitter can be added to wait periods.
+             */
+            class HAZELCAST_API connection_retry_config {
+            public:
+                /**
+                 * how long to wait after the first failure before retrying
+                 *
+                 * @return initial_backoff_duration_
+                 */
+                const std::chrono::milliseconds &get_initial_backoff_duration() const;
+
+                /**
+                 * @param initial_backoff_duration how long to wait after the first failure before retrying
+                 * @return updated connection_retry_config
+                 */
+                connection_retry_config &
+                set_initial_backoff_duration(const std::chrono::milliseconds &initial_backoff_duration);
+
+                /**
+                 * When backoff reaches this upper bound, it does not increase any more.
+                 *
+                 * @return max_backoff_duration_
+                 */
+                const std::chrono::milliseconds &get_max_backoff_duration() const;
+
+                /**
+                 * When backoff reaches this upper bound, it does not increase any more.
+                 *
+                 * @param max_backoff_duration upper bound on backoff
+                 * @return updated connection_retry_config
+                 */
+                connection_retry_config &set_max_backoff_duration(const std::chrono::milliseconds &max_backoff_duration);
+
+                /**
+                 * factor with which to multiply backoff time after a failed retry
+                 *
+                 * @return multiplier_
+                 */
+                double get_multiplier() const;
+
+                /**
+                 * @param multiplier factor with which to multiply backoff after a failed retry
+                 * @return updated connection_retry_config
+                 */
+                connection_retry_config &set_multiplier(double multiplier);
+
+                /**
+                 * Timeout value for the client to give up to connect to the current cluster
+                 *  Theclient can shutdown after reaching the timeout.
+                 *
+                 * @return cluster_connect_timeout_
+                 */
+                const std::chrono::milliseconds &get_cluster_connect_timeout() const;
+
+                /**
+                 * @param cluster_connect_timeout timeout for the client to give up to connect to the current cluster
+                 *                                    The client can shutdown after reaching the timeout.
+                 * @return updated connection_retry_config
+                 */
+                connection_retry_config &
+                set_cluster_connect_timeout(const std::chrono::milliseconds &cluster_connect_timeout);
+
+                /**
+                 * by how much to randomize backoffs.
+                 * At each iteration calculated back-off is randomized via following method
+                 * random(-jitter * current_backoff, jitter * current_backoff)
+                 *
+                 * @return jitter_
+                 */
+                double get_jitter() const;
+
+                /**
+                 * At each iteration calculated back-off is randomized via following method
+                 * random(-jitter * current_backoff, jitter * current_backoff)
+                 *
+                 * @param jitter by how much to randomize backoffs
+                 * @return updated connection_retry_config
+                 */
+                connection_retry_config &set_jitter(double jitter);
+
+            private:
+                static constexpr std::chrono::milliseconds INITIAL_BACKOFF{1000};
+                static constexpr std::chrono::milliseconds MAX_BACKOFF{30000};
+                static constexpr std::chrono::milliseconds CLUSTER_CONNECT_TIMEOUT{20000};
+                static constexpr double JITTER = 0;
+                std::chrono::milliseconds initial_backoff_duration_ = INITIAL_BACKOFF;
+                std::chrono::milliseconds max_backoff_duration_ = MAX_BACKOFF;
+                double multiplier_ = 1;
+                std::chrono::milliseconds cluster_connect_timeout_ = CLUSTER_CONNECT_TIMEOUT;
+                double jitter_ = JITTER;
+            };
+
+        }
+    }
+}
+
+#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
+#pragma warning(pop)
+#endif
+
+

--- a/hazelcast/include/hazelcast/client/config/connection_retry_config.h
+++ b/hazelcast/include/hazelcast/client/config/connection_retry_config.h
@@ -38,21 +38,21 @@ namespace hazelcast {
                  *
                  * @return initial_backoff_duration_
                  */
-                const std::chrono::milliseconds &get_initial_backoff_duration() const;
+                std::chrono::milliseconds get_initial_backoff_duration() const;
 
                 /**
                  * @param initial_backoff_duration how long to wait after the first failure before retrying
                  * @return updated connection_retry_config
                  */
                 connection_retry_config &
-                set_initial_backoff_duration(const std::chrono::milliseconds &initial_backoff_duration);
+                set_initial_backoff_duration(std::chrono::milliseconds initial_backoff_duration);
 
                 /**
                  * When backoff reaches this upper bound, it does not increase any more.
                  *
                  * @return max_backoff_duration_
                  */
-                const std::chrono::milliseconds &get_max_backoff_duration() const;
+                std::chrono::milliseconds get_max_backoff_duration() const;
 
                 /**
                  * When backoff reaches this upper bound, it does not increase any more.
@@ -60,7 +60,7 @@ namespace hazelcast {
                  * @param max_backoff_duration upper bound on backoff
                  * @return updated connection_retry_config
                  */
-                connection_retry_config &set_max_backoff_duration(const std::chrono::milliseconds &max_backoff_duration);
+                connection_retry_config &set_max_backoff_duration(std::chrono::milliseconds max_backoff_duration);
 
                 /**
                  * factor with which to multiply backoff time after a failed retry
@@ -81,7 +81,7 @@ namespace hazelcast {
                  *
                  * @return cluster_connect_timeout_
                  */
-                const std::chrono::milliseconds &get_cluster_connect_timeout() const;
+                std::chrono::milliseconds get_cluster_connect_timeout() const;
 
                 /**
                  * @param cluster_connect_timeout timeout for the client to give up to connect to the current cluster
@@ -89,7 +89,7 @@ namespace hazelcast {
                  * @return updated connection_retry_config
                  */
                 connection_retry_config &
-                set_cluster_connect_timeout(const std::chrono::milliseconds &cluster_connect_timeout);
+                set_cluster_connect_timeout(std::chrono::milliseconds cluster_connect_timeout);
 
                 /**
                  * by how much to randomize backoffs.
@@ -128,5 +128,4 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-
 

--- a/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
+++ b/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
@@ -245,6 +245,8 @@ namespace hazelcast {
                 void check_partition_count(int32_t new_partition_count);
 
                 void trigger_cluster_reconnection();
+
+                std::shared_ptr<Connection> connect(const address &address);
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
+++ b/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
@@ -102,9 +102,9 @@ namespace hazelcast {
                  * @return associated connection if available, creates new connection otherwise
                  * @throws io if connection is not established
                  */
-                std::shared_ptr<Connection> get_or_connect_to_address(const address &address);
+                std::shared_ptr<Connection> get_or_connect(const address &address);
 
-                std::shared_ptr<Connection> get_or_connect_to_member(const member &m);
+                std::shared_ptr<Connection> get_or_connect(const member &m);
 
                 std::vector<std::shared_ptr<Connection>> get_active_connections();
 
@@ -174,9 +174,9 @@ namespace hazelcast {
 
                 template<typename T>
                 std::shared_ptr<Connection>
-                connect(const T &target, std::function<std::shared_ptr<Connection>(const T &)> f) {
+                try_connect(const T &target) {
                     try {
-                        return f(target);
+                        return get_or_connect(target);
                     } catch (std::exception &e) {
                         HZ_LOG(logger_, warning,
                                boost::str(boost::format("Exception during initial connection to %1%: %2%")

--- a/hazelcast/include/hazelcast/client/connection/wait_strategy.h
+++ b/hazelcast/include/hazelcast/client/connection/wait_strategy.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <random>
+
+#include "hazelcast/util/hazelcast_dll.h"
+
+namespace hazelcast {
+    namespace client {
+        namespace config {
+            class connection_retry_config;
+        }
+        namespace connection {
+            class wait_strategy {
+            public:
+                wait_strategy(const config::connection_retry_config &retry_config, logger &log);
+
+                void reset();
+
+                bool sleep();
+
+            private:
+                const std::chrono::milliseconds initial_backoff_millis_;
+                const std::chrono::milliseconds max_backoff_millis_;
+                const double multiplier_;
+                const double jitter_;
+                logger &logger_;
+                std::mt19937 random_generator_{std::random_device{}()};
+                std::uniform_real_distribution<double> random_{0.0, 1.0};
+                int attempt_ = 0;
+                std::chrono::milliseconds current_backoff_millis_{0};
+                std::chrono::milliseconds cluster_connect_timeout_millis_{0};
+                std::chrono::steady_clock::time_point cluster_connect_attempt_begin_{
+                        std::chrono::steady_clock::now()};
+            };
+        }
+    }
+}
+
+
+

--- a/hazelcast/include/hazelcast/client/protocol/AuthenticationStatus.h
+++ b/hazelcast/include/hazelcast/client/protocol/AuthenticationStatus.h
@@ -23,7 +23,8 @@ namespace hazelcast {
             enum HAZELCAST_API authentication_status {
                 AUTHENTICATED = 0,
                 CREDENTIALS_FAILED = 1,
-                SERIALIZATION_VERSION_MISMATCH = 2
+                SERIALIZATION_VERSION_MISMATCH = 2,
+                NOT_ALLOWED_IN_CLUSTER = 3
             };
         }
     }

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -373,7 +373,6 @@ namespace hazelcast {
             logger *BaseEventHandler::get_logger() const {
                 return logger_;
             }
-
         }
 
         constexpr int address::ID;

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -160,7 +160,7 @@ namespace hazelcast {
             client_flake_id_generator_config &
             client_flake_id_generator_config::set_prefetch_validity_duration(std::chrono::milliseconds duration) {
                 util::Preconditions::check_not_negative(duration.count(),
-                                                        "prefetchValidityMs must be non negative");
+                                                        "duration must be nonnegative");
                 prefetch_validity_duration_ = duration;
                 return *this;
             }
@@ -316,8 +316,8 @@ namespace hazelcast {
             }
 
             client_connection_strategy_config &
-            client_connection_strategy_config::set_retry_config(const connection_retry_config &retry_config) {
-                retry_config_ = retry_config;
+            client_connection_strategy_config::set_retry_config(connection_retry_config retry_config) {
+                retry_config_ = std::move(retry_config);
                 return *this;
             }
 

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -170,25 +170,24 @@ namespace hazelcast {
             constexpr std::chrono::milliseconds connection_retry_config::CLUSTER_CONNECT_TIMEOUT;
             constexpr double connection_retry_config::JITTER;
 
-            const std::chrono::milliseconds &connection_retry_config::get_initial_backoff_duration() const {
+            std::chrono::milliseconds connection_retry_config::get_initial_backoff_duration() const {
                 return initial_backoff_duration_;
             }
 
             connection_retry_config &
-            connection_retry_config::set_initial_backoff_duration(
-                    const std::chrono::milliseconds &initial_backoff_duration) {
+            connection_retry_config::set_initial_backoff_duration(std::chrono::milliseconds initial_backoff_duration) {
                 util::Preconditions::check_not_negative(initial_backoff_duration.count(),
                                                         "Initial backoff must be non-negative!");
                 initial_backoff_duration_ = initial_backoff_duration;
                 return *this;
             }
 
-            const std::chrono::milliseconds &connection_retry_config::get_max_backoff_duration() const {
+            std::chrono::milliseconds connection_retry_config::get_max_backoff_duration() const {
                 return max_backoff_duration_;
             }
 
             connection_retry_config &
-            connection_retry_config::set_max_backoff_duration(const std::chrono::milliseconds &max_backoff_duration) {
+            connection_retry_config::set_max_backoff_duration(std::chrono::milliseconds max_backoff_duration) {
                 util::Preconditions::check_not_negative(max_backoff_duration.count(),
                                                         "Max backoff must be non-negative!");
                 max_backoff_duration_ = max_backoff_duration;
@@ -205,12 +204,12 @@ namespace hazelcast {
                 return *this;
             }
 
-            const std::chrono::milliseconds &connection_retry_config::get_cluster_connect_timeout() const {
+            std::chrono::milliseconds connection_retry_config::get_cluster_connect_timeout() const {
                 return cluster_connect_timeout_;
             }
 
             connection_retry_config &connection_retry_config::set_cluster_connect_timeout(
-                    const std::chrono::milliseconds &cluster_connect_timeout) {
+                    std::chrono::milliseconds cluster_connect_timeout) {
                 util::Preconditions::check_not_negative(cluster_connect_timeout.count(),
                                                         "Cluster connect timeout must be non-negative!");
                 cluster_connect_timeout_ = cluster_connect_timeout;

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -61,31 +61,31 @@
 #include "hazelcast/client/config/ssl_config.h"
 #include "hazelcast/util/IOUtil.h"
 #include "hazelcast/client/internal/socket/SocketFactory.h"
+#include "hazelcast/client/connection/wait_strategy.h"
 
 namespace hazelcast {
     namespace client {
         namespace connection {
             constexpr size_t ClientConnectionManagerImpl::EXECUTOR_CORE_POOL_SIZE;
-            constexpr int32_t ClientConnectionManagerImpl::DEFAULT_CONNECTION_ATTEMPT_LIMIT_SYNC;
-            constexpr int32_t ClientConnectionManagerImpl::DEFAULT_CONNECTION_ATTEMPT_LIMIT_ASYNC;
 
             ClientConnectionManagerImpl::ClientConnectionManagerImpl(spi::ClientContext &client,
                                                                      const std::shared_ptr<AddressTranslator> &address_translator,
                                                                      const std::vector<std::shared_ptr<AddressProvider> > &address_providers)
-                    : alive_(false), logger_(client.get_logger()), connection_timeout_millis_(std::chrono::milliseconds::max()),
+                    : alive_(false), logger_(client.get_logger()),
+                      connection_timeout_millis_(std::chrono::milliseconds::max()),
                       client_(client),
                       socket_interceptor_(client.get_client_config().get_socket_interceptor()),
-                      execution_service_(client.get_client_execution_service()),
                       translator_(address_translator), connection_id_gen_(0),
-                      heartbeat_(client, *this), partition_count_(-1),
+                      heartbeat_(client, *this),
                       async_start_(client.get_client_config().get_connection_strategy_config().is_async_start()),
                       reconnect_mode_(client.get_client_config().get_connection_strategy_config().get_reconnect_mode()),
                       smart_routing_enabled_(client.get_client_config().get_network_config().is_smart_routing()),
-                      connect_to_cluster_task_submitted_(false),
                       client_uuid_(client.random_uuid()),
                       authentication_timeout_(boost::chrono::milliseconds(heartbeat_.get_heartbeat_timeout().count())),
-                      cluster_id_(boost::uuids::nil_uuid()),
-                      load_balancer_(client.get_client_config().get_load_balancer()) {
+                      load_balancer_(client.get_client_config().get_load_balancer()),
+                      wait_strategy_(client.get_client_config().get_connection_strategy_config().get_retry_config(),
+                                     logger_), cluster_id_(boost::uuids::nil_uuid()),
+                      connect_to_cluster_task_submitted_(false) {
 
                 config::client_network_config &networkConfig = client.get_client_config().get_network_config();
                 auto connTimeout = networkConfig.get_connection_timeout();
@@ -97,18 +97,6 @@ namespace hazelcast {
                 shuffle_member_list_ = clientProperties.get_boolean(clientProperties.get_shuffle_member_list());
 
                 ClientConnectionManagerImpl::address_providers_ = address_providers;
-
-                connection_attempt_period_ = networkConfig.get_connection_attempt_period();
-
-                int connAttemptLimit = networkConfig.get_connection_attempt_limit();
-                bool isAsync = client.get_client_config().get_connection_strategy_config().is_async_start();
-
-                if (connAttemptLimit < 0) {
-                    this->connection_attempt_limit_ = isAsync ? DEFAULT_CONNECTION_ATTEMPT_LIMIT_ASYNC
-                                                           : DEFAULT_CONNECTION_ATTEMPT_LIMIT_SYNC;
-                } else {
-                    this->connection_attempt_limit_ = connAttemptLimit == 0 ? INT32_MAX : connAttemptLimit;
-                }
 
                 io_thread_count_ = clientProperties.get_integer(clientProperties.get_io_thread_count());
             }
@@ -198,16 +186,8 @@ namespace hazelcast {
             }
 
             std::shared_ptr<Connection>
-            ClientConnectionManagerImpl::get_or_connect(const address &address) {
+            ClientConnectionManagerImpl::get_or_connect_to_address(const address &address) {
                 auto connection = get_connection(address);
-                if (connection) {
-                    return connection;
-                }
-
-                auto f = conn_locks_.get_or_put_if_absent(address, std::make_shared<std::mutex>());
-                std::lock_guard<std::mutex> g(*f.first);
-                // double check here
-                connection = get_connection(address);
                 if (connection) {
                     return connection;
                 }
@@ -223,9 +203,34 @@ namespace hazelcast {
                 // call the interceptor from user thread
                 socket_interceptor_.connect_(connection->get_socket());
 
-                authenticate_on_cluster(connection);
+                auto result = authenticate_on_cluster(connection);
 
-                return connection;
+                return on_authenticated(connection, result);
+            }
+
+            std::shared_ptr<Connection>
+            ClientConnectionManagerImpl::get_or_connect_to_member(const member &m) {
+                const auto &uuid = m.get_uuid();
+                auto connection = active_connections_.get(uuid);
+                if (connection) {
+                    return connection;
+                }
+
+                auto server_address = m.get_address();
+                auto target = translator_->translate(server_address);
+                HZ_LOG(logger_, info, boost::str(
+                        boost::format("Trying to connect to %1%. Translated address:%2%.") % server_address % target));
+
+                connection = std::make_shared<Connection>(target, client_, ++connection_id_gen_,
+                                                          *socket_factory_, *this, connection_timeout_millis_);
+                connection->connect();
+
+                // call the interceptor from user thread
+                socket_interceptor_.connect_(connection->get_socket());
+
+                auto result = authenticate_on_cluster(connection);
+
+                return on_authenticated(connection, result);
             }
 
             std::vector<std::shared_ptr<Connection> > ClientConnectionManagerImpl::get_active_connections() {
@@ -247,7 +252,7 @@ namespace hazelcast {
                 return active_connections_.get(uuid);
             }
 
-            void
+            ClientConnectionManagerImpl::auth_response
             ClientConnectionManagerImpl::authenticate_on_cluster(std::shared_ptr<Connection> &connection) {
                 auto request = encode_authentication_request(client_.get_serialization_service());
                 auto clientInvocation = spi::impl::ClientInvocation::create(client_, request, "", connection);
@@ -287,19 +292,27 @@ namespace hazelcast {
                 auto authentication_status = (protocol::authentication_status) result.status;
                 switch (authentication_status) {
                     case protocol::AUTHENTICATED: {
-                        handle_successful_auth(connection, std::move(result));
-                        break;
+                        return result;
                     }
                     case protocol::CREDENTIALS_FAILED: {
-                        auto e = std::make_exception_ptr(exception::authentication("AuthCallback::onResponse",
-                                                                                            "Authentication failed. The configured cluster name on the client (see ClientConfig::setClusterName()) does not match the one configured in the cluster or the credentials set in the Client security config could not be authenticated"));
+                        auto e = std::make_exception_ptr(
+                                exception::authentication("ClientConnectionManagerImpl::authenticate_on_cluster",
+                                                          "Authentication failed. The configured cluster name on the client (see client_config::set_cluster_name()) does not match the one configured in the cluster or the credentials set in the Client security config could not be authenticated"));
+                        connection->close("Failed to authenticate connection", e);
+                        std::rethrow_exception(e);
+                    }
+                    case protocol::NOT_ALLOWED_IN_CLUSTER: {
+                        auto e = std::make_exception_ptr(
+                                exception::authentication("ClientConnectionManagerImpl::authenticate_on_cluster",
+                                                          "Client is not allowed in the cluster"));
                         connection->close("Failed to authenticate connection", e);
                         std::rethrow_exception(e);
                     }
                     default: {
                         auto e = std::make_exception_ptr(exception::authentication(
-                                "AuthCallback::onResponse",
-                                (boost::format("Authentication status code not supported. status: %1%") %authentication_status).str()));
+                                "ClientConnectionManagerImpl::authenticate_on_cluster",
+                                (boost::format("Authentication status code not supported. status: %1%") %
+                                 authentication_status).str()));
                         connection->close("Failed to authenticate connection", e);
                         std::rethrow_exception(e);
                     }
@@ -380,19 +393,21 @@ namespace hazelcast {
             }
 
             void ClientConnectionManagerImpl::submit_connect_to_cluster_task() {
-                bool expected = false;
-                if (!connect_to_cluster_task_submitted_.compare_exchange_strong(expected, true)) {
+                // called in std::lock_guard<std::mutex>(client_state_mutex_)
+                if (connect_to_cluster_task_submitted_) {
                     return;
                 }
 
-                boost::asio::post(executor_->get_executor(), [=] () {
+                boost::asio::post(executor_->get_executor(), [=]() {
                     try {
                         do_connect_to_cluster();
+
+                        std::lock_guard<std::mutex> guard(client_state_mutex_);
                         connect_to_cluster_task_submitted_ = false;
                         if (active_connections_.empty()) {
-                            HZ_LOG(logger_, finest, 
-                                boost::str(boost::format("No connection to cluster: %1%")
-                                                         % cluster_id_)
+                            HZ_LOG(logger_, finest,
+                                   boost::str(boost::format("No connection to cluster: %1%")
+                                              % cluster_id_)
                             );
 
                             submit_connect_to_cluster_task();
@@ -428,7 +443,7 @@ namespace hazelcast {
                                     return;
                                 }
                                 if (!get_connection(member.get_uuid())) {
-                                    get_or_connect(addr);
+                                    get_or_connect_to_address(addr);
                                 }
                                 connecting_addresses_.remove(addr);
                             } catch (std::exception &) {
@@ -440,51 +455,51 @@ namespace hazelcast {
             }
 
             bool ClientConnectionManagerImpl::do_connect_to_cluster() {
-                int attempt = 0;
-                std::unordered_set<address> triedAddresses;
+                std::unordered_set<address> tried_addresses;
+                wait_strategy_.reset();
 
-                while (attempt < connection_attempt_limit_) {
-                    attempt++;
-                    auto nextTryTime = std::chrono::steady_clock::now() + connection_attempt_period_;
+                do {
+                    std::unordered_set<address> tried_addresses_per_attempt;
+                    auto member_list = client_.get_client_cluster_service().get_member_list();
+                    if (shuffle_member_list_) {
+                        shuffle(member_list);
+                    }
 
-                    for (const address &address : get_possible_member_addresses()) {
+                    //try to connect to a member in the member list first
+                    for (const auto &m : member_list) {
                         check_client_active();
-                        triedAddresses.insert(address);
-                        auto connection = connect(address);
+                        tried_addresses_per_attempt.insert(m.get_address());
+                        auto connection = connect<member>(m, [=](const member &server) {
+                            return get_or_connect_to_member(server);
+                        });
                         if (connection) {
                             return true;
                         }
                     }
+                    //try to connect to a member given via config(explicit config/discovery mechanisms)
+                    for (const address &server_address : get_possible_member_addresses()) {
+                        check_client_active();
+                        if (!tried_addresses_per_attempt.insert(server_address).second) {
+                            //if we can not add it means that it is already tried to be connected with the member list
+                            continue;
+                        }
 
-                    // If the address providers load no addresses (which seems to be possible), then the above loop is not entered
+                        auto connection = connect<address>(server_address, [=](const address &target) {
+                            return get_or_connect_to_address(target);
+                        });
+                        if (connection) {
+                            return true;
+                        }
+                    }
+                    tried_addresses.insert(tried_addresses_per_attempt.begin(), tried_addresses_per_attempt.end());
+                    // If the address provider loads no addresses, then the above loop is not entered
                     // and the lifecycle check is missing, hence we need to repeat the same check at this point.
                     check_client_active();
+                } while (wait_strategy_.sleep());
 
-                    if (attempt < connection_attempt_limit_) {
-                        auto remainingTime = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                nextTryTime - std::chrono::steady_clock::now()).count();
-                        HZ_LOG(logger_, warning,
-                            boost::str(boost::format("Unable to get alive cluster connection, try in "
-                                                     "%1% ms later, attempt %2% of %3%.")
-                                                     % (remainingTime > 0 ? remainingTime : 0)
-                                                     % attempt % connection_attempt_limit_)
-                        );
-
-                        if (remainingTime > 0) {
-                            // TODO use a condition variable here
-                            std::this_thread::sleep_for(std::chrono::milliseconds(remainingTime));
-                        }
-                    } else {
-                        HZ_LOG(logger_, warning, 
-                            boost::str(boost::format("Unable to get alive cluster connection, "
-                                                     "attempt %1% of %2%.")
-                                                     % attempt % connection_attempt_limit_)
-                        );
-                    }
-                }
                 std::ostringstream out;
                 out << "Unable to connect to any address! The following addresses were tried: { ";
-                for (const auto &address : triedAddresses) {
+                for (const auto &address : tried_addresses) {
                     out << address << " , ";
                 }
                 out << "}";
@@ -529,28 +544,28 @@ namespace hazelcast {
                 return alive_;
             }
 
-            void ClientConnectionManagerImpl::on_connection_close(Connection &connection, std::exception_ptr cause) {
-                auto endpoint = connection.get_remote_address();
-                auto member_uuid = connection.get_remote_uuid();
+            void ClientConnectionManagerImpl::on_connection_close(const std::shared_ptr<Connection> &connection) {
+                auto endpoint = connection->get_remote_address();
+                auto member_uuid = connection->get_remote_uuid();
 
-                auto socket_remote_address = connection.get_socket().get_remote_endpoint();
+                auto socket_remote_address = connection->get_socket().get_remote_endpoint();
 
                 if (!endpoint) {
                     HZ_LOG(logger_, finest,
-                        boost::str(boost::format("Destroying %1% , but it has end-point set to null "
-                                                 "-> not removing it from a connection map")
-                                                 % connection)
+                           boost::str(boost::format("Destroying %1% , but it has end-point set to null "
+                                                    "-> not removing it from a connection map")
+                                      % *connection)
                     );
                     return;
                 }
 
-                auto conn = connection.shared_from_this();
-                if (active_connections_.remove(member_uuid, conn)) {
-                    active_connection_ids_.remove(conn->get_connection_id());
+                std::lock_guard<std::mutex> guard(client_state_mutex_);
+                if (active_connections_.remove(member_uuid, connection)) {
+                    active_connection_ids_.remove(connection->get_connection_id());
 
-                    HZ_LOG(logger_, info, 
-                        boost::str(boost::format("Removed connection to endpoint: %1%, connection: %2%")
-                                                 % *endpoint % connection)
+                    HZ_LOG(logger_, info,
+                           boost::str(boost::format("Removed connection to endpoint: %1%, connection: %2%")
+                                      % *endpoint % *connection)
                     );
 
                     if (active_connections_.empty()) {
@@ -559,12 +574,12 @@ namespace hazelcast {
                         trigger_cluster_reconnection();
                     }
 
-                    fire_connection_removed_event(connection.shared_from_this());
+                    fire_connection_removed_event(connection);
                 } else {
                     HZ_LOG(logger_, finest,
                         boost::str(boost::format("Destroying a connection, but there is no mapping "
                                                  "%1% -> %2% in the connection map.")
-                                                 % endpoint % connection)
+                                   % endpoint % *connection)
                     );
                 }
             }
@@ -586,72 +601,83 @@ namespace hazelcast {
             void ClientConnectionManagerImpl::check_client_active() {
                 if (!client_.get_lifecycle_service().is_running()) {
                     BOOST_THROW_EXCEPTION(exception::hazelcast_client_not_active(
-                            "ClientConnectionManagerImpl::check_client_active", "Client is shutdown"));
+                                                  "ClientConnectionManagerImpl::check_client_active", "Client is shutdown"));
                 }
             }
 
-            std::shared_ptr<Connection> ClientConnectionManagerImpl::connect(const address &address) {
-                try {
-                    return get_or_connect(address);
-                } catch (std::exception &e) {
-                    HZ_LOG(logger_, warning,
-                        boost::str(boost::format("Exception during initial connection to %1%: %2%")
-                                                 % address % e.what()));
+            std::shared_ptr<Connection>
+            ClientConnectionManagerImpl::on_authenticated(const std::shared_ptr<Connection> &connection,
+                                                          auth_response &response) {
+                {
+                    std::lock_guard<std::mutex> guard(client_state_mutex_);
+                    check_partition_count(response.partition_count);
+                    connection->set_connected_server_version(response.server_version);
+                    connection->set_remote_address(std::move(response.server_address));
+                    connection->set_remote_uuid(response.member_uuid);
+
+                    auto existing_connection = active_connections_.get(response.member_uuid);
+                    if (existing_connection) {
+                        connection->close((boost::format("Duplicate connection to same member with uuid : %1%") %
+                                           boost::uuids::to_string(response.member_uuid)).str());
+                        return existing_connection;
+                    }
+
+
+                    auto new_cluster_id = response.cluster_id;
+                    boost::uuids::uuid current_cluster_id = cluster_id_;
+
+                    HZ_LOG(logger_, finest,
+                           boost::str(boost::format("Checking the cluster: %1%, current cluster: %2%")
+                                      % new_cluster_id % current_cluster_id)
+                    );
+
+                    auto cluster_id_changed = !current_cluster_id.is_nil() && !(new_cluster_id == current_cluster_id);
+                    if (cluster_id_changed) {
+                        HZ_LOG(logger_, warning,
+                               boost::str(boost::format("Switching from current cluster: %1%  to new cluster: %2%")
+                                          % current_cluster_id % new_cluster_id)
+                        );
+                        client_.get_hazelcast_client_implementation()->on_cluster_restart();
+                    }
+
+                    auto connections_empty = active_connections_.empty();
+                    active_connection_ids_.put(connection->get_connection_id(), connection);
+                    active_connections_.put(response.member_uuid, connection);
+                    if (connections_empty) {
+                        cluster_id_ = new_cluster_id;
+                        fire_life_cycle_event(lifecycle_event::lifecycle_state::CLIENT_CONNECTED);
+                    }
+
+                    auto local_address = connection->get_local_socket_address();
+                    if (local_address) {
+                        HZ_LOG(logger_, info,
+                               boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
+                                                        "local address: %4%")
+                                          % response.server_address % response.member_uuid
+                                          % response.server_version % *local_address)
+                        );
+                    } else {
+                        HZ_LOG(logger_, info,
+                               boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
+                                                        "no local address: (connection disconnected ?)")
+                                          % response.server_address % response.member_uuid
+                                          % response.server_version)
+                        );
+                    }
+
+                    fire_connection_added_event(connection);
+                }
+
+                // It could happen that this connection is already closed and
+                // on_connection_close() is called even before the synchronized block
+                // above is executed. In this case, now we have a closed but registered
+                // connection. We do a final check here to remove this connection
+                // if needed.
+                if (!connection->is_alive()) {
+                    on_connection_close(connection);
                     return nullptr;
                 }
-            }
-
-            void ClientConnectionManagerImpl::handle_successful_auth(const std::shared_ptr<Connection> &connection,
-                                                                   auth_response response) {
-                check_partition_count(response.partition_count);
-                connection->set_connected_server_version(response.server_version);
-                connection->set_remote_address(std::move(response.server_address));
-                connection->set_remote_uuid(response.member_uuid);
-
-                auto new_cluster_id = response.cluster_id;
-                boost::uuids::uuid current_cluster_id = cluster_id_;
-
-                HZ_LOG(logger_, finest, 
-                    boost::str(boost::format("Checking the cluster: %1%, current cluster: %2%") 
-                                             % new_cluster_id % current_cluster_id)    
-                );
-
-                auto initial_connection = active_connections_.empty();
-                auto changedCluster = initial_connection && !current_cluster_id.is_nil() && !(new_cluster_id == current_cluster_id);
-                if (changedCluster) {
-                    HZ_LOG(logger_, warning,
-                        boost::str(boost::format("Switching from current cluster: %1%  to new cluster: %2%")
-                                                 % current_cluster_id % new_cluster_id)
-                    );
-                    client_.get_hazelcast_client_implementation()->on_cluster_restart();
-                }
-
-                active_connection_ids_.put(connection->get_connection_id(), connection);
-                active_connections_.put(response.member_uuid, connection);
-
-                if (initial_connection) {
-                    cluster_id_ = new_cluster_id;
-                    fire_life_cycle_event(lifecycle_event::lifecycle_state::CLIENT_CONNECTED);
-                }
-
-                auto local_address = connection->get_local_socket_address();
-                if (local_address) {
-                    HZ_LOG(logger_, info,
-                        boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
-                                                 "local address: %4%")
-                                   % response.server_address % response.member_uuid
-                                   % response.server_version % *local_address)
-                    );
-                } else {
-                    HZ_LOG(logger_, info,
-                        boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
-                                                 "no local address: (connection disconnected ?)")
-                                   % response.server_address % response.member_uuid
-                                   % response.server_version)
-                    );
-                }
-
-                fire_connection_added_event(connection);
+                return connection;
             }
 
             void ClientConnectionManagerImpl::fire_life_cycle_event(lifecycle_event::lifecycle_state state) {
@@ -731,7 +757,7 @@ namespace hazelcast {
 
                 for (const auto &member : client_.get_client_cluster_service().get_member_list()) {
                     try {
-                        get_or_connect(member.get_address());
+                        get_or_connect_to_address(member.get_address());
                     } catch (std::exception &) {
                         // ignore
                     }
@@ -868,18 +894,19 @@ namespace hazelcast {
                     inner_close();
                 } catch (exception::iexception &e) {
                     HZ_LOG(client_context_.get_logger(), warning,
-                        boost::str(boost::format("Exception while closing connection %1%")
-                                                 % e.get_message())
+                           boost::str(boost::format("Exception while closing connection %1%")
+                                      % e.get_message())
                     );
                 }
 
-                client_context_.get_connection_manager().on_connection_close(*this, close_cause_);
-
                 auto thisConnection = shared_from_this();
+                client_context_.get_connection_manager().on_connection_close(thisConnection);
+
                 boost::asio::post(socket_->get_executor(), [=]() {
                     for (auto &invocationEntry : thisConnection->invocations) {
-                        invocationEntry.second->notify_exception(std::make_exception_ptr(boost::enable_current_exception(
-                                exception::target_disconnected("Connection::close",
+                        invocationEntry.second->notify_exception(
+                                std::make_exception_ptr(boost::enable_current_exception(
+                                        exception::target_disconnected("Connection::close",
                                                                        thisConnection->get_close_reason()))));
                     }
                 });
@@ -1123,6 +1150,51 @@ namespace hazelcast {
                 return heartbeat_timeout_;
             }
 
+            void wait_strategy::reset() {
+                attempt_ = 0;
+                cluster_connect_attempt_begin_ = std::chrono::steady_clock::now();
+                current_backoff_millis_ = std::min(max_backoff_millis_, initial_backoff_millis_);
+            }
+
+            wait_strategy::wait_strategy(const config::connection_retry_config &retry_config, logger &log)
+                    : initial_backoff_millis_(retry_config.get_initial_backoff_duration()),
+                      max_backoff_millis_(retry_config.get_max_backoff_duration()),
+                      multiplier_(retry_config.get_multiplier()), jitter_(retry_config.get_jitter()), logger_(log),
+                      cluster_connect_timeout_millis_(retry_config.get_cluster_connect_timeout()) {}
+
+            bool wait_strategy::sleep() {
+                attempt_++;
+                using namespace std::chrono;
+                auto current_time = steady_clock::now();
+                auto time_passed = duration_cast<milliseconds>(current_time - cluster_connect_attempt_begin_);
+                if (time_passed > cluster_connect_timeout_millis_) {
+                    HZ_LOG(logger_, warning, (boost::format(
+                            "Unable to get live cluster connection, cluster connect timeout (%1% millis) is reached. Attempt %2%.") %
+                                              duration_cast<milliseconds>(cluster_connect_timeout_millis_).count() %
+                                              attempt_).str());
+                    return false;
+                }
+
+                //sleep time: current_backoff_millis_(1 +- (jitter * [0, 1]))
+                auto actual_sleep_time = current_backoff_millis_ + milliseconds(
+                        static_cast<milliseconds::rep>(current_backoff_millis_.count() * jitter_ *
+                                                       (2.0 * random_(random_generator_) - 1.0)));
+
+                actual_sleep_time = (std::min)(actual_sleep_time, cluster_connect_timeout_millis_ - time_passed);
+
+                HZ_LOG(logger_, warning, (boost::format(
+                        "Unable to get live cluster connection, retry in %1% ms, attempt: %2% , cluster connect timeout: %3% seconds , max backoff millis: %4%") %
+                                          actual_sleep_time.count() % attempt_ %
+                                          cluster_connect_timeout_millis_.count() %
+                                          max_backoff_millis_.count()).str());
+
+                std::this_thread::sleep_for(actual_sleep_time);
+
+                current_backoff_millis_ = (std::min)(
+                        milliseconds(static_cast<milliseconds::rep>(current_backoff_millis_.count() * multiplier_)),
+                        max_backoff_millis_);
+                return true;
+            }
         }
 
         namespace internal {

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1325,7 +1325,9 @@ namespace hazelcast {
                         client_config clientConfig;
                         clientConfig.set_property(client_properties::PROP_HEARTBEAT_TIMEOUT, "10");
                         auto member = server.get_member();
-                        clientConfig.get_network_config().add_address(address(member.host, member.port)).set_connection_attempt_period(std::chrono::seconds(10));
+                        clientConfig.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                                std::chrono::seconds(10));
+                        clientConfig.get_network_config().add_address(address(member.host, member.port));
 
                         Stats stats;
                         auto lg = std::make_shared<logger>("SimpleMapTest", "SimpleMapTest",
@@ -1424,7 +1426,8 @@ namespace hazelcast {
 
                 // 2. Start a client
                 client_config clientConfig = get_config();
-                clientConfig.get_network_config().set_connection_attempt_limit(10);
+                clientConfig.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(10));
 
                 hazelcast_client client(std::move(clientConfig));
 


### PR DESCRIPTION
Removed the **cluster connect attempt limit** and *cluster connect attempt period* configurations and added the client strategy config `connection_retry_config`. This makes the client more compatible with Java client configuration and it also allows exponential backoff algorithm. (back-ported https://github.com/hazelcast/hazelcast/pull/13248 and https://github.com/hazelcast/hazelcast/pull/15923)

Also back-ported, https://github.com/hazelcast/hazelcast/pull/17844

fixes #741 