### PR TITLE
Remove file name and line number in log line and the logger function API

### DIFF
--- a/examples/learning-basics/configure-logging/custom_log_handler.cpp
+++ b/examples/learning-basics/configure-logging/custom_log_handler.cpp
@@ -20,8 +20,6 @@
 
 void my_log_handler(const std::string &instance_name, 
                     const std::string &cluster_name,
-                    const char *file_name,
-                    int line,
                     hazelcast::logger::level lvl,
                     const std::string &msg) 
 {
@@ -35,8 +33,6 @@ void my_log_handler(const std::string &instance_name,
     std::cerr << "{\n"
               << "  \"instance_name\": \"" << instance_name << "\",\n"
               << "  \"cluster_name\": \"" << cluster_name << "\",\n"
-              << "  \"file_name\": \"" << file_name << "\",\n"
-              << "  \"line\": " << line << ",\n"
               << "  \"level\": \"" << lvl << "\",\n"
               << "  \"message\": \"" << msg << "\"\n"
               << "}\n\n";

--- a/examples/learning-basics/destroying-instances/main.cpp
+++ b/examples/learning-basics/destroying-instances/main.cpp
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hazelcast/include/hazelcast/logger.h
+++ b/hazelcast/include/hazelcast/logger.h
@@ -12,9 +12,9 @@
 #endif
 
 #ifndef HZ_LOGGING_DISABLED
-    #define HZ_LOG(lg, lvl, msg) \
+#define HZ_LOG(lg, lvl, msg) \
         if ((lg).enabled( ::hazelcast::logger::level::lvl )) { \
-            (lg).log(__FILE__, __LINE__, ::hazelcast::logger::level::lvl, ( msg )); \
+            (lg).log(::hazelcast::logger::level::lvl, ( msg )); \
         }
 #else
     #define HZ_LOG(lg, lvl, msg) 
@@ -32,8 +32,6 @@ public:
 
     using handler_type = std::function<void(const std::string &,
                                             const std::string &,
-                                            const char *,
-                                            int line,
                                             level,
                                             const std::string &)>;
 
@@ -42,13 +40,10 @@ public:
 
     bool enabled(level lvl) noexcept;
 
-    void log(const char* file_name, int line, 
-             level lvl, const std::string &msg) noexcept;
+    void log(level lvl, const std::string &msg) noexcept;
 
     static void default_handler(const std::string &instance_name,
                                 const std::string &cluster_name,
-                                const char *file_name,
-                                int line,
                                 level lvl,
                                 const std::string &msg) noexcept;
 

--- a/hazelcast/src/hazelcast/logger.cpp
+++ b/hazelcast/src/hazelcast/logger.cpp
@@ -49,9 +49,8 @@ bool logger::enabled(level lvl) noexcept {
     return lvl >= level_;
 }
 
-void logger::log(const char *file_name, int line, 
-                 level lvl, const std::string &msg) noexcept {
-    handler_(instance_name_, cluster_name_, file_name, line, lvl, msg);
+void logger::log(level lvl, const std::string &msg) noexcept {
+    handler_(instance_name_, cluster_name_, lvl, msg);
 }
 
 namespace {
@@ -71,12 +70,10 @@ std::tm time_t_to_localtime(const std::time_t &t) {
 }
 
 void logger::default_handler(const std::string &instance_name,
-                             const std::string &cluster_name, 
-                             const char* file_name,
-                             int line,
+                             const std::string &cluster_name,
                              level lvl, 
                              const std::string &msg) noexcept {
-                             
+
     auto tp = std::chrono::system_clock::now();
     auto t = std::chrono::system_clock::to_time_t(tp);
     auto local_t = time_t_to_localtime(t);
@@ -94,8 +91,7 @@ void logger::default_handler(const std::string &instance_name,
           << std::setfill('0') << std::setw(3) << ms << ' '
           << lvl << ": [" << std::this_thread::get_id() << "] "
           << instance_name << '[' << cluster_name << "] ["
-          << client::version() << "] ["
-          << file_name << ':' << line << "] "
+          << client::version() << "] "
           << msg
           << '\n';
 

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -468,15 +468,13 @@ namespace hazelcast {
 
                 auto h = [&called](const std::string &,
                                    const std::string &,
-                                   const char*,
-                                   int,
                                    logger::level,
                                    const std::string &) {
                     called = true;
                 };
 
                 logger_config.handler(h);
-                logger_config.handler()("", "", "", 0, logger::level::fine, "");
+                logger_config.handler()("", 0, logger::level::fine, "");
 
                 ASSERT_TRUE(called);
             }

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -460,7 +460,7 @@ namespace hazelcast {
                 ASSERT_THROW(config.get_logger_config().handler(nullptr), exception::illegal_argument);
             }
 
-            TEST_F(ClientConfigTest, testSetGetLoadHandler) {
+            TEST_F(ClientConfigTest, testSetGetLogHandler) {
                 client_config config;
                 auto logger_config = config.get_logger_config();
 
@@ -474,7 +474,7 @@ namespace hazelcast {
                 };
 
                 logger_config.handler(h);
-                logger_config.handler()("", 0, logger::level::fine, "");
+                logger_config.handler()("", "", logger::level::fine, "");
 
                 ASSERT_TRUE(called);
             }

--- a/hazelcast/test/src/logger_test.cpp
+++ b/hazelcast/test/src/logger_test.cpp
@@ -107,16 +107,16 @@ protected:
 };
 
 TEST_F(default_log_handler_test, test_format) {
-    logger::default_handler("instance0", "cluster0",logger::level::warning, "message");
+    logger::default_handler("instance0", "cluster0", logger::level::warning, "message");
 
     int day, mon, year, hr, mn, sec, ms;
     char lev[64], tid[64], msg[64], ins_grp[64], ver[64];
 
-    int read = std::sscanf(sstrm_.str().c_str(), 
-        "%02d/%02d/%04d %02d:%02d:%02d.%03d %s %s %s %s %s\n",
-         &day, &mon, &year, &hr, &mn, &sec, &ms, lev, tid, ins_grp, ver, msg);
+    int read = std::sscanf(sstrm_.str().c_str(),
+                           "%02d/%02d/%04d %02d:%02d:%02d.%03d %s %s %s %s %s\n",
+                           &day, &mon, &year, &hr, &mn, &sec, &ms, lev, tid, ins_grp, ver, msg);
 
-    ASSERT_EQ(13, read);
+    ASSERT_EQ(12, read);
 
     ASSERT_TRUE(0 <= day && day <= 31);
     ASSERT_TRUE(1 <= mon && mon <= 12);

--- a/hazelcast/test/src/logger_test.cpp
+++ b/hazelcast/test/src/logger_test.cpp
@@ -66,35 +66,27 @@ TEST(logger_test, test_log) {
     struct {
         std::string instance_name;
         std::string cluster_name;
-        std::string file_name;
-        int line;
         logger::level level;
         std::string msg;
     } results;
 
     auto mock_handler = [&results](const std::string &instance_name,
-                                   const std::string &cluster_name, 
-                                   const char* file_name,
-                                   int line,
+                                   const std::string &cluster_name,
                                    logger::level level, 
                                    const std::string &msg) 
     {
         results.instance_name = instance_name;
         results.cluster_name = cluster_name;
-        results.file_name = file_name;
-        results.line = line;
         results.level = level;
         results.msg = msg;
     };
 
     logger lg{ "instance0", "cluster0", logger::level::info, mock_handler };
 
-    lg.log("file.cpp", 42, logger::level::info, "message");
+    lg.log(logger::level::info, "message");
 
     ASSERT_EQ("instance0", results.instance_name);
     ASSERT_EQ("cluster0", results.cluster_name);
-    ASSERT_EQ("file.cpp", results.file_name);
-    ASSERT_EQ(42, results.line);
     ASSERT_EQ(logger::level::info, results.level);
     ASSERT_EQ("message", results.msg);
 }
@@ -115,15 +107,14 @@ protected:
 };
 
 TEST_F(default_log_handler_test, test_format) {
-    logger::default_handler("instance0", "cluster0", "file.cpp", 123, 
-                            logger::level::warning, "message");
+    logger::default_handler("instance0", "cluster0",logger::level::warning, "message");
 
     int day, mon, year, hr, mn, sec, ms;
-    char lev[64], tid[64], msg[64], ins_grp[64], ver[64], file_line[256];
+    char lev[64], tid[64], msg[64], ins_grp[64], ver[64];
 
     int read = std::sscanf(sstrm_.str().c_str(), 
-        "%02d/%02d/%04d %02d:%02d:%02d.%03d %s %s %s %s %s %s\n", 
-         &day, &mon, &year, &hr, &mn, &sec, &ms, lev, tid, ins_grp, ver, file_line, msg);
+        "%02d/%02d/%04d %02d:%02d:%02d.%03d %s %s %s %s %s\n",
+         &day, &mon, &year, &hr, &mn, &sec, &ms, lev, tid, ins_grp, ver, msg);
 
     ASSERT_EQ(13, read);
 
@@ -140,38 +131,30 @@ TEST_F(default_log_handler_test, test_format) {
     ASSERT_EQ(expected_tid.str(), std::string(tid));
     ASSERT_EQ("instance0[cluster0]", std::string(ins_grp));
     ASSERT_EQ(std::string() + "[" + HAZELCAST_VERSION + "]", std::string(ver));
-    ASSERT_EQ("[file.cpp:123]", std::string(file_line));
     ASSERT_EQ("message", std::string(msg));
 }
 
 TEST(log_macro_test, test_log_when_enabled) {
     struct mock_logger {
         bool called{ false };
-        std::string file_name;
-        int line;
         logger::level level;
         std::string msg;
 
         bool enabled(logger::level) {
             return true;
         }
-        void log(const char* file_name, int line, logger::level level, const std::string &msg) {
+        void log(logger::level l, const std::string &m) {
             called = true;
-            this->file_name = file_name;
-            this->line = line;
-            this->level = level;
-            this->msg = msg;
+            this->level = l;
+            this->msg = m;
         }
     };
 
     mock_logger lg;
 
     HZ_LOG(lg, warning, "message"); 
-    int expected_line = __LINE__ - 1;
 
     ASSERT_TRUE(lg.called);
-    ASSERT_EQ(__FILE__, lg.file_name);
-    ASSERT_EQ(expected_line, lg.line);
     ASSERT_EQ(logger::level::warning, lg.level);
     ASSERT_EQ("message", lg.msg);
 }


### PR DESCRIPTION
Removed file name and log line number from the log lines.

fixes #737 