### PR TITLE
Remove `include(Find<package>)`s from CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,6 @@ if ((NOT GENERATOR_IS_MULTI_CONFIG) AND (NOT CMAKE_BUILD_TYPE))
     set(CMAKE_BUILD_TYPE Release)
 endif ()
 
-include(FindThreads)
-include(FindBoost)
-include(FindOpenSSL)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(GenerateExportHeader)
@@ -99,9 +96,6 @@ if (WITH_OPENSSL)
         # the one in the specified ROOT folder.
         # See https://stackoverflow.com/a/62063357
         set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
-        set(OPENSSL_INCLUDE_DIR ${OPENSSL_ROOT_DIR}/include CACHE FILEPATH "" FORCE)
-        set(OPENSSL_CRYPTO_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib CACHE FILEPATH "" FORCE)
-        set(OPENSSL_SSL_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libssl.dylib CACHE FILEPATH "" FORCE)
     endif ()
 
     find_package(OpenSSL REQUIRED)

--- a/hazelcast/test/CMakeLists.txt
+++ b/hazelcast/test/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-include(FindGTest)
-
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
`include(Find<package>)` is not necessary before a `find_package(<package>)`. When the `find_package` command is invoked, CMake first searches for a file named `Find<package>.cmake` in the `CMAKE_MODULE_PATH`, if it is found it gets used. If not found, then by default, `find_package` falls back to "Config" mode and searches for `<package>-config.cmake`.
This behavior haven't changed since CMake version 3.0 (may be even earlier, didn't check). Detailed description [here](https://cmake.org/cmake/help/v3.0/command/find_package.html).

This pull-request removes such uses.

Forced cache writes for `APPLE` are also not necessary anymore, as `include(FindOpenSSL)` is removed.