### PR TITLE
Removed unused codec methods

### DIFF
--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
@@ -16,6 +16,7 @@
 
 #include <boost/uuid/uuid.hpp>
 #include "hazelcast/client/member.h"
+#include "hazelcast/logger.h"
 
 #include "codecs.h"
 
@@ -23,11 +24,17 @@ namespace hazelcast {
     namespace client {
         namespace protocol {
             namespace codec {
-                ClientMessage client_authentication_encode(const std::string  & cluster_name, const std::string  * username, const std::string  * password, boost::uuids::uuid uuid, const std::string  & client_type, byte serialization_version, const std::string  & client_hazelcast_version, const std::string  & client_name, const std::vector<std::string>  & labels) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage client_authentication_encode(const std::string &cluster_name, const std::string *username,
+                                                           const std::string *password, boost::uuids::uuid uuid,
+                                                           const std::string &client_type, byte serialization_version,
+                                                           const std::string &client_hazelcast_version,
+                                                           const std::string &client_name,
+                                                           const std::vector<std::string> &labels) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Client.Authentication");
+                    msg.set_operation_name("client.authentication");
 
                     msg.set_message_type(static_cast<int32_t>(256));
                     msg.set_partition_id(-1);
@@ -51,11 +58,19 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_authenticationcustom_encode(const std::string  & cluster_name, const std::vector<byte>  & credentials, boost::uuids::uuid uuid, const std::string  & client_type, byte serialization_version, const std::string  & client_hazelcast_version, const std::string  & client_name, const std::vector<std::string>  & labels) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage client_authenticationcustom_encode(const std::string &cluster_name,
+                                                                 const std::vector<byte> &credentials,
+                                                                 boost::uuids::uuid uuid,
+                                                                 const std::string &client_type,
+                                                                 byte serialization_version,
+                                                                 const std::string &client_hazelcast_version,
+                                                                 const std::string &client_name,
+                                                                 const std::vector<std::string> &labels) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Client.AuthenticationCustom");
+                    msg.set_operation_name("client.authenticationcustom");
 
                     msg.set_message_type(static_cast<int32_t>(512));
                     msg.set_partition_id(-1);
@@ -81,7 +96,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Client.AddClusterViewListener");
+                    msg.set_operation_name("client.addclusterviewlistener");
 
                     msg.set_message_type(static_cast<int32_t>(768));
                     msg.set_partition_id(-1);
@@ -102,7 +117,8 @@ namespace hazelcast {
                         return;
                     }
                     if (messageType == 771) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
+                                ClientMessage::EVENT_HEADER_LEN));
                         auto version = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
@@ -110,18 +126,16 @@ namespace hazelcast {
                         handle_partitionsview(version, partitions);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[client_addclusterviewlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[client_addclusterviewlistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage client_createproxy_encode(const std::string  & name, const std::string  & service_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                ClientMessage client_createproxy_encode(const std::string &name, const std::string &service_name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Client.CreateProxy");
+                    msg.set_operation_name("client.createproxy");
 
                     msg.set_message_type(static_cast<int32_t>(1024));
                     msg.set_partition_id(-1);
@@ -133,11 +147,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_destroyproxy_encode(const std::string  & name, const std::string  & service_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                ClientMessage client_destroyproxy_encode(const std::string &name, const std::string &service_name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Client.DestroyProxy");
+                    msg.set_operation_name("client.destroyproxy");
 
                     msg.set_message_type(static_cast<int32_t>(1280));
                     msg.set_partition_id(-1);
@@ -149,114 +163,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_addpartitionlostlistener_encode(bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
-                    ClientMessage msg(initial_frame_size, true);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Client.AddPartitionLostListener");
-
-                    msg.set_message_type(static_cast<int32_t>(1536));
-                    msg.set_partition_id(-1);
-
-                    msg.set(local_only);
-                    return msg;
-                }
-
-                void client_addpartitionlostlistener_handler::handle(ClientMessage &msg) {
-                    auto messageType = msg.get_message_type();
-                    if (messageType == 1538) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
-                        auto partitionId = msg.get<int32_t>();
-                        auto lostBackupCount = msg.get<int32_t>();
-                        auto source = msg.get<boost::uuids::uuid>();
-                        msg.seek(static_cast<int32_t>(initial_frame->frame_len));
-
-                        handle_partitionlost(partitionId, lostBackupCount, source);
-                        return;
-                    }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[client_addpartitionlostlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
-                }
-
-                ClientMessage client_removepartitionlostlistener_encode(boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
-                    ClientMessage msg(initial_frame_size, true);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Client.RemovePartitionLostListener");
-
-                    msg.set_message_type(static_cast<int32_t>(1792));
-                    msg.set_partition_id(-1);
-
-                    msg.set(registration_id);
-                    return msg;
-                }
-
-                ClientMessage client_getdistributedobjects_encode() {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
-                    ClientMessage msg(initial_frame_size, true);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Client.GetDistributedObjects");
-
-                    msg.set_message_type(static_cast<int32_t>(2048));
-                    msg.set_partition_id(-1);
-
-                    return msg;
-                }
-
-                ClientMessage client_adddistributedobjectlistener_encode(bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
-                    ClientMessage msg(initial_frame_size, true);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Client.AddDistributedObjectListener");
-
-                    msg.set_message_type(static_cast<int32_t>(2304));
-                    msg.set_partition_id(-1);
-
-                    msg.set(local_only);
-                    return msg;
-                }
-
-                void client_adddistributedobjectlistener_handler::handle(ClientMessage &msg) {
-                    auto messageType = msg.get_message_type();
-                    if (messageType == 2306) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
-                        auto source = msg.get<boost::uuids::uuid>();
-                        msg.seek(static_cast<int32_t>(initial_frame->frame_len));
-
-                        auto name = msg.get<std::string>();
-                        auto serviceName = msg.get<std::string>();
-                        auto eventType = msg.get<std::string>();
-                        handle_distributedobject(name, serviceName, eventType, source);
-                        return;
-                    }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[client_adddistributedobjectlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
-                }
-
-                ClientMessage client_removedistributedobjectlistener_encode(boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
-                    ClientMessage msg(initial_frame_size, true);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Client.RemoveDistributedObjectListener");
-
-                    msg.set_message_type(static_cast<int32_t>(2560));
-                    msg.set_partition_id(-1);
-
-                    msg.set(registration_id);
-                    return msg;
-                }
-
                 ClientMessage client_ping_encode() {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Client.Ping");
+                    msg.set_operation_name("client.ping");
 
                     msg.set_message_type(static_cast<int32_t>(2816));
                     msg.set_partition_id(-1);
@@ -264,11 +175,12 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_statistics_encode(int64_t timestamp, const std::string  & client_attributes, const std::vector<byte>  & metrics_blob) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                ClientMessage client_statistics_encode(int64_t timestamp, const std::string &client_attributes,
+                                                       const std::vector<byte> &metrics_blob) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Client.Statistics");
+                    msg.set_operation_name("client.statistics");
 
                     msg.set_message_type(static_cast<int32_t>(3072));
                     msg.set_partition_id(-1);
@@ -281,39 +193,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_deployclasses_encode(const std::vector<std::pair<std::string, std::vector<byte>>>  & class_definitions) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Client.DeployClasses");
-
-                    msg.set_message_type(static_cast<int32_t>(3328));
-                    msg.set_partition_id(-1);
-
-                    msg.set(class_definitions, true);
-
-                    return msg;
-                }
-
-                ClientMessage client_createproxies_encode(const std::vector<std::pair<std::string, std::string>>  & proxies) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Client.CreateProxies");
-
-                    msg.set_message_type(static_cast<int32_t>(3584));
-                    msg.set_partition_id(-1);
-
-                    msg.set(proxies, true);
-
-                    return msg;
-                }
-
                 ClientMessage client_localbackuplistener_encode() {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Client.LocalBackupListener");
+                    msg.set_operation_name("client.localbackuplistener");
 
                     msg.set_message_type(static_cast<int32_t>(3840));
                     msg.set_partition_id(-1);
@@ -324,29 +208,29 @@ namespace hazelcast {
                 void client_localbackuplistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 3842) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
+                                ClientMessage::EVENT_HEADER_LEN));
                         auto sourceInvocationCorrelationId = msg.get<int64_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         handle_backup(sourceInvocationCorrelationId);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[client_localbackuplistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[client_localbackuplistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage client_triggerpartitionassignment_encode() {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                ClientMessage client_removemigrationlistener_encode(boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Client.TriggerPartitionAssignment");
+                    msg.set_operation_name("client.removemigrationlistener");
 
-                    msg.set_message_type(static_cast<int32_t>(4096));
+                    msg.set_message_type(static_cast<int32_t>(4608));
                     msg.set_partition_id(-1);
 
+                    msg.set(registration_id);
                     return msg;
                 }
 
@@ -356,7 +240,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Put");
+                    msg.set_operation_name("map.put");
 
                     msg.set_message_type(static_cast<int32_t>(65792));
                     msg.set_partition_id(-1);
@@ -377,7 +261,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.Get");
+                    msg.set_operation_name("map.get");
 
                     msg.set_message_type(static_cast<int32_t>(66048));
                     msg.set_partition_id(-1);
@@ -395,7 +279,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Remove");
+                    msg.set_operation_name("map.remove");
 
                     msg.set_message_type(static_cast<int32_t>(66304));
                     msg.set_partition_id(-1);
@@ -413,7 +297,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Replace");
+                    msg.set_operation_name("map.replace");
 
                     msg.set_message_type(static_cast<int32_t>(66560));
                     msg.set_partition_id(-1);
@@ -434,7 +318,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.ReplaceIfSame");
+                    msg.set_operation_name("map.replaceifsame");
 
                     msg.set_message_type(static_cast<int32_t>(66816));
                     msg.set_partition_id(-1);
@@ -456,7 +340,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.ContainsKey");
+                    msg.set_operation_name("map.containskey");
 
                     msg.set_message_type(static_cast<int32_t>(67072));
                     msg.set_partition_id(-1);
@@ -474,7 +358,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.ContainsValue");
+                    msg.set_operation_name("map.containsvalue");
 
                     msg.set_message_type(static_cast<int32_t>(67328));
                     msg.set_partition_id(-1);
@@ -491,7 +375,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.RemoveIfSame");
+                    msg.set_operation_name("map.removeifsame");
 
                     msg.set_message_type(static_cast<int32_t>(67584));
                     msg.set_partition_id(-1);
@@ -511,7 +395,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Delete");
+                    msg.set_operation_name("map.delete");
 
                     msg.set_message_type(static_cast<int32_t>(67840));
                     msg.set_partition_id(-1);
@@ -528,7 +412,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Flush");
+                    msg.set_operation_name("map.flush");
 
                     msg.set_message_type(static_cast<int32_t>(68096));
                     msg.set_partition_id(-1);
@@ -545,7 +429,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.TryRemove");
+                    msg.set_operation_name("map.tryremove");
 
                     msg.set_message_type(static_cast<int32_t>(68352));
                     msg.set_partition_id(-1);
@@ -566,7 +450,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.TryPut");
+                    msg.set_operation_name("map.tryput");
 
                     msg.set_message_type(static_cast<int32_t>(68608));
                     msg.set_partition_id(-1);
@@ -589,7 +473,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.PutTransient");
+                    msg.set_operation_name("map.puttransient");
 
                     msg.set_message_type(static_cast<int32_t>(68864));
                     msg.set_partition_id(-1);
@@ -612,7 +496,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.PutIfAbsent");
+                    msg.set_operation_name("map.putifabsent");
 
                     msg.set_message_type(static_cast<int32_t>(69120));
                     msg.set_partition_id(-1);
@@ -634,7 +518,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Set");
+                    msg.set_operation_name("map.set");
 
                     msg.set_message_type(static_cast<int32_t>(69376));
                     msg.set_partition_id(-1);
@@ -658,7 +542,7 @@ namespace hazelcast {
                             ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.Lock");
+                    msg.set_operation_name("map.lock");
 
                     msg.set_message_type(static_cast<int32_t>(69632));
                     msg.set_partition_id(-1);
@@ -681,7 +565,7 @@ namespace hazelcast {
                             ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.TryLock");
+                    msg.set_operation_name("map.trylock");
 
                     msg.set_message_type(static_cast<int32_t>(69888));
                     msg.set_partition_id(-1);
@@ -701,7 +585,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.IsLocked");
+                    msg.set_operation_name("map.islocked");
 
                     msg.set_message_type(static_cast<int32_t>(70144));
                     msg.set_partition_id(-1);
@@ -720,7 +604,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.Unlock");
+                    msg.set_operation_name("map.unlock");
 
                     msg.set_message_type(static_cast<int32_t>(70400));
                     msg.set_partition_id(-1);
@@ -739,7 +623,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddInterceptor");
+                    msg.set_operation_name("map.addinterceptor");
 
                     msg.set_message_type(static_cast<int32_t>(70656));
                     msg.set_partition_id(-1);
@@ -755,7 +639,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.RemoveInterceptor");
+                    msg.set_operation_name("map.removeinterceptor");
 
                     msg.set_message_type(static_cast<int32_t>(70912));
                     msg.set_partition_id(-1);
@@ -767,57 +651,6 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_addentrylistenertokeywithpredicate_encode(const std::string &name,
-                                                                            const serialization::pimpl::data &key,
-                                                                            const serialization::pimpl::data &predicate,
-                                                                            bool include_value, int32_t listener_flags,
-                                                                            bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::UINT8_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddEntryListenerToKeyWithPredicate");
-
-                    msg.set_message_type(static_cast<int32_t>(71168));
-                    msg.set_partition_id(-1);
-
-                    msg.set(include_value);
-                    msg.set(listener_flags);
-                    msg.set(local_only);
-                    msg.set(name);
-
-                    msg.set(key);
-
-                    msg.set(predicate, true);
-
-                    return msg;
-                }
-
-                void map_addentrylistenertokeywithpredicate_handler::handle(ClientMessage &msg) {
-                    auto messageType = msg.get_message_type();
-                    if (messageType == 71170) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
-                        auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
-                        msg.seek(static_cast<int32_t>(initial_frame->frame_len));
-
-                        auto key = msg.get_nullable<serialization::pimpl::data>();
-                        auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
-                        return;
-                    }
-                    HZ_LOG(*get_logger(), warning,
-                           boost::str(boost::format("[map_addentrylistenertokeywithpredicate_handler::handle] "
-                                                    "Unknown message type (%1%) received on event handler.")
-                                      % messageType)
-                    );
-                }
-
                 ClientMessage map_addentrylistenerwithpredicate_encode(const std::string &name,
                                                                        const serialization::pimpl::data &predicate,
                                                                        bool include_value, int32_t listener_flags,
@@ -827,7 +660,7 @@ namespace hazelcast {
                             ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddEntryListenerWithPredicate");
+                    msg.set_operation_name("map.addentrylistenerwithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(71424));
                     msg.set_partition_id(-1);
@@ -859,11 +692,9 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                           boost::str(boost::format("[map_addentrylistenerwithpredicate_handler::handle] "
-                                                    "Unknown message type (%1%) received on event handler.")
-                                      % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[map_addentrylistenerwithpredicate_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
                 ClientMessage
@@ -874,7 +705,7 @@ namespace hazelcast {
                             ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddEntryListenerToKey");
+                    msg.set_operation_name("map.addentrylistenertokey");
 
                     msg.set_message_type(static_cast<int32_t>(71680));
                     msg.set_partition_id(-1);
@@ -906,18 +737,20 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[map_addentrylistenertokey_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[map_addentrylistenertokey_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage map_addentrylistener_encode(const std::string  & name, bool include_value, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage
+                map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags,
+                                            bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE +
+                            ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddEntryListener");
+                    msg.set_operation_name("map.addentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(71936));
                     msg.set_partition_id(-1);
@@ -947,68 +780,19 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[map_addentrylistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[map_addentrylistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage map_removeentrylistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage
+                map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.RemoveEntryListener");
+                    msg.set_operation_name("map.removeentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(72192));
-                    msg.set_partition_id(-1);
-
-                    msg.set(registration_id);
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                ClientMessage map_addpartitionlostlistener_encode(const std::string  & name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddPartitionLostListener");
-
-                    msg.set_message_type(static_cast<int32_t>(72448));
-                    msg.set_partition_id(-1);
-
-                    msg.set(local_only);
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                void map_addpartitionlostlistener_handler::handle(ClientMessage &msg) {
-                    auto messageType = msg.get_message_type();
-                    if (messageType == 72450) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
-                        auto partitionId = msg.get<int32_t>();
-                        auto uuid = msg.get<boost::uuids::uuid>();
-                        msg.seek(static_cast<int32_t>(initial_frame->frame_len));
-
-                        handle_mappartitionlost(partitionId, uuid);
-                        return;
-                    }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[map_addpartitionlostlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
-                }
-
-                ClientMessage map_removepartitionlostlistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.RemovePartitionLostListener");
-
-                    msg.set_message_type(static_cast<int32_t>(72704));
                     msg.set_partition_id(-1);
 
                     msg.set(registration_id);
@@ -1022,7 +806,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.GetEntryView");
+                    msg.set_operation_name("map.getentryview");
 
                     msg.set_message_type(static_cast<int32_t>(72960));
                     msg.set_partition_id(-1);
@@ -1040,7 +824,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Evict");
+                    msg.set_operation_name("map.evict");
 
                     msg.set_message_type(static_cast<int32_t>(73216));
                     msg.set_partition_id(-1);
@@ -1057,7 +841,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.EvictAll");
+                    msg.set_operation_name("map.evictall");
 
                     msg.set_message_type(static_cast<int32_t>(73472));
                     msg.set_partition_id(-1);
@@ -1067,45 +851,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_loadall_encode(const std::string  & name, bool replace_existing_values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.LoadAll");
-
-                    msg.set_message_type(static_cast<int32_t>(73728));
-                    msg.set_partition_id(-1);
-
-                    msg.set(replace_existing_values);
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_loadgivenkeys_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys,
-                                         bool replace_existing_values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.LoadGivenKeys");
-
-                    msg.set_message_type(static_cast<int32_t>(73984));
-                    msg.set_partition_id(-1);
-
-                    msg.set(replace_existing_values);
-                    msg.set(name);
-
-                    msg.set(keys, true);
-
-                    return msg;
-                }
-
                 ClientMessage map_keyset_encode(const std::string  & name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.KeySet");
+                    msg.set_operation_name("map.keyset");
 
                     msg.set_message_type(static_cast<int32_t>(74240));
                     msg.set_partition_id(-1);
@@ -1120,7 +870,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.GetAll");
+                    msg.set_operation_name("map.getall");
 
                     msg.set_message_type(static_cast<int32_t>(74496));
                     msg.set_partition_id(-1);
@@ -1136,7 +886,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.Values");
+                    msg.set_operation_name("map.values");
 
                     msg.set_message_type(static_cast<int32_t>(74752));
                     msg.set_partition_id(-1);
@@ -1150,7 +900,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.EntrySet");
+                    msg.set_operation_name("map.entryset");
 
                     msg.set_message_type(static_cast<int32_t>(75008));
                     msg.set_partition_id(-1);
@@ -1165,7 +915,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.KeySetWithPredicate");
+                    msg.set_operation_name("map.keysetwithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(75264));
                     msg.set_partition_id(-1);
@@ -1182,7 +932,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.ValuesWithPredicate");
+                    msg.set_operation_name("map.valueswithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(75520));
                     msg.set_partition_id(-1);
@@ -1199,7 +949,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.EntriesWithPredicate");
+                    msg.set_operation_name("map.entrieswithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(75776));
                     msg.set_partition_id(-1);
@@ -1211,11 +961,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_addindex_encode(const std::string  & name, const config::index_config  & index_config) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                ClientMessage map_addindex_encode(const std::string &name, const config::index_config &index_config) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddIndex");
+                    msg.set_operation_name("map.addindex");
 
                     msg.set_message_type(static_cast<int32_t>(76032));
                     msg.set_partition_id(-1);
@@ -1231,7 +981,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.Size");
+                    msg.set_operation_name("map.size");
 
                     msg.set_message_type(static_cast<int32_t>(76288));
                     msg.set_partition_id(-1);
@@ -1245,7 +995,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.IsEmpty");
+                    msg.set_operation_name("map.isempty");
 
                     msg.set_message_type(static_cast<int32_t>(76544));
                     msg.set_partition_id(-1);
@@ -1261,7 +1011,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.PutAll");
+                    msg.set_operation_name("map.putall");
 
                     msg.set_message_type(static_cast<int32_t>(76800));
                     msg.set_partition_id(-1);
@@ -1278,7 +1028,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.Clear");
+                    msg.set_operation_name("map.clear");
 
                     msg.set_message_type(static_cast<int32_t>(77056));
                     msg.set_partition_id(-1);
@@ -1294,7 +1044,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.ExecuteOnKey");
+                    msg.set_operation_name("map.executeonkey");
 
                     msg.set_message_type(static_cast<int32_t>(77312));
                     msg.set_partition_id(-1);
@@ -1315,7 +1065,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.SubmitToKey");
+                    msg.set_operation_name("map.submittokey");
 
                     msg.set_message_type(static_cast<int32_t>(77568));
                     msg.set_partition_id(-1);
@@ -1335,7 +1085,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.ExecuteOnAllKeys");
+                    msg.set_operation_name("map.executeonallkeys");
 
                     msg.set_message_type(static_cast<int32_t>(77824));
                     msg.set_partition_id(-1);
@@ -1353,7 +1103,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.ExecuteWithPredicate");
+                    msg.set_operation_name("map.executewithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(78080));
                     msg.set_partition_id(-1);
@@ -1373,7 +1123,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.ExecuteOnKeys");
+                    msg.set_operation_name("map.executeonkeys");
 
                     msg.set_message_type(static_cast<int32_t>(78336));
                     msg.set_partition_id(-1);
@@ -1392,7 +1142,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.ForceUnlock");
+                    msg.set_operation_name("map.forceunlock");
 
                     msg.set_message_type(static_cast<int32_t>(78592));
                     msg.set_partition_id(-1);
@@ -1409,7 +1159,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.KeySetWithpaging_predicate");
+                    msg.set_operation_name("map.keysetwithpagingpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(78848));
                     msg.set_partition_id(-1);
@@ -1425,7 +1175,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.ValuesWithpaging_predicate");
+                    msg.set_operation_name("map.valueswithpagingpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(79104));
                     msg.set_partition_id(-1);
@@ -1441,7 +1191,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Map.EntriesWithpaging_predicate");
+                    msg.set_operation_name("map.entrieswithpagingpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(79360));
                     msg.set_partition_id(-1);
@@ -1453,135 +1203,12 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_fetchkeys_encode(const std::string  & name, const std::vector<std::pair<int32_t, int32_t>>  & iteration_pointers, int32_t batch) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.FetchKeys");
-
-                    msg.set_message_type(static_cast<int32_t>(79616));
-                    msg.set_partition_id(-1);
-
-                    msg.set(batch);
-                    msg.set(name);
-
-                    msg.set(iteration_pointers, true);
-
-                    return msg;
-                }
-
-                ClientMessage map_fetchentries_encode(const std::string  & name, const std::vector<std::pair<int32_t, int32_t>>  & iteration_pointers, int32_t batch) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.FetchEntries");
-
-                    msg.set_message_type(static_cast<int32_t>(79872));
-                    msg.set_partition_id(-1);
-
-                    msg.set(batch);
-                    msg.set(name);
-
-                    msg.set(iteration_pointers, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_aggregate_encode(const std::string &name, const serialization::pimpl::data &aggregator) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.Aggregate");
-
-                    msg.set_message_type(static_cast<int32_t>(80128));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name);
-
-                    msg.set(aggregator, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_aggregatewithpredicate_encode(const std::string &name, const serialization::pimpl::data &aggregator,
-                                                  const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.AggregateWithPredicate");
-
-                    msg.set_message_type(static_cast<int32_t>(80384));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name);
-
-                    msg.set(aggregator);
-
-                    msg.set(predicate, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_project_encode(const std::string &name, const serialization::pimpl::data &projection) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.Project");
-
-                    msg.set_message_type(static_cast<int32_t>(80640));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name);
-
-                    msg.set(projection, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_projectwithpredicate_encode(const std::string &name, const serialization::pimpl::data &projection,
-                                                const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.ProjectWithPredicate");
-
-                    msg.set_message_type(static_cast<int32_t>(80896));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name);
-
-                    msg.set(projection);
-
-                    msg.set(predicate, true);
-
-                    return msg;
-                }
-
-                ClientMessage map_fetchnearcacheinvalidationmetadata_encode(const std::vector<std::string>  & names, boost::uuids::uuid uuid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.FetchNearCacheInvalidationMetadata");
-
-                    msg.set_message_type(static_cast<int32_t>(81152));
-                    msg.set_partition_id(-1);
-
-                    msg.set(uuid);
-                    msg.set(names, true);
-
-                    return msg;
-                }
-
                 ClientMessage
                 map_removeall_encode(const std::string &name, const serialization::pimpl::data &predicate) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.RemoveAll");
+                    msg.set_operation_name("map.removeall");
 
                     msg.set_message_type(static_cast<int32_t>(81408));
                     msg.set_partition_id(-1);
@@ -1593,11 +1220,14 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_addnearcacheinvalidationlistener_encode(const std::string  & name, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage
+                map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags,
+                                                            bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Map.AddNearCacheInvalidationListener");
+                    msg.set_operation_name("map.addnearcacheinvalidationlistener");
 
                     msg.set_message_type(static_cast<int32_t>(81664));
                     msg.set_partition_id(-1);
@@ -1633,195 +1263,9 @@ namespace hazelcast {
                         handle_imapbatchinvalidation(keys, sourceUuids, partitionUuids, sequences);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                           boost::str(boost::format("[map_addnearcacheinvalidationlistener_handler::handle] "
-                                                    "Unknown message type (%1%) received on event handler.")
-                                      % messageType)
-                    );
-                }
-
-                ClientMessage map_fetchwithquery_encode(const std::string &name,
-                                                        const std::vector<std::pair<int32_t, int32_t>> &iteration_pointers,
-                                                        int32_t batch, const serialization::pimpl::data &projection,
-                                                        const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.FetchWithQuery");
-
-                    msg.set_message_type(static_cast<int32_t>(81920));
-                    msg.set_partition_id(-1);
-
-                    msg.set(batch);
-                    msg.set(name);
-
-                    msg.set(iteration_pointers);
-
-                    msg.set(projection);
-
-                    msg.set(predicate, true);
-
-                    return msg;
-                }
-
-                ClientMessage map_eventjournalsubscribe_encode(const std::string  & name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.EventJournalSubscribe");
-
-                    msg.set_message_type(static_cast<int32_t>(82176));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_eventjournalread_encode(const std::string &name, int64_t start_sequence, int32_t min_size,
-                                            int32_t max_size, const serialization::pimpl::data *predicate,
-                                            const serialization::pimpl::data *projection) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::INT32_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("Map.EventJournalRead");
-
-                    msg.set_message_type(static_cast<int32_t>(82432));
-                    msg.set_partition_id(-1);
-
-                    msg.set(start_sequence);
-                    msg.set(min_size);
-                    msg.set(max_size);
-                    msg.set(name);
-
-                    msg.set_nullable(predicate);
-
-                    msg.set_nullable(projection, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_setttl_encode(const std::string &name, const serialization::pimpl::data &key, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.SetTtl");
-
-                    msg.set_message_type(static_cast<int32_t>(82688));
-                    msg.set_partition_id(-1);
-
-                    msg.set(ttl);
-                    msg.set(name);
-
-                    msg.set(key, true);
-
-                    return msg;
-                }
-
-                ClientMessage map_putwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                        const serialization::pimpl::data &value, int64_t thread_id,
-                                                        int64_t ttl, int64_t max_idle) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.PutWithMaxIdle");
-
-                    msg.set_message_type(static_cast<int32_t>(82944));
-                    msg.set_partition_id(-1);
-
-                    msg.set(thread_id);
-                    msg.set(ttl);
-                    msg.set(max_idle);
-                    msg.set(name);
-
-                    msg.set(key);
-
-                    msg.set(value, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_puttransientwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                   const serialization::pimpl::data &value, int64_t thread_id,
-                                                   int64_t ttl, int64_t max_idle) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.PutTransientWithMaxIdle");
-
-                    msg.set_message_type(static_cast<int32_t>(83200));
-                    msg.set_partition_id(-1);
-
-                    msg.set(thread_id);
-                    msg.set(ttl);
-                    msg.set(max_idle);
-                    msg.set(name);
-
-                    msg.set(key);
-
-                    msg.set(value, true);
-
-                    return msg;
-                }
-
-                ClientMessage
-                map_putifabsentwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                  const serialization::pimpl::data &value, int64_t thread_id,
-                                                  int64_t ttl, int64_t max_idle) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.PutIfAbsentWithMaxIdle");
-
-                    msg.set_message_type(static_cast<int32_t>(83456));
-                    msg.set_partition_id(-1);
-
-                    msg.set(thread_id);
-                    msg.set(ttl);
-                    msg.set(max_idle);
-                    msg.set(name);
-
-                    msg.set(key);
-
-                    msg.set(value, true);
-
-                    return msg;
-                }
-
-                ClientMessage map_setwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                        const serialization::pimpl::data &value, int64_t thread_id,
-                                                        int64_t ttl, int64_t max_idle) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Map.SetWithMaxIdle");
-
-                    msg.set_message_type(static_cast<int32_t>(83712));
-                    msg.set_partition_id(-1);
-
-                    msg.set(thread_id);
-                    msg.set(ttl);
-                    msg.set(max_idle);
-                    msg.set(name);
-
-                    msg.set(key);
-
-                    msg.set(value, true);
-
-                    return msg;
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[map_addnearcacheinvalidationlistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
                 ClientMessage multimap_put_encode(const std::string &name, const serialization::pimpl::data &key,
@@ -1829,7 +1273,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.Put");
+                    msg.set_operation_name("multimap.put");
 
                     msg.set_message_type(static_cast<int32_t>(131328));
                     msg.set_partition_id(-1);
@@ -1849,7 +1293,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.Get");
+                    msg.set_operation_name("multimap.get");
 
                     msg.set_message_type(static_cast<int32_t>(131584));
                     msg.set_partition_id(-1);
@@ -1867,7 +1311,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.Remove");
+                    msg.set_operation_name("multimap.remove");
 
                     msg.set_message_type(static_cast<int32_t>(131840));
                     msg.set_partition_id(-1);
@@ -1884,7 +1328,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.KeySet");
+                    msg.set_operation_name("multimap.keyset");
 
                     msg.set_message_type(static_cast<int32_t>(132096));
                     msg.set_partition_id(-1);
@@ -1898,7 +1342,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.Values");
+                    msg.set_operation_name("multimap.values");
 
                     msg.set_message_type(static_cast<int32_t>(132352));
                     msg.set_partition_id(-1);
@@ -1912,7 +1356,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.EntrySet");
+                    msg.set_operation_name("multimap.entryset");
 
                     msg.set_message_type(static_cast<int32_t>(132608));
                     msg.set_partition_id(-1);
@@ -1928,7 +1372,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.ContainsKey");
+                    msg.set_operation_name("multimap.containskey");
 
                     msg.set_message_type(static_cast<int32_t>(132864));
                     msg.set_partition_id(-1);
@@ -1946,7 +1390,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.ContainsValue");
+                    msg.set_operation_name("multimap.containsvalue");
 
                     msg.set_message_type(static_cast<int32_t>(133120));
                     msg.set_partition_id(-1);
@@ -1964,7 +1408,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.ContainsEntry");
+                    msg.set_operation_name("multimap.containsentry");
 
                     msg.set_message_type(static_cast<int32_t>(133376));
                     msg.set_partition_id(-1);
@@ -1983,7 +1427,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.Size");
+                    msg.set_operation_name("multimap.size");
 
                     msg.set_message_type(static_cast<int32_t>(133632));
                     msg.set_partition_id(-1);
@@ -1997,7 +1441,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.Clear");
+                    msg.set_operation_name("multimap.clear");
 
                     msg.set_message_type(static_cast<int32_t>(133888));
                     msg.set_partition_id(-1);
@@ -2012,7 +1456,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.ValueCount");
+                    msg.set_operation_name("multimap.valuecount");
 
                     msg.set_message_type(static_cast<int32_t>(134144));
                     msg.set_partition_id(-1);
@@ -2032,7 +1476,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.AddEntryListenerToKey");
+                    msg.set_operation_name("multimap.addentrylistenertokey");
 
                     msg.set_message_type(static_cast<int32_t>(134400));
                     msg.set_partition_id(-1);
@@ -2063,18 +1507,18 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[multimap_addentrylistenertokey_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[multimap_addentrylistenertokey_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage multimap_addentrylistener_encode(const std::string  & name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage
+                multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.AddEntryListener");
+                    msg.set_operation_name("multimap.addentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(134656));
                     msg.set_partition_id(-1);
@@ -2103,18 +1547,17 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[multimap_addentrylistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[multimap_addentrylistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage multimap_removeentrylistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage
+                multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.RemoveEntryListener");
+                    msg.set_operation_name("multimap.removeentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(134912));
                     msg.set_partition_id(-1);
@@ -2133,7 +1576,7 @@ namespace hazelcast {
                             ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.Lock");
+                    msg.set_operation_name("multimap.lock");
 
                     msg.set_message_type(static_cast<int32_t>(135168));
                     msg.set_partition_id(-1);
@@ -2156,7 +1599,7 @@ namespace hazelcast {
                             ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.TryLock");
+                    msg.set_operation_name("multimap.trylock");
 
                     msg.set_message_type(static_cast<int32_t>(135424));
                     msg.set_partition_id(-1);
@@ -2176,7 +1619,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.IsLocked");
+                    msg.set_operation_name("multimap.islocked");
 
                     msg.set_message_type(static_cast<int32_t>(135680));
                     msg.set_partition_id(-1);
@@ -2194,7 +1637,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.Unlock");
+                    msg.set_operation_name("multimap.unlock");
 
                     msg.set_message_type(static_cast<int32_t>(135936));
                     msg.set_partition_id(-1);
@@ -2214,7 +1657,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("MultiMap.ForceUnlock");
+                    msg.set_operation_name("multimap.forceunlock");
 
                     msg.set_message_type(static_cast<int32_t>(136192));
                     msg.set_partition_id(-1);
@@ -2233,7 +1676,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.RemoveEntry");
+                    msg.set_operation_name("multimap.removeentry");
 
                     msg.set_message_type(static_cast<int32_t>(136448));
                     msg.set_partition_id(-1);
@@ -2248,47 +1691,12 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_delete_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                     int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.Delete");
-
-                    msg.set_message_type(static_cast<int32_t>(136704));
-                    msg.set_partition_id(-1);
-
-                    msg.set(thread_id);
-                    msg.set(name);
-
-                    msg.set(key, true);
-
-                    return msg;
-                }
-
-                ClientMessage multimap_putall_encode(const std::string &name,
-                                                     const std::vector<std::pair<serialization::pimpl::data, std::vector<serialization::pimpl::data>>> &entries) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("MultiMap.PutAll");
-
-                    msg.set_message_type(static_cast<int32_t>(136960));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name);
-
-                    msg.set(entries, true);
-
-                    return msg;
-                }
-
                 ClientMessage queue_offer_encode(const std::string &name, const serialization::pimpl::data &value,
                                                  int64_t timeout_millis) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Offer");
+                    msg.set_operation_name("queue.offer");
 
                     msg.set_message_type(static_cast<int32_t>(196864));
                     msg.set_partition_id(-1);
@@ -2305,7 +1713,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Put");
+                    msg.set_operation_name("queue.put");
 
                     msg.set_message_type(static_cast<int32_t>(197120));
                     msg.set_partition_id(-1);
@@ -2321,7 +1729,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Size");
+                    msg.set_operation_name("queue.size");
 
                     msg.set_message_type(static_cast<int32_t>(197376));
                     msg.set_partition_id(-1);
@@ -2335,7 +1743,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Remove");
+                    msg.set_operation_name("queue.remove");
 
                     msg.set_message_type(static_cast<int32_t>(197632));
                     msg.set_partition_id(-1);
@@ -2347,11 +1755,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_poll_encode(const std::string  & name, int64_t timeout_millis) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                ClientMessage queue_poll_encode(const std::string &name, int64_t timeout_millis) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Poll");
+                    msg.set_operation_name("queue.poll");
 
                     msg.set_message_type(static_cast<int32_t>(197888));
                     msg.set_partition_id(-1);
@@ -2366,7 +1774,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Take");
+                    msg.set_operation_name("queue.take");
 
                     msg.set_message_type(static_cast<int32_t>(198144));
                     msg.set_partition_id(-1);
@@ -2380,7 +1788,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Peek");
+                    msg.set_operation_name("queue.peek");
 
                     msg.set_message_type(static_cast<int32_t>(198400));
                     msg.set_partition_id(-1);
@@ -2394,7 +1802,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Iterator");
+                    msg.set_operation_name("queue.iterator");
 
                     msg.set_message_type(static_cast<int32_t>(198656));
                     msg.set_partition_id(-1);
@@ -2408,7 +1816,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.DrainTo");
+                    msg.set_operation_name("queue.drainto");
 
                     msg.set_message_type(static_cast<int32_t>(198912));
                     msg.set_partition_id(-1);
@@ -2418,11 +1826,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_draintomaxsize_encode(const std::string  & name, int32_t max_size) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                ClientMessage queue_draintomaxsize_encode(const std::string &name, int32_t max_size) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.DrainToMaxSize");
+                    msg.set_operation_name("queue.draintomaxsize");
 
                     msg.set_message_type(static_cast<int32_t>(199168));
                     msg.set_partition_id(-1);
@@ -2437,7 +1845,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Contains");
+                    msg.set_operation_name("queue.contains");
 
                     msg.set_message_type(static_cast<int32_t>(199424));
                     msg.set_partition_id(-1);
@@ -2454,7 +1862,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.ContainsAll");
+                    msg.set_operation_name("queue.containsall");
 
                     msg.set_message_type(static_cast<int32_t>(199680));
                     msg.set_partition_id(-1);
@@ -2471,7 +1879,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.CompareAndRemoveAll");
+                    msg.set_operation_name("queue.compareandremoveall");
 
                     msg.set_message_type(static_cast<int32_t>(199936));
                     msg.set_partition_id(-1);
@@ -2488,7 +1896,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.CompareAndRetainAll");
+                    msg.set_operation_name("queue.compareandretainall");
 
                     msg.set_message_type(static_cast<int32_t>(200192));
                     msg.set_partition_id(-1);
@@ -2504,7 +1912,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.Clear");
+                    msg.set_operation_name("queue.clear");
 
                     msg.set_message_type(static_cast<int32_t>(200448));
                     msg.set_partition_id(-1);
@@ -2519,7 +1927,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.AddAll");
+                    msg.set_operation_name("queue.addall");
 
                     msg.set_message_type(static_cast<int32_t>(200704));
                     msg.set_partition_id(-1);
@@ -2531,11 +1939,12 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_addlistener_encode(const std::string  & name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage queue_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.AddListener");
+                    msg.set_operation_name("queue.addlistener");
 
                     msg.set_message_type(static_cast<int32_t>(200960));
                     msg.set_partition_id(-1);
@@ -2550,7 +1959,8 @@ namespace hazelcast {
                 void queue_addlistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 200962) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
+                                ClientMessage::EVENT_HEADER_LEN));
                         auto uuid = msg.get<boost::uuids::uuid>();
                         auto eventType = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
@@ -2559,18 +1969,16 @@ namespace hazelcast {
                         handle_item(item, uuid, eventType);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[queue_addlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[queue_addlistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage queue_removelistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage queue_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Queue.RemoveListener");
+                    msg.set_operation_name("queue.removelistener");
 
                     msg.set_message_type(static_cast<int32_t>(201216));
                     msg.set_partition_id(-1);
@@ -2585,7 +1993,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.RemainingCapacity");
+                    msg.set_operation_name("queue.remainingcapacity");
 
                     msg.set_message_type(static_cast<int32_t>(201472));
                     msg.set_partition_id(-1);
@@ -2599,7 +2007,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Queue.IsEmpty");
+                    msg.set_operation_name("queue.isempty");
 
                     msg.set_message_type(static_cast<int32_t>(201728));
                     msg.set_partition_id(-1);
@@ -2613,7 +2021,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Topic.Publish");
+                    msg.set_operation_name("topic.publish");
 
                     msg.set_message_type(static_cast<int32_t>(262400));
                     msg.set_partition_id(-1);
@@ -2625,11 +2033,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage topic_addmessagelistener_encode(const std::string  & name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                ClientMessage topic_addmessagelistener_encode(const std::string &name, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Topic.AddMessageListener");
+                    msg.set_operation_name("topic.addmessagelistener");
 
                     msg.set_message_type(static_cast<int32_t>(262656));
                     msg.set_partition_id(-1);
@@ -2643,7 +2051,8 @@ namespace hazelcast {
                 void topic_addmessagelistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 262658) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
+                                ClientMessage::EVENT_HEADER_LEN));
                         auto publishTime = msg.get<int64_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
@@ -2652,18 +2061,17 @@ namespace hazelcast {
                         handle_topic(item, publishTime, uuid);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[topic_addmessagelistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[topic_addmessagelistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage topic_removemessagelistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage
+                topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Topic.RemoveMessageListener");
+                    msg.set_operation_name("topic.removemessagelistener");
 
                     msg.set_message_type(static_cast<int32_t>(262912));
                     msg.set_partition_id(-1);
@@ -2674,28 +2082,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage topic_publishall_encode(const std::string &name,
-                                                      const std::vector<serialization::pimpl::data> &messages) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("Topic.PublishAll");
-
-                    msg.set_message_type(static_cast<int32_t>(263168));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name);
-
-                    msg.set(messages, true);
-
-                    return msg;
-                }
-
                 ClientMessage list_size_encode(const std::string  & name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.Size");
+                    msg.set_operation_name("list.size");
 
                     msg.set_message_type(static_cast<int32_t>(327936));
                     msg.set_partition_id(-1);
@@ -2709,7 +2100,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.Contains");
+                    msg.set_operation_name("list.contains");
 
                     msg.set_message_type(static_cast<int32_t>(328192));
                     msg.set_partition_id(-1);
@@ -2726,7 +2117,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.ContainsAll");
+                    msg.set_operation_name("list.containsall");
 
                     msg.set_message_type(static_cast<int32_t>(328448));
                     msg.set_partition_id(-1);
@@ -2742,7 +2133,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.Add");
+                    msg.set_operation_name("list.add");
 
                     msg.set_message_type(static_cast<int32_t>(328704));
                     msg.set_partition_id(-1);
@@ -2758,7 +2149,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.Remove");
+                    msg.set_operation_name("list.remove");
 
                     msg.set_message_type(static_cast<int32_t>(328960));
                     msg.set_partition_id(-1);
@@ -2775,7 +2166,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.AddAll");
+                    msg.set_operation_name("list.addall");
 
                     msg.set_message_type(static_cast<int32_t>(329216));
                     msg.set_partition_id(-1);
@@ -2792,7 +2183,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.CompareAndRemoveAll");
+                    msg.set_operation_name("list.compareandremoveall");
 
                     msg.set_message_type(static_cast<int32_t>(329472));
                     msg.set_partition_id(-1);
@@ -2809,7 +2200,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.CompareAndRetainAll");
+                    msg.set_operation_name("list.compareandretainall");
 
                     msg.set_message_type(static_cast<int32_t>(329728));
                     msg.set_partition_id(-1);
@@ -2825,7 +2216,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.Clear");
+                    msg.set_operation_name("list.clear");
 
                     msg.set_message_type(static_cast<int32_t>(329984));
                     msg.set_partition_id(-1);
@@ -2839,7 +2230,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.GetAll");
+                    msg.set_operation_name("list.getall");
 
                     msg.set_message_type(static_cast<int32_t>(330240));
                     msg.set_partition_id(-1);
@@ -2849,11 +2240,12 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_addlistener_encode(const std::string  & name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage list_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.AddListener");
+                    msg.set_operation_name("list.addlistener");
 
                     msg.set_message_type(static_cast<int32_t>(330496));
                     msg.set_partition_id(-1);
@@ -2868,7 +2260,8 @@ namespace hazelcast {
                 void list_addlistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 330498) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
+                                ClientMessage::EVENT_HEADER_LEN));
                         auto uuid = msg.get<boost::uuids::uuid>();
                         auto eventType = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
@@ -2877,18 +2270,16 @@ namespace hazelcast {
                         handle_item(item, uuid, eventType);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[list_addlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[list_addlistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage list_removelistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage list_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.RemoveListener");
+                    msg.set_operation_name("list.removelistener");
 
                     msg.set_message_type(static_cast<int32_t>(330752));
                     msg.set_partition_id(-1);
@@ -2903,7 +2294,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.IsEmpty");
+                    msg.set_operation_name("list.isempty");
 
                     msg.set_message_type(static_cast<int32_t>(331008));
                     msg.set_partition_id(-1);
@@ -2918,7 +2309,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.AddAllWithIndex");
+                    msg.set_operation_name("list.addallwithindex");
 
                     msg.set_message_type(static_cast<int32_t>(331264));
                     msg.set_partition_id(-1);
@@ -2935,7 +2326,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.Get");
+                    msg.set_operation_name("list.get");
 
                     msg.set_message_type(static_cast<int32_t>(331520));
                     msg.set_partition_id(-1);
@@ -2951,7 +2342,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.Set");
+                    msg.set_operation_name("list.set");
 
                     msg.set_message_type(static_cast<int32_t>(331776));
                     msg.set_partition_id(-1);
@@ -2969,7 +2360,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.AddWithIndex");
+                    msg.set_operation_name("list.addwithindex");
 
                     msg.set_message_type(static_cast<int32_t>(332032));
                     msg.set_partition_id(-1);
@@ -2986,7 +2377,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("List.RemoveWithIndex");
+                    msg.set_operation_name("list.removewithindex");
 
                     msg.set_message_type(static_cast<int32_t>(332288));
                     msg.set_partition_id(-1);
@@ -3002,7 +2393,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.LastIndexOf");
+                    msg.set_operation_name("list.lastindexof");
 
                     msg.set_message_type(static_cast<int32_t>(332544));
                     msg.set_partition_id(-1);
@@ -3018,7 +2409,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.IndexOf");
+                    msg.set_operation_name("list.indexof");
 
                     msg.set_message_type(static_cast<int32_t>(332800));
                     msg.set_partition_id(-1);
@@ -3034,7 +2425,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("List.Sub");
+                    msg.set_operation_name("list.sub");
 
                     msg.set_message_type(static_cast<int32_t>(333056));
                     msg.set_partition_id(-1);
@@ -3046,40 +2437,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_iterator_encode(const std::string  & name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("List.Iterator");
-
-                    msg.set_message_type(static_cast<int32_t>(333312));
-                    msg.set_partition_id(-1);
-
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                ClientMessage list_listiterator_encode(const std::string  & name, int32_t index) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("List.ListIterator");
-
-                    msg.set_message_type(static_cast<int32_t>(333568));
-                    msg.set_partition_id(-1);
-
-                    msg.set(index);
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
                 ClientMessage set_size_encode(const std::string  & name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.Size");
+                    msg.set_operation_name("set.size");
 
                     msg.set_message_type(static_cast<int32_t>(393472));
                     msg.set_partition_id(-1);
@@ -3093,7 +2455,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.Contains");
+                    msg.set_operation_name("set.contains");
 
                     msg.set_message_type(static_cast<int32_t>(393728));
                     msg.set_partition_id(-1);
@@ -3110,7 +2472,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.ContainsAll");
+                    msg.set_operation_name("set.containsall");
 
                     msg.set_message_type(static_cast<int32_t>(393984));
                     msg.set_partition_id(-1);
@@ -3126,7 +2488,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.Add");
+                    msg.set_operation_name("set.add");
 
                     msg.set_message_type(static_cast<int32_t>(394240));
                     msg.set_partition_id(-1);
@@ -3142,7 +2504,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.Remove");
+                    msg.set_operation_name("set.remove");
 
                     msg.set_message_type(static_cast<int32_t>(394496));
                     msg.set_partition_id(-1);
@@ -3159,7 +2521,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.AddAll");
+                    msg.set_operation_name("set.addall");
 
                     msg.set_message_type(static_cast<int32_t>(394752));
                     msg.set_partition_id(-1);
@@ -3176,7 +2538,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.CompareAndRemoveAll");
+                    msg.set_operation_name("set.compareandremoveall");
 
                     msg.set_message_type(static_cast<int32_t>(395008));
                     msg.set_partition_id(-1);
@@ -3193,7 +2555,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.CompareAndRetainAll");
+                    msg.set_operation_name("set.compareandretainall");
 
                     msg.set_message_type(static_cast<int32_t>(395264));
                     msg.set_partition_id(-1);
@@ -3209,7 +2571,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.Clear");
+                    msg.set_operation_name("set.clear");
 
                     msg.set_message_type(static_cast<int32_t>(395520));
                     msg.set_partition_id(-1);
@@ -3223,7 +2585,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.GetAll");
+                    msg.set_operation_name("set.getall");
 
                     msg.set_message_type(static_cast<int32_t>(395776));
                     msg.set_partition_id(-1);
@@ -3233,11 +2595,12 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_addlistener_encode(const std::string  & name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage set_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.AddListener");
+                    msg.set_operation_name("set.addlistener");
 
                     msg.set_message_type(static_cast<int32_t>(396032));
                     msg.set_partition_id(-1);
@@ -3252,7 +2615,8 @@ namespace hazelcast {
                 void set_addlistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 396034) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
+                                ClientMessage::EVENT_HEADER_LEN));
                         auto uuid = msg.get<boost::uuids::uuid>();
                         auto eventType = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
@@ -3261,18 +2625,16 @@ namespace hazelcast {
                         handle_item(item, uuid, eventType);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[set_addlistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[set_addlistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage set_removelistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage set_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Set.RemoveListener");
+                    msg.set_operation_name("set.removelistener");
 
                     msg.set_message_type(static_cast<int32_t>(396288));
                     msg.set_partition_id(-1);
@@ -3287,7 +2649,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Set.IsEmpty");
+                    msg.set_operation_name("set.isempty");
 
                     msg.set_message_type(static_cast<int32_t>(396544));
                     msg.set_partition_id(-1);
@@ -3305,7 +2667,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("FencedLock.Lock");
+                    msg.set_operation_name("fencedlock.lock");
 
                     msg.set_message_type(static_cast<int32_t>(459008));
                     msg.set_partition_id(-1);
@@ -3328,7 +2690,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("FencedLock.TryLock");
+                    msg.set_operation_name("fencedlock.trylock");
 
                     msg.set_message_type(static_cast<int32_t>(459264));
                     msg.set_partition_id(-1);
@@ -3352,7 +2714,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("FencedLock.Unlock");
+                    msg.set_operation_name("fencedlock.unlock");
 
                     msg.set_message_type(static_cast<int32_t>(459520));
                     msg.set_partition_id(-1);
@@ -3372,7 +2734,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("FencedLock.GetLockOwnership");
+                    msg.set_operation_name("fencedlock.getlockownership");
 
                     msg.set_message_type(static_cast<int32_t>(459776));
                     msg.set_partition_id(-1);
@@ -3388,7 +2750,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ExecutorService.Shutdown");
+                    msg.set_operation_name("executorservice.shutdown");
 
                     msg.set_message_type(static_cast<int32_t>(524544));
                     msg.set_partition_id(-1);
@@ -3402,7 +2764,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ExecutorService.IsShutdown");
+                    msg.set_operation_name("executorservice.isshutdown");
 
                     msg.set_message_type(static_cast<int32_t>(524800));
                     msg.set_partition_id(-1);
@@ -3416,7 +2778,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ExecutorService.CancelOnPartition");
+                    msg.set_operation_name("executorservice.cancelonpartition");
 
                     msg.set_message_type(static_cast<int32_t>(525056));
                     msg.set_partition_id(-1);
@@ -3426,11 +2788,15 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid, bool interrupt) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage
+                executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid,
+                                                      bool interrupt) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE +
+                            ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ExecutorService.CancelOnMember");
+                    msg.set_operation_name("executorservice.cancelonmember");
 
                     msg.set_message_type(static_cast<int32_t>(525312));
                     msg.set_partition_id(-1);
@@ -3446,7 +2812,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ExecutorService.SubmitToPartition");
+                    msg.set_operation_name("executorservice.submittopartition");
 
                     msg.set_message_type(static_cast<int32_t>(525568));
                     msg.set_partition_id(-1);
@@ -3466,7 +2832,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ExecutorService.SubmitToMember");
+                    msg.set_operation_name("executorservice.submittomember");
 
                     msg.set_message_type(static_cast<int32_t>(525824));
                     msg.set_partition_id(-1);
@@ -3485,7 +2851,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicLong.Apply");
+                    msg.set_operation_name("atomiclong.apply");
 
                     msg.set_message_type(static_cast<int32_t>(590080));
                     msg.set_partition_id(-1);
@@ -3505,7 +2871,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicLong.Alter");
+                    msg.set_operation_name("atomiclong.alter");
 
                     msg.set_message_type(static_cast<int32_t>(590336));
                     msg.set_partition_id(-1);
@@ -3525,7 +2891,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicLong.AddAndGet");
+                    msg.set_operation_name("atomiclong.addandget");
 
                     msg.set_message_type(static_cast<int32_t>(590592));
                     msg.set_partition_id(-1);
@@ -3545,7 +2911,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicLong.CompareAndSet");
+                    msg.set_operation_name("atomiclong.compareandset");
 
                     msg.set_message_type(static_cast<int32_t>(590848));
                     msg.set_partition_id(-1);
@@ -3563,7 +2929,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("AtomicLong.Get");
+                    msg.set_operation_name("atomiclong.get");
 
                     msg.set_message_type(static_cast<int32_t>(591104));
                     msg.set_partition_id(-1);
@@ -3580,7 +2946,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicLong.GetAndAdd");
+                    msg.set_operation_name("atomiclong.getandadd");
 
                     msg.set_message_type(static_cast<int32_t>(591360));
                     msg.set_partition_id(-1);
@@ -3598,7 +2964,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicLong.GetAndSet");
+                    msg.set_operation_name("atomiclong.getandset");
 
                     msg.set_message_type(static_cast<int32_t>(591616));
                     msg.set_partition_id(-1);
@@ -3618,7 +2984,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicRef.Apply");
+                    msg.set_operation_name("atomicref.apply");
 
                     msg.set_message_type(static_cast<int32_t>(655616));
                     msg.set_partition_id(-1);
@@ -3640,7 +3006,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicRef.CompareAndSet");
+                    msg.set_operation_name("atomicref.compareandset");
 
                     msg.set_message_type(static_cast<int32_t>(655872));
                     msg.set_partition_id(-1);
@@ -3661,7 +3027,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("AtomicRef.Contains");
+                    msg.set_operation_name("atomicref.contains");
 
                     msg.set_message_type(static_cast<int32_t>(656128));
                     msg.set_partition_id(-1);
@@ -3679,7 +3045,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("AtomicRef.Get");
+                    msg.set_operation_name("atomicref.get");
 
                     msg.set_message_type(static_cast<int32_t>(656384));
                     msg.set_partition_id(-1);
@@ -3696,7 +3062,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("AtomicRef.Set");
+                    msg.set_operation_name("atomicref.set");
 
                     msg.set_message_type(static_cast<int32_t>(656640));
                     msg.set_partition_id(-1);
@@ -3717,7 +3083,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CountDownLatch.TrySetCount");
+                    msg.set_operation_name("countdownlatch.trysetcount");
 
                     msg.set_message_type(static_cast<int32_t>(721152));
                     msg.set_partition_id(-1);
@@ -3736,7 +3102,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CountDownLatch.Await");
+                    msg.set_operation_name("countdownlatch.await");
 
                     msg.set_message_type(static_cast<int32_t>(721408));
                     msg.set_partition_id(-1);
@@ -3757,7 +3123,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CountDownLatch.CountDown");
+                    msg.set_operation_name("countdownlatch.countdown");
 
                     msg.set_message_type(static_cast<int32_t>(721664));
                     msg.set_partition_id(-1);
@@ -3776,7 +3142,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CountDownLatch.GetCount");
+                    msg.set_operation_name("countdownlatch.getcount");
 
                     msg.set_message_type(static_cast<int32_t>(721920));
                     msg.set_partition_id(-1);
@@ -3793,7 +3159,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CountDownLatch.GetRound");
+                    msg.set_operation_name("countdownlatch.getround");
 
                     msg.set_message_type(static_cast<int32_t>(722176));
                     msg.set_partition_id(-1);
@@ -3810,7 +3176,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.Init");
+                    msg.set_operation_name("semaphore.init");
 
                     msg.set_message_type(static_cast<int32_t>(786688));
                     msg.set_partition_id(-1);
@@ -3832,7 +3198,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.Acquire");
+                    msg.set_operation_name("semaphore.acquire");
 
                     msg.set_message_type(static_cast<int32_t>(786944));
                     msg.set_partition_id(-1);
@@ -3857,7 +3223,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.Release");
+                    msg.set_operation_name("semaphore.release");
 
                     msg.set_message_type(static_cast<int32_t>(787200));
                     msg.set_partition_id(-1);
@@ -3881,7 +3247,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.Drain");
+                    msg.set_operation_name("semaphore.drain");
 
                     msg.set_message_type(static_cast<int32_t>(787456));
                     msg.set_partition_id(-1);
@@ -3904,7 +3270,7 @@ namespace hazelcast {
                             ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.Change");
+                    msg.set_operation_name("semaphore.change");
 
                     msg.set_message_type(static_cast<int32_t>(787712));
                     msg.set_partition_id(-1);
@@ -3925,7 +3291,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.AvailablePermits");
+                    msg.set_operation_name("semaphore.availablepermits");
 
                     msg.set_message_type(static_cast<int32_t>(787968));
                     msg.set_partition_id(-1);
@@ -3937,11 +3303,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage semaphore_getsemaphoretype_encode(const std::string  & proxy_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                ClientMessage semaphore_getsemaphoretype_encode(const std::string &proxy_name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Semaphore.GetSemaphoreType");
+                    msg.set_operation_name("semaphore.getsemaphoretype");
 
                     msg.set_message_type(static_cast<int32_t>(788224));
                     msg.set_partition_id(-1);
@@ -3956,7 +3322,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.Put");
+                    msg.set_operation_name("replicatedmap.put");
 
                     msg.set_message_type(static_cast<int32_t>(852224));
                     msg.set_partition_id(-1);
@@ -3975,7 +3341,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.Size");
+                    msg.set_operation_name("replicatedmap.size");
 
                     msg.set_message_type(static_cast<int32_t>(852480));
                     msg.set_partition_id(-1);
@@ -3989,7 +3355,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.IsEmpty");
+                    msg.set_operation_name("replicatedmap.isempty");
 
                     msg.set_message_type(static_cast<int32_t>(852736));
                     msg.set_partition_id(-1);
@@ -4004,7 +3370,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.ContainsKey");
+                    msg.set_operation_name("replicatedmap.containskey");
 
                     msg.set_message_type(static_cast<int32_t>(852992));
                     msg.set_partition_id(-1);
@@ -4021,7 +3387,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.ContainsValue");
+                    msg.set_operation_name("replicatedmap.containsvalue");
 
                     msg.set_message_type(static_cast<int32_t>(853248));
                     msg.set_partition_id(-1);
@@ -4037,7 +3403,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.Get");
+                    msg.set_operation_name("replicatedmap.get");
 
                     msg.set_message_type(static_cast<int32_t>(853504));
                     msg.set_partition_id(-1);
@@ -4054,7 +3420,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.Remove");
+                    msg.set_operation_name("replicatedmap.remove");
 
                     msg.set_message_type(static_cast<int32_t>(853760));
                     msg.set_partition_id(-1);
@@ -4071,7 +3437,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.PutAll");
+                    msg.set_operation_name("replicatedmap.putall");
 
                     msg.set_message_type(static_cast<int32_t>(854016));
                     msg.set_partition_id(-1);
@@ -4087,7 +3453,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.Clear");
+                    msg.set_operation_name("replicatedmap.clear");
 
                     msg.set_message_type(static_cast<int32_t>(854272));
                     msg.set_partition_id(-1);
@@ -4104,7 +3470,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.AddEntryListenerToKeyWithPredicate");
+                    msg.set_operation_name("replicatedmap.addentrylistenertokeywithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(854528));
                     msg.set_partition_id(-1);
@@ -4136,12 +3502,9 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                           boost::str(
-                                   boost::format("[replicatedmap_addentrylistenertokeywithpredicate_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                   % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[replicatedmap_addentrylistenertokeywithpredicate_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
                 ClientMessage replicatedmap_addentrylistenerwithpredicate_encode(const std::string &name,
@@ -4150,7 +3513,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.AddEntryListenerWithPredicate");
+                    msg.set_operation_name("replicatedmap.addentrylistenerwithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(854784));
                     msg.set_partition_id(-1);
@@ -4180,11 +3543,9 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                           boost::str(boost::format("[replicatedmap_addentrylistenerwithpredicate_handler::handle] "
-                                                    "Unknown message type (%1%) received on event handler.")
-                                      % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[replicatedmap_addentrylistenerwithpredicate_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
                 ClientMessage replicatedmap_addentrylistenertokey_encode(const std::string &name,
@@ -4193,7 +3554,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.AddEntryListenerToKey");
+                    msg.set_operation_name("replicatedmap.addentrylistenertokey");
 
                     msg.set_message_type(static_cast<int32_t>(855040));
                     msg.set_partition_id(-1);
@@ -4223,18 +3584,16 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[replicatedmap_addentrylistenertokey_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[replicatedmap_addentrylistenertokey_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage replicatedmap_addentrylistener_encode(const std::string  & name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                ClientMessage replicatedmap_addentrylistener_encode(const std::string &name, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.AddEntryListener");
+                    msg.set_operation_name("replicatedmap.addentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(855296));
                     msg.set_partition_id(-1);
@@ -4262,18 +3621,17 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                        boost::str(boost::format("[replicatedmap_addentrylistener_handler::handle] "
-                                                 "Unknown message type (%1%) received on event handler.")
-                                                 % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[replicatedmap_addentrylistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
-                ClientMessage replicatedmap_removeentrylistener_encode(const std::string  & name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage
+                replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.RemoveEntryListener");
+                    msg.set_operation_name("replicatedmap.removeentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(855552));
                     msg.set_partition_id(-1);
@@ -4288,7 +3646,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.KeySet");
+                    msg.set_operation_name("replicatedmap.keyset");
 
                     msg.set_message_type(static_cast<int32_t>(855808));
                     msg.set_partition_id(-1);
@@ -4302,7 +3660,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.Values");
+                    msg.set_operation_name("replicatedmap.values");
 
                     msg.set_message_type(static_cast<int32_t>(856064));
                     msg.set_partition_id(-1);
@@ -4316,7 +3674,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("ReplicatedMap.EntrySet");
+                    msg.set_operation_name("replicatedmap.entryset");
 
                     msg.set_message_type(static_cast<int32_t>(856320));
                     msg.set_partition_id(-1);
@@ -4326,11 +3684,14 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_addnearcacheentrylistener_encode(const std::string  & name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage
+                replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value,
+                                                               bool local_only) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("ReplicatedMap.AddNearCacheEntryListener");
+                    msg.set_operation_name("replicatedmap.addnearcacheentrylistener");
 
                     msg.set_message_type(static_cast<int32_t>(856576));
                     msg.set_partition_id(-1);
@@ -4359,11 +3720,9 @@ namespace hazelcast {
                         handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
                         return;
                     }
-                    HZ_LOG(*get_logger(), warning,
-                           boost::str(boost::format("[replicatedmap_addnearcacheentrylistener_handler::handle] "
-                                                    "Unknown message type (%1%) received on event handler.")
-                                      % messageType)
-                    );
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[replicatedmap_addnearcacheentrylistener_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
                 ClientMessage transactionalmap_containskey_encode(const std::string &name, boost::uuids::uuid txn_id,
@@ -4373,7 +3732,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.ContainsKey");
+                    msg.set_operation_name("transactionalmap.containskey");
 
                     msg.set_message_type(static_cast<int32_t>(917760));
                     msg.set_partition_id(-1);
@@ -4394,7 +3753,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Get");
+                    msg.set_operation_name("transactionalmap.get");
 
                     msg.set_message_type(static_cast<int32_t>(918016));
                     msg.set_partition_id(-1);
@@ -4408,32 +3767,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_getforupdate_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                   int64_t thread_id,
-                                                                   const serialization::pimpl::data &key) {
+                ClientMessage
+                transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
                     size_t initial_frame_size =
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.GetForUpdate");
-
-                    msg.set_message_type(static_cast<int32_t>(918272));
-                    msg.set_partition_id(-1);
-
-                    msg.set(txn_id);
-                    msg.set(thread_id);
-                    msg.set(name);
-
-                    msg.set(key, true);
-
-                    return msg;
-                }
-
-                ClientMessage transactionalmap_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Size");
+                    msg.set_operation_name("transactionalmap.size");
 
                     msg.set_message_type(static_cast<int32_t>(918528));
                     msg.set_partition_id(-1);
@@ -4445,11 +3785,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_isempty_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.IsEmpty");
+                    msg.set_operation_name("transactionalmap.isempty");
 
                     msg.set_message_type(static_cast<int32_t>(918784));
                     msg.set_partition_id(-1);
@@ -4470,7 +3812,7 @@ namespace hazelcast {
                             ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Put");
+                    msg.set_operation_name("transactionalmap.put");
 
                     msg.set_message_type(static_cast<int32_t>(919040));
                     msg.set_partition_id(-1);
@@ -4495,7 +3837,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Set");
+                    msg.set_operation_name("transactionalmap.set");
 
                     msg.set_message_type(static_cast<int32_t>(919296));
                     msg.set_partition_id(-1);
@@ -4519,7 +3861,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.PutIfAbsent");
+                    msg.set_operation_name("transactionalmap.putifabsent");
 
                     msg.set_message_type(static_cast<int32_t>(919552));
                     msg.set_partition_id(-1);
@@ -4543,7 +3885,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Replace");
+                    msg.set_operation_name("transactionalmap.replace");
 
                     msg.set_message_type(static_cast<int32_t>(919808));
                     msg.set_partition_id(-1);
@@ -4568,7 +3910,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.ReplaceIfSame");
+                    msg.set_operation_name("transactionalmap.replaceifsame");
 
                     msg.set_message_type(static_cast<int32_t>(920064));
                     msg.set_partition_id(-1);
@@ -4593,7 +3935,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Remove");
+                    msg.set_operation_name("transactionalmap.remove");
 
                     msg.set_message_type(static_cast<int32_t>(920320));
                     msg.set_partition_id(-1);
@@ -4614,7 +3956,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Delete");
+                    msg.set_operation_name("transactionalmap.delete");
 
                     msg.set_message_type(static_cast<int32_t>(920576));
                     msg.set_partition_id(-1);
@@ -4636,7 +3978,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.RemoveIfSame");
+                    msg.set_operation_name("transactionalmap.removeifsame");
 
                     msg.set_message_type(static_cast<int32_t>(920832));
                     msg.set_partition_id(-1);
@@ -4652,11 +3994,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_keyset_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.KeySet");
+                    msg.set_operation_name("transactionalmap.keyset");
 
                     msg.set_message_type(static_cast<int32_t>(921088));
                     msg.set_partition_id(-1);
@@ -4676,7 +4020,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.KeySetWithPredicate");
+                    msg.set_operation_name("transactionalmap.keysetwithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(921344));
                     msg.set_partition_id(-1);
@@ -4690,11 +4034,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_values_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.Values");
+                    msg.set_operation_name("transactionalmap.values");
 
                     msg.set_message_type(static_cast<int32_t>(921600));
                     msg.set_partition_id(-1);
@@ -4714,7 +4060,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.ValuesWithPredicate");
+                    msg.set_operation_name("transactionalmap.valueswithpredicate");
 
                     msg.set_message_type(static_cast<int32_t>(921856));
                     msg.set_partition_id(-1);
@@ -4728,27 +4074,6 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_containsvalue_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                    int64_t thread_id,
-                                                                    const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMap.ContainsValue");
-
-                    msg.set_message_type(static_cast<int32_t>(922112));
-                    msg.set_partition_id(-1);
-
-                    msg.set(txn_id);
-                    msg.set(thread_id);
-                    msg.set(name);
-
-                    msg.set(value, true);
-
-                    return msg;
-                }
-
                 ClientMessage
                 transactionalmultimap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
                                                  const serialization::pimpl::data &key,
@@ -4757,7 +4082,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMultiMap.Put");
+                    msg.set_operation_name("transactionalmultimap.put");
 
                     msg.set_message_type(static_cast<int32_t>(983296));
                     msg.set_partition_id(-1);
@@ -4780,7 +4105,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMultiMap.Get");
+                    msg.set_operation_name("transactionalmultimap.get");
 
                     msg.set_message_type(static_cast<int32_t>(983552));
                     msg.set_partition_id(-1);
@@ -4801,7 +4126,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMultiMap.Remove");
+                    msg.set_operation_name("transactionalmultimap.remove");
 
                     msg.set_message_type(static_cast<int32_t>(983808));
                     msg.set_partition_id(-1);
@@ -4823,7 +4148,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMultiMap.RemoveEntry");
+                    msg.set_operation_name("transactionalmultimap.removeentry");
 
                     msg.set_message_type(static_cast<int32_t>(984064));
                     msg.set_partition_id(-1);
@@ -4846,7 +4171,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMultiMap.ValueCount");
+                    msg.set_operation_name("transactionalmultimap.valuecount");
 
                     msg.set_message_type(static_cast<int32_t>(984320));
                     msg.set_partition_id(-1);
@@ -4860,11 +4185,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmultimap_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id,
+                                                                int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalMultiMap.Size");
+                    msg.set_operation_name("transactionalmultimap.size");
 
                     msg.set_message_type(static_cast<int32_t>(984576));
                     msg.set_partition_id(-1);
@@ -4883,7 +4210,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalSet.Add");
+                    msg.set_operation_name("transactionalset.add");
 
                     msg.set_message_type(static_cast<int32_t>(1048832));
                     msg.set_partition_id(-1);
@@ -4904,7 +4231,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalSet.Remove");
+                    msg.set_operation_name("transactionalset.remove");
 
                     msg.set_message_type(static_cast<int32_t>(1049088));
                     msg.set_partition_id(-1);
@@ -4918,11 +4245,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalset_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalSet.Size");
+                    msg.set_operation_name("transactionalset.size");
 
                     msg.set_message_type(static_cast<int32_t>(1049344));
                     msg.set_partition_id(-1);
@@ -4941,7 +4270,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalList.Add");
+                    msg.set_operation_name("transactionallist.add");
 
                     msg.set_message_type(static_cast<int32_t>(1114368));
                     msg.set_partition_id(-1);
@@ -4962,7 +4291,7 @@ namespace hazelcast {
                             ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalList.Remove");
+                    msg.set_operation_name("transactionallist.remove");
 
                     msg.set_message_type(static_cast<int32_t>(1114624));
                     msg.set_partition_id(-1);
@@ -4976,11 +4305,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionallist_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalList.Size");
+                    msg.set_operation_name("transactionallist.size");
 
                     msg.set_message_type(static_cast<int32_t>(1114880));
                     msg.set_partition_id(-1);
@@ -5000,7 +4331,7 @@ namespace hazelcast {
                             ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalQueue.Offer");
+                    msg.set_operation_name("transactionalqueue.offer");
 
                     msg.set_message_type(static_cast<int32_t>(1179904));
                     msg.set_partition_id(-1);
@@ -5015,27 +4346,15 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalqueue_take_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
+                                               int64_t timeout) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE +
+                            ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalQueue.Take");
-
-                    msg.set_message_type(static_cast<int32_t>(1180160));
-                    msg.set_partition_id(-1);
-
-                    msg.set(txn_id);
-                    msg.set(thread_id);
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                ClientMessage transactionalqueue_poll_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalQueue.Poll");
+                    msg.set_operation_name("transactionalqueue.poll");
 
                     msg.set_message_type(static_cast<int32_t>(1180416));
                     msg.set_partition_id(-1);
@@ -5048,28 +4367,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalqueue_peek_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage
+                transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalQueue.Peek");
-
-                    msg.set_message_type(static_cast<int32_t>(1180672));
-                    msg.set_partition_id(-1);
-
-                    msg.set(txn_id);
-                    msg.set(thread_id);
-                    msg.set(timeout);
-                    msg.set(name, true);
-
-                    return msg;
-                }
-
-                ClientMessage transactionalqueue_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
-                    ClientMessage msg(initial_frame_size);
-                    msg.set_retryable(false);
-                    msg.set_operation_name("TransactionalQueue.Size");
+                    msg.set_operation_name("transactionalqueue.size");
 
                     msg.set_message_type(static_cast<int32_t>(1180928));
                     msg.set_partition_id(-1);
@@ -5082,10 +4386,11 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Transaction.Commit");
+                    msg.set_operation_name("transaction.commit");
 
                     msg.set_message_type(static_cast<int32_t>(1376512));
                     msg.set_partition_id(-1);
@@ -5095,11 +4400,14 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type,
+                                                        int64_t thread_id) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE +
+                            ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Transaction.Create");
+                    msg.set_operation_name("transaction.create");
 
                     msg.set_message_type(static_cast<int32_t>(1376768));
                     msg.set_partition_id(-1);
@@ -5112,10 +4420,11 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Transaction.Rollback");
+                    msg.set_operation_name("transaction.rollback");
 
                     msg.set_message_type(static_cast<int32_t>(1377024));
                     msg.set_partition_id(-1);
@@ -5129,7 +4438,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.Size");
+                    msg.set_operation_name("ringbuffer.size");
 
                     msg.set_message_type(static_cast<int32_t>(1507584));
                     msg.set_partition_id(-1);
@@ -5143,7 +4452,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.TailSequence");
+                    msg.set_operation_name("ringbuffer.tailsequence");
 
                     msg.set_message_type(static_cast<int32_t>(1507840));
                     msg.set_partition_id(-1);
@@ -5157,7 +4466,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.HeadSequence");
+                    msg.set_operation_name("ringbuffer.headsequence");
 
                     msg.set_message_type(static_cast<int32_t>(1508096));
                     msg.set_partition_id(-1);
@@ -5171,7 +4480,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.Capacity");
+                    msg.set_operation_name("ringbuffer.capacity");
 
                     msg.set_message_type(static_cast<int32_t>(1508352));
                     msg.set_partition_id(-1);
@@ -5185,7 +4494,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.RemainingCapacity");
+                    msg.set_operation_name("ringbuffer.remainingcapacity");
 
                     msg.set_message_type(static_cast<int32_t>(1508608));
                     msg.set_partition_id(-1);
@@ -5200,7 +4509,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Ringbuffer.Add");
+                    msg.set_operation_name("ringbuffer.add");
 
                     msg.set_message_type(static_cast<int32_t>(1508864));
                     msg.set_partition_id(-1);
@@ -5217,7 +4526,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.ReadOne");
+                    msg.set_operation_name("ringbuffer.readone");
 
                     msg.set_message_type(static_cast<int32_t>(1509120));
                     msg.set_partition_id(-1);
@@ -5234,7 +4543,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("Ringbuffer.AddAll");
+                    msg.set_operation_name("ringbuffer.addall");
 
                     msg.set_message_type(static_cast<int32_t>(1509376));
                     msg.set_partition_id(-1);
@@ -5255,7 +4564,7 @@ namespace hazelcast {
                             ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("Ringbuffer.ReadMany");
+                    msg.set_operation_name("ringbuffer.readmany");
 
                     msg.set_message_type(static_cast<int32_t>(1509632));
                     msg.set_partition_id(-1);
@@ -5270,11 +4579,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage flakeidgenerator_newidbatch_encode(const std::string  & name, int32_t batch_size) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                ClientMessage flakeidgenerator_newidbatch_encode(const std::string &name, int32_t batch_size) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("FlakeIdGenerator.NewIdBatch");
+                    msg.set_operation_name("flakeidgenerator.newidbatch");
 
                     msg.set_message_type(static_cast<int32_t>(1835264));
                     msg.set_partition_id(-1);
@@ -5285,11 +4594,13 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_get_encode(const std::string  & name, const std::vector<std::pair<boost::uuids::uuid, int64_t>>  & replica_timestamps, boost::uuids::uuid target_replica_uuid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage pncounter_get_encode(const std::string &name,
+                                                   const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
+                                                   boost::uuids::uuid target_replica_uuid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("PNCounter.Get");
+                    msg.set_operation_name("pncounter.get");
 
                     msg.set_message_type(static_cast<int32_t>(1900800));
                     msg.set_partition_id(-1);
@@ -5302,11 +4613,15 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_add_encode(const std::string  & name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>>  & replica_timestamps, boost::uuids::uuid target_replica_uuid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::UINT8_SIZE + ClientMessage::UUID_SIZE;
+                ClientMessage pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update,
+                                                   const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
+                                                   boost::uuids::uuid target_replica_uuid) {
+                    size_t initial_frame_size =
+                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::UINT8_SIZE +
+                            ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("PNCounter.Add");
+                    msg.set_operation_name("pncounter.add");
 
                     msg.set_message_type(static_cast<int32_t>(1901056));
                     msg.set_partition_id(-1);
@@ -5325,7 +4640,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("PNCounter.GetConfiguredReplicaCount");
+                    msg.set_operation_name("pncounter.getconfiguredreplicacount");
 
                     msg.set_message_type(static_cast<int32_t>(1901312));
                     msg.set_partition_id(-1);
@@ -5335,11 +4650,11 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage cpgroup_createcpgroup_encode(const std::string  & proxy_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                ClientMessage cpgroup_createcpgroup_encode(const std::string &proxy_name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CPGroup.CreateCPGroup");
+                    msg.set_operation_name("cpgroup.createcpgroup");
 
                     msg.set_message_type(static_cast<int32_t>(1966336));
                     msg.set_partition_id(-1);
@@ -5355,7 +4670,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CPGroup.DestroyCPObject");
+                    msg.set_operation_name("cpgroup.destroycpobject");
 
                     msg.set_message_type(static_cast<int32_t>(1966592));
                     msg.set_partition_id(-1);
@@ -5374,7 +4689,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CPSession.CreateSession");
+                    msg.set_operation_name("cpsession.createsession");
 
                     msg.set_message_type(static_cast<int32_t>(2031872));
                     msg.set_partition_id(-1);
@@ -5390,7 +4705,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CPSession.CloseSession");
+                    msg.set_operation_name("cpsession.closesession");
 
                     msg.set_message_type(static_cast<int32_t>(2032128));
                     msg.set_partition_id(-1);
@@ -5405,7 +4720,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CPSession.HeartbeatSession");
+                    msg.set_operation_name("cpsession.heartbeatsession");
 
                     msg.set_message_type(static_cast<int32_t>(2032384));
                     msg.set_partition_id(-1);
@@ -5420,7 +4735,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
-                    msg.set_operation_name("CPSession.GenerateThreadId");
+                    msg.set_operation_name("cpsession.generatethreadid");
 
                     msg.set_message_type(static_cast<int32_t>(2032640));
                     msg.set_partition_id(-1);

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
@@ -29,12 +29,24 @@ namespace hazelcast {
                 /**
                  * Makes an authentication request to the cluster.
                  */
-                ClientMessage HAZELCAST_API client_authentication_encode(const std::string  & cluster_name, const std::string  * username, const std::string  * password, boost::uuids::uuid uuid, const std::string  & client_type, byte serialization_version, const std::string  & client_hazelcast_version, const std::string  & client_name, const std::vector<std::string>  & labels);
+                ClientMessage HAZELCAST_API
+                client_authentication_encode(const std::string &cluster_name, const std::string *username,
+                                             const std::string *password, boost::uuids::uuid uuid,
+                                             const std::string &client_type, byte serialization_version,
+                                             const std::string &client_hazelcast_version,
+                                             const std::string &client_name, const std::vector<std::string> &labels);
 
                 /**
                  * Makes an authentication request to the cluster using custom credentials.
                  */
-                ClientMessage HAZELCAST_API client_authenticationcustom_encode(const std::string  & cluster_name, const std::vector<byte>  & credentials, boost::uuids::uuid uuid, const std::string  & client_type, byte serialization_version, const std::string  & client_hazelcast_version, const std::string  & client_name, const std::vector<std::string>  & labels);
+                ClientMessage HAZELCAST_API client_authenticationcustom_encode(const std::string &cluster_name,
+                                                                               const std::vector<byte> &credentials,
+                                                                               boost::uuids::uuid uuid,
+                                                                               const std::string &client_type,
+                                                                               byte serialization_version,
+                                                                               const std::string &client_hazelcast_version,
+                                                                               const std::string &client_name,
+                                                                               const std::vector<std::string> &labels);
 
                 /**
                  * Adds a cluster view listener to a connection.
@@ -43,12 +55,13 @@ namespace hazelcast {
 
                 struct HAZELCAST_API client_addclusterviewlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
+
                     /**
                      * @param version Incremental member list version
                      * @param memberInfos List of member infos  at the cluster associated with the given version
                      *                    params:
                     */
-                    virtual void handle_membersview(int32_t version, std::vector<member> const & member_infos) = 0;
+                    virtual void handle_membersview(int32_t version, std::vector<member> const &member_infos) = 0;
 
                     /**
                      * @param version Incremental state version of the partition table
@@ -61,63 +74,14 @@ namespace hazelcast {
                 /**
                  * Creates a cluster-wide proxy with the given name and service.
                  */
-                ClientMessage HAZELCAST_API client_createproxy_encode(const std::string  & name, const std::string  & service_name);
+                ClientMessage HAZELCAST_API
+                client_createproxy_encode(const std::string &name, const std::string &service_name);
 
                 /**
                  * Destroys the proxy given by its name cluster-wide. Also, clears and releases all resources of this proxy.
                  */
-                ClientMessage HAZELCAST_API client_destroyproxy_encode(const std::string  & name, const std::string  & service_name);
-
-                /**
-                 * Adds a partition lost listener to the cluster.
-                 */
-                ClientMessage HAZELCAST_API client_addpartitionlostlistener_encode(bool local_only);
-
-                struct HAZELCAST_API client_addpartitionlostlistener_handler : public impl::BaseEventHandler {
-                    void handle(ClientMessage &msg);
-                    /**
-                     * @param partitionId Id of the lost partition.
-                     * @param lostBackupCount The number of lost backups for the partition. 0: the owner, 1: first backup, 2: second backup...
-                     * @param source UUID of the node that dispatches the event
-                    */
-                    virtual void handle_partitionlost(int32_t partition_id, int32_t lost_backup_count,  boost::uuids::uuid source) = 0;
-
-                };
-
-                /**
-                 * Removes the specified partition lost listener. If there is no such listener added before, this call does no change
-                 * in the cluster and returns false.
-                 */
-                ClientMessage HAZELCAST_API client_removepartitionlostlistener_encode(boost::uuids::uuid registration_id);
-
-                /**
-                 * Gets the list of distributed objects in the cluster.
-                 */
-                ClientMessage HAZELCAST_API client_getdistributedobjects_encode();
-
-                /**
-                 * Adds a distributed object listener to the cluster. This listener will be notified
-                 * when a distributed object is created or destroyed.
-                 */
-                ClientMessage HAZELCAST_API client_adddistributedobjectlistener_encode(bool local_only);
-
-                struct HAZELCAST_API client_adddistributedobjectlistener_handler : public impl::BaseEventHandler {
-                    void handle(ClientMessage &msg);
-                    /**
-                     * @param name Name of the distributed object.
-                     * @param serviceName Service name of the distributed object.
-                     * @param eventType Type of the event. It is either CREATED or DESTROYED.
-                     * @param source The UUID (client or member) of the source of this proxy event.
-                    */
-                    virtual void handle_distributedobject(std::string const & name, std::string const & service_name, std::string const & event_type, boost::uuids::uuid source) = 0;
-
-                };
-
-                /**
-                 * Removes the specified distributed object listener. If there is no such listener added before, this call does no
-                 * change in the cluster and returns false.
-                 */
-                ClientMessage HAZELCAST_API client_removedistributedobjectlistener_encode(boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                client_destroyproxy_encode(const std::string &name, const std::string &service_name);
 
                 /**
                  * Sends a ping to the given connection.
@@ -283,23 +247,9 @@ namespace hazelcast {
                  * 
                  * The metrics blob constructed this way is then gets ZLIB compressed.
                  */
-                ClientMessage HAZELCAST_API client_statistics_encode(int64_t timestamp, const std::string  & client_attributes, const std::vector<byte>  & metrics_blob);
-
-                /**
-                 * Deploys the list of classes to cluster
-                 * Each item is a Map.Entry<String, byte[]> in the list.
-                 * key of entry is full class name, and byte[] is the class definition.
-                 */
-                ClientMessage HAZELCAST_API client_deployclasses_encode(const std::vector<std::pair<std::string, std::vector<byte>>>  & class_definitions);
-
-                /**
-                 * Proxies will be created on all cluster members.
-                 * If the member is  a lite member, a replicated map will not be created.
-                 * Any proxy creation failure is logged on the server side.
-                 * Exceptions related to a proxy creation failure is not send to the client.
-                 * A proxy creation failure does not cancel this operation, all proxies will be attempted to be created.
-                 */
-                ClientMessage HAZELCAST_API client_createproxies_encode(const std::vector<std::pair<std::string, std::string>>  & proxies);
+                ClientMessage HAZELCAST_API
+                client_statistics_encode(int64_t timestamp, const std::string &client_attributes,
+                                         const std::vector<byte> &metrics_blob);
 
                 /**
                  * Adds listener for backup acks
@@ -316,10 +266,9 @@ namespace hazelcast {
                 };
 
                 /**
-                 * Triggers partition assignment manually on the cluster.
-                 * Note that Partition based operations triggers this automatically
+                 * Removes the specified migration listener.
                  */
-                ClientMessage HAZELCAST_API client_triggerpartitionassignment_encode();
+                ClientMessage HAZELCAST_API client_removemigrationlistener_encode(boost::uuids::uuid registration_id);
 
                 /**
                  * Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
@@ -494,48 +443,6 @@ namespace hazelcast {
                 ClientMessage HAZELCAST_API map_removeinterceptor_encode(const std::string  & name, const std::string  & id);
 
                 /**
-                 * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
-                 * sub-interface for that event.
-                 */
-                ClientMessage HAZELCAST_API map_addentrylistenertokeywithpredicate_encode(const std::string &name,
-                                                                                          const serialization::pimpl::data &key,
-                                                                                          const serialization::pimpl::data &predicate,
-                                                                                          bool include_value,
-                                                                                          int32_t listener_flags,
-                                                                                          bool local_only);
-
-                struct HAZELCAST_API map_addentrylistenertokeywithpredicate_handler : public impl::BaseEventHandler {
-                    void handle(ClientMessage &msg);
-
-                    /**
-                     * @param key Key of the entry event.
-                     * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
-                     * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
-                    */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
-
-                };
-
-                /**
                  * Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
                  * filtered by the given predicate.
                  */
@@ -619,7 +526,9 @@ namespace hazelcast {
                  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
                  * sub-interface for that event.
                  */
-                ClientMessage HAZELCAST_API map_addentrylistener_encode(const std::string  & name, bool include_value, int32_t listener_flags, bool local_only);
+                ClientMessage HAZELCAST_API
+                map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags,
+                                            bool local_only);
 
                 struct HAZELCAST_API map_addentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -656,33 +565,8 @@ namespace hazelcast {
                  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API map_removeentrylistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
-
-                /**
-                 * Adds a MapPartitionLostListener. The addPartitionLostListener returns a register-id. This id is needed to remove
-                 * the MapPartitionLostListener using the removePartitionLostListener(String) method.
-                 * There is no check for duplicate registrations, so if you register the listener twice, it will get events twice.
-                 * IMPORTANT: Please see com.hazelcast.partition.PartitionLostListener for weaknesses.
-                 * IMPORTANT: Listeners registered from hazelcast_client may miss some of the map partition lost events due
-                 * to design limitations.
-                 */
-                ClientMessage HAZELCAST_API map_addpartitionlostlistener_encode(const std::string  & name, bool local_only);
-
-                struct HAZELCAST_API map_addpartitionlostlistener_handler : public impl::BaseEventHandler {
-                    void handle(ClientMessage &msg);
-                    /**
-                     * @param partitionId Id of the lost partition.
-                     * @param uuid UUID of the member that owns the lost partition.
-                    */
-                    virtual void handle_mappartitionlost(int32_t partition_id, boost::uuids::uuid uuid) = 0;
-
-                };
-
-                /**
-                 * Removes the specified map partition lost listener. If there is no such listener added before, this call does no
-                 * change in the cluster and returns false.
-                 */
-                ClientMessage HAZELCAST_API map_removepartitionlostlistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns the EntryView for the specified key.
@@ -708,18 +592,6 @@ namespace hazelcast {
                 ClientMessage HAZELCAST_API map_evictall_encode(const std::string  & name);
 
                 /**
-                 * Loads all keys into the store. This is a batch load operation so that an implementation can optimize the multiple loads.
-                 */
-                ClientMessage HAZELCAST_API map_loadall_encode(const std::string  & name, bool replace_existing_values);
-
-                /**
-                 * Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
-                 */
-                ClientMessage HAZELCAST_API
-                map_loadgivenkeys_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys,
-                                         bool replace_existing_values);
-
-                /**
                  * Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
                  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
                  * throw a query_result_size_exceeded if query result size limit is configured.
@@ -739,7 +611,7 @@ namespace hazelcast {
                 /**
                  * Returns a collection clone of the values contained in this map.
                  * The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
-                 * This method is always executed by a distributed query, so it may throw a query_result_size_exceeded_exception
+                 * This method is always executed by a distributed query, so it may throw a query_result_size_exceeded
                  * if query result size limit is configured.
                  */
                 ClientMessage HAZELCAST_API map_values_encode(const std::string  & name);
@@ -747,7 +619,7 @@ namespace hazelcast {
                 /**
                  * Returns a Set clone of the mappings contained in this map.
                  * The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
-                 * This method is always executed by a distributed query, so it may throw a query_result_size_exceeded_exception
+                 * This method is always executed by a distributed query, so it may throw a query_result_size_exceeded
                  * if query result size limit is configured.
                  */
                 ClientMessage HAZELCAST_API map_entryset_encode(const std::string  & name);
@@ -782,7 +654,8 @@ namespace hazelcast {
                 /**
                  * Adds an index to this map with specified configuration.
                  */
-                ClientMessage HAZELCAST_API map_addindex_encode(const std::string  & name, const config::index_config  & index_config);
+                ClientMessage HAZELCAST_API
+                map_addindex_encode(const std::string &name, const config::index_config &index_config);
 
                 /**
                  * Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
@@ -887,47 +760,6 @@ namespace hazelcast {
                 ClientMessage HAZELCAST_API map_entrieswithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate);
 
                 /**
-                 * Fetches specified number of keys from the specified partition starting from specified table index.
-                 */
-                ClientMessage HAZELCAST_API map_fetchkeys_encode(const std::string  & name, const std::vector<std::pair<int32_t, int32_t>>  & iteration_pointers, int32_t batch);
-
-                /**
-                 * Fetches specified number of entries from the specified partition starting from specified table index.
-                 */
-                ClientMessage HAZELCAST_API map_fetchentries_encode(const std::string  & name, const std::vector<std::pair<int32_t, int32_t>>  & iteration_pointers, int32_t batch);
-
-                /**
-                 * Applies the aggregation logic on all map entries and returns the result
-                 */
-                ClientMessage HAZELCAST_API
-                map_aggregate_encode(const std::string &name, const serialization::pimpl::data &aggregator);
-
-                /**
-                 * Applies the aggregation logic on map entries filtered with the Predicate and returns the result
-                 */
-                ClientMessage HAZELCAST_API
-                map_aggregatewithpredicate_encode(const std::string &name, const serialization::pimpl::data &aggregator,
-                                                  const serialization::pimpl::data &predicate);
-
-                /**
-                 * Applies the projection logic on all map entries and returns the result
-                 */
-                ClientMessage HAZELCAST_API
-                map_project_encode(const std::string &name, const serialization::pimpl::data &projection);
-
-                /**
-                 * Applies the projection logic on map entries filtered with the Predicate and returns the result
-                 */
-                ClientMessage HAZELCAST_API
-                map_projectwithpredicate_encode(const std::string &name, const serialization::pimpl::data &projection,
-                                                const serialization::pimpl::data &predicate);
-
-                /**
-                 * Fetches invalidation metadata from partitions of map.
-                 */
-                ClientMessage HAZELCAST_API map_fetchnearcacheinvalidationmetadata_encode(const std::vector<std::string>  & names, boost::uuids::uuid uuid);
-
-                /**
                  * Removes all entries which match with the supplied predicate
                  */
                 ClientMessage HAZELCAST_API
@@ -936,7 +768,9 @@ namespace hazelcast {
                 /**
                  * Adds listener to map. This listener will be used to listen near cache invalidation events.
                  */
-                ClientMessage HAZELCAST_API map_addnearcacheinvalidationlistener_encode(const std::string  & name, int32_t listener_flags, bool local_only);
+                ClientMessage HAZELCAST_API
+                map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags,
+                                                            bool local_only);
 
                 struct HAZELCAST_API map_addnearcacheinvalidationlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -963,97 +797,6 @@ namespace hazelcast {
                                                               std::vector<int64_t> const &sequences) = 0;
 
                 };
-
-                /**
-                 * Fetches the specified number of entries from the specified partition starting from specified table index
-                 * that match the predicate and applies the projection logic on them.
-                 */
-                ClientMessage HAZELCAST_API map_fetchwithquery_encode(const std::string &name,
-                                                                      const std::vector<std::pair<int32_t, int32_t>> &iteration_pointers,
-                                                                      int32_t batch,
-                                                                      const serialization::pimpl::data &projection,
-                                                                      const serialization::pimpl::data &predicate);
-
-                /**
-                 * Performs the initial subscription to the map event journal.
-                 * This includes retrieving the event journal sequences of the
-                 * oldest and newest event in the journal.
-                 */
-                ClientMessage HAZELCAST_API map_eventjournalsubscribe_encode(const std::string  & name);
-
-                /**
-                 * Reads from the map event journal in batches. You may specify the start sequence,
-                 * the minumum required number of items in the response, the maximum number of items
-                 * in the response, a predicate that the events should pass and a projection to
-                 * apply to the events in the journal.
-                 * If the event journal currently contains less events than {@code minSize}, the
-                 * call will wait until it has sufficient items.
-                 * The predicate, filter and projection may be {@code null} in which case all elements are returned
-                 * and no projection is applied.
-                 */
-                ClientMessage HAZELCAST_API
-                map_eventjournalread_encode(const std::string &name, int64_t start_sequence, int32_t min_size,
-                                            int32_t max_size, const serialization::pimpl::data *predicate,
-                                            const serialization::pimpl::data *projection);
-
-                /**
-                 * Updates TTL (time to live) value of the entry specified by {@code key} with a new TTL value.
-                 * New TTL value is valid from this operation is invoked, not from the original creation of the entry.
-                 * If the entry does not exist or already expired, then this call has no effect.
-                 * <p>
-                 * The entry will expire and get evicted after the TTL. If the TTL is 0,
-                 * then the entry lives forever. If the TTL is negative, then the TTL
-                 * from the map configuration will be used (default: forever).
-                 * 
-                 * If there is no entry with key {@code key}, this call has no effect.
-                 * 
-                 * <b>Warning:</b>
-                 * <p>
-                 * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
-                 */
-                ClientMessage HAZELCAST_API
-                map_setttl_encode(const std::string &name, const serialization::pimpl::data &key, int64_t ttl);
-
-                /**
-                 * Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
-                 * If ttl is 0, then the entry lives forever.This method returns a clone of the previous value, not the original
-                 * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
-                 * rounded to the next closest second value.
-                 */
-                ClientMessage HAZELCAST_API
-                map_putwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                          const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl,
-                                          int64_t max_idle);
-
-                /**
-                 * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
-                 * If ttl and maxIdle are 0, then the entry lives forever.
-                 */
-                ClientMessage HAZELCAST_API
-                map_puttransientwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                   const serialization::pimpl::data &value, int64_t thread_id,
-                                                   int64_t ttl, int64_t max_idle);
-
-                /**
-                 * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
-                 * with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
-                 */
-                ClientMessage HAZELCAST_API
-                map_putifabsentwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                  const serialization::pimpl::data &value, int64_t thread_id,
-                                                  int64_t ttl, int64_t max_idle);
-
-                /**
-                 * Puts an entry into this map with a given ttl (time to live) value and maxIdle.
-                 * Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
-                 * If ttl and maxIdle are 0, then the entry lives forever.
-                 * 
-                 * Similar to the put operation except that set doesn't return the old value, which is more efficient.
-                 */
-                ClientMessage HAZELCAST_API
-                map_setwithmaxidle_encode(const std::string &name, const serialization::pimpl::data &key,
-                                          const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl,
-                                          int64_t max_idle);
 
                 /**
                  * Stores a key-value pair in the multimap.
@@ -1173,7 +916,8 @@ namespace hazelcast {
                 /**
                  * Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
                  */
-                ClientMessage HAZELCAST_API multimap_addentrylistener_encode(const std::string  & name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API
+                multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API multimap_addentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -1210,7 +954,8 @@ namespace hazelcast {
                  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API multimap_removeentrylistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Acquires the lock for the specified key for the specified lease time. After the lease time, the lock will be
@@ -1264,22 +1009,6 @@ namespace hazelcast {
                                             const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
-                 * Removes all the entries with the given key.
-                 */
-                ClientMessage HAZELCAST_API
-                multimap_delete_encode(const std::string &name, const serialization::pimpl::data &key,
-                                       int64_t thread_id);
-
-                /**
-                 * Copies all of the mappings from the specified map to this MultiMap. The effect of this call is
-                 * equivalent to that of calling put(k, v) on this MultiMap iteratively for each value in the mapping from key k to value
-                 * v in the specified MultiMap. The behavior of this operation is undefined if the specified map is modified while the
-                 * operation is in progress.
-                 */
-                ClientMessage HAZELCAST_API multimap_putall_encode(const std::string &name,
-                                                                   const std::vector<std::pair<serialization::pimpl::data, std::vector<serialization::pimpl::data>>> &entries);
-
-                /**
                  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
                  * become available.
                  */
@@ -1310,7 +1039,7 @@ namespace hazelcast {
                  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
                  * to become available.
                  */
-                ClientMessage HAZELCAST_API queue_poll_encode(const std::string  & name, int64_t timeout_millis);
+                ClientMessage HAZELCAST_API queue_poll_encode(const std::string &name, int64_t timeout_millis);
 
                 /**
                  * Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
@@ -1344,7 +1073,7 @@ namespace hazelcast {
                  * ILLEGAL_ARGUMENT. Further, the behavior of this operation is undefined if the specified collection is
                  * modified while the operation is in progress.
                  */
-                ClientMessage HAZELCAST_API queue_draintomaxsize_encode(const std::string  & name, int32_t max_size);
+                ClientMessage HAZELCAST_API queue_draintomaxsize_encode(const std::string &name, int32_t max_size);
 
                 /**
                  * Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
@@ -1391,7 +1120,8 @@ namespace hazelcast {
                 /**
                  * Adds an listener for this collection. Listener will be notified or all collection add/remove events.
                  */
-                ClientMessage HAZELCAST_API queue_addlistener_encode(const std::string  & name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API
+                queue_addlistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API queue_addlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -1411,7 +1141,8 @@ namespace hazelcast {
                  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API queue_removelistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                queue_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns the number of additional elements that this queue can ideally (in the absence of memory or resource
@@ -1436,7 +1167,7 @@ namespace hazelcast {
                  * Subscribes to this topic. When someone publishes a message on this topic. onMessage() function of the given
                  * MessageListener is called. More than one message listener can be added on one instance.
                  */
-                ClientMessage HAZELCAST_API topic_addmessagelistener_encode(const std::string  & name, bool local_only);
+                ClientMessage HAZELCAST_API topic_addmessagelistener_encode(const std::string &name, bool local_only);
 
                 struct HAZELCAST_API topic_addmessagelistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -1454,7 +1185,8 @@ namespace hazelcast {
                 /**
                  * Stops receiving messages for the given message listener.If the given listener already removed, this method does nothing.
                  */
-                ClientMessage HAZELCAST_API topic_removemessagelistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
@@ -1526,7 +1258,8 @@ namespace hazelcast {
                 /**
                  * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
                  */
-                ClientMessage HAZELCAST_API list_addlistener_encode(const std::string  & name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API
+                list_addlistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API list_addlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -1546,7 +1279,8 @@ namespace hazelcast {
                  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API list_removelistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                list_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns true if this list contains no elements
@@ -1608,26 +1342,13 @@ namespace hazelcast {
                  * operations supported by this list.
                  * This method eliminates the need for explicit range operations (of the sort that commonly exist for arrays).
                  * Any operation that expects a list can be used as a range operation by passing a subList view instead of a whole list.
-                 * Similar idioms may be constructed for index_of and last_index_of, and all of the algorithms in the Collections class
+                 * Similar idioms may be constructed for indexOf and lastIndexOf, and all of the algorithms in the Collections class
                  * can be applied to a subList.
                  * The semantics of the list returned by this method become undefined if the backing list (i.e., this list) is
                  * structurally modified in any way other than via the returned list.(Structural modifications are those that change
                  * the size of this list, or otherwise perturb it in such a fashion that iterations in progress may yield incorrect results.)
                  */
                 ClientMessage HAZELCAST_API list_sub_encode(const std::string  & name, int32_t from, int32_t to);
-
-                /**
-                 * Returns an iterator over the elements in this list in proper sequence.
-                 */
-                ClientMessage HAZELCAST_API list_iterator_encode(const std::string  & name);
-
-                /**
-                 * Returns a list iterator over the elements in this list (in proper sequence), starting at the specified position
-                 * in the list. The specified index indicates the first element that would be returned by an initial call to
-                 * ListIterator#next next. An initial call to ListIterator#previous previous would return the element with the
-                 * specified index minus one.
-                 */
-                ClientMessage HAZELCAST_API list_listiterator_encode(const std::string  & name, int32_t index);
 
                 /**
                  * Returns the number of elements in this set (its cardinality). If this set contains more than Integer.MAX_VALUE
@@ -1669,7 +1390,7 @@ namespace hazelcast {
 
                 /**
                  * Adds all of the elements in the specified collection to this set if they're not already present
-                 * (optional operation). If the specified collection is also a set, the add_all operation effectively modifies this
+                 * (optional operation). If the specified collection is also a set, the addAll operation effectively modifies this
                  * set so that its value is the union of the two sets. The behavior of this operation is undefined if the specified
                  * collection is modified while the operation is in progress.
                  */
@@ -1706,7 +1427,8 @@ namespace hazelcast {
                 /**
                  * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
                  */
-                ClientMessage HAZELCAST_API set_addlistener_encode(const std::string  & name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API
+                set_addlistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API set_addlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -1726,7 +1448,8 @@ namespace hazelcast {
                  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API set_removelistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                set_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns true if this set contains no elements.
@@ -1740,7 +1463,7 @@ namespace hazelcast {
                  * If the lock is held by some other endpoint when this method is called,
                  * the caller thread is blocked until the lock is released. If the session
                  * is closed between reentrant acquires, the call fails with
-                 * {@code lock_ownership_lost}.
+                 * {@code LockOwnershipLostException}.
                  */
                 ClientMessage HAZELCAST_API
                 fencedlock_lock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
@@ -1754,7 +1477,7 @@ namespace hazelcast {
                  * If the lock is held by some other endpoint when this method is called,
                  * the caller thread is blocked until the lock is released or the timeout
                  * duration passes. If the session is closed between reentrant acquires,
-                 * the call fails with {@code lock_ownership_lost}.
+                 * the call fails with {@code LockOwnershipLostException}.
                  */
                 ClientMessage HAZELCAST_API
                 fencedlock_trylock_encode(const cp::raft_group_id &group_id, const std::string &name,
@@ -1763,9 +1486,9 @@ namespace hazelcast {
 
                 /**
                  * Unlocks the given FencedLock on the given CP group. If the lock is
-                 * not acquired, the call fails with {@link illegal_monitor_state}.
+                 * not acquired, the call fails with {@link IllegalMonitorStateException}.
                  * If the session is closed while holding the lock, the call fails with
-                 * {@code lock_ownership_lost}. Returns true if the lock is still
+                 * {@code LockOwnershipLostException}. Returns true if the lock is still
                  * held by the caller after a successful unlock() call, false otherwise.
                  */
                 ClientMessage HAZELCAST_API
@@ -1797,7 +1520,9 @@ namespace hazelcast {
                 /**
                  * Cancels the task running on the member with the given address.
                  */
-                ClientMessage HAZELCAST_API executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid, bool interrupt);
+                ClientMessage HAZELCAST_API
+                executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid,
+                                                      bool interrupt);
 
                 /**
                  * Submits the task to the member that owns the partition with the given id.
@@ -1919,7 +1644,7 @@ namespace hazelcast {
                  * thread, or the specified waiting time elapses. If the count reaches zero
                  * then the method returns with the value true. If the current thread has
                  * its interrupted status set on entry to this method, or is interrupted
-                 * while waiting, then {@code interrupted} is thrown
+                 * while waiting, then {@code InterruptedException} is thrown
                  * and the current thread's interrupted status is cleared. If the specified
                  * waiting time elapses then the value false is returned.  If the time is
                  * less than or equal to zero, the method will not wait at all.
@@ -2001,7 +1726,7 @@ namespace hazelcast {
                 /**
                  * Returns true if the semaphore is JDK compatible
                  */
-                ClientMessage HAZELCAST_API semaphore_getsemaphoretype_encode(const std::string  & proxy_name);
+                ClientMessage HAZELCAST_API semaphore_getsemaphoretype_encode(const std::string &proxy_name);
 
                 /**
                  * Associates a given value to the specified key and replicates it to the cluster. If there is an old value, it will
@@ -2040,7 +1765,7 @@ namespace hazelcast {
                  * Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
                  * If this map permits null values, then a return value of null does not
                  * necessarily indicate that the map contains no mapping for the key; it's also possible that the map
-                 * explicitly maps the key to null.  The #contains_key operation may be used to distinguish these two cases.
+                 * explicitly maps the key to null.  The #containsKey operation may be used to distinguish these two cases.
                  */
                 ClientMessage HAZELCAST_API
                 replicatedmap_get_encode(const std::string &name, const serialization::pimpl::data &key);
@@ -2193,7 +1918,8 @@ namespace hazelcast {
                 /**
                  * Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_addentrylistener_encode(const std::string  & name, bool local_only);
+                ClientMessage HAZELCAST_API
+                replicatedmap_addentrylistener_encode(const std::string &name, bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -2230,7 +1956,8 @@ namespace hazelcast {
                  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_removeentrylistener_encode(const std::string  & name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API
+                replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns a lazy Set view of the key contained in this map. A LazySet is optimized for querying speed
@@ -2255,7 +1982,9 @@ namespace hazelcast {
                 /**
                  * Adds a near cache entry listener for this map. This listener will be notified when an entry is added/removed/updated/evicted/expired etc. so that the near cache entries can be invalidated.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_addnearcacheentrylistener_encode(const std::string  & name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API
+                replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value,
+                                                               bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addnearcacheentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
@@ -2303,22 +2032,16 @@ namespace hazelcast {
                                             const serialization::pimpl::data &key);
 
                 /**
-                 * Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
-                 * the end of the transaction (either commit or rollback).
-                 */
-                ClientMessage HAZELCAST_API
-                transactionalmap_getforupdate_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                     int64_t thread_id, const serialization::pimpl::data &key);
-
-                /**
                  * Returns the number of entries in this map.
                  */
-                ClientMessage HAZELCAST_API transactionalmap_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Returns true if this map contains no entries.
                  */
-                ClientMessage HAZELCAST_API transactionalmap_isempty_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Associates the specified value with the specified key in this map. If the map previously contained a mapping for
@@ -2401,7 +2124,8 @@ namespace hazelcast {
                  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
                  * a query_result_size_exceeded if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API transactionalmap_keyset_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
@@ -2419,7 +2143,8 @@ namespace hazelcast {
                  * so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
                  * distributed query, so it may throw a query_result_size_exceeded if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API transactionalmap_values_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
@@ -2431,13 +2156,6 @@ namespace hazelcast {
                 transactionalmap_valueswithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id,
                                                             int64_t thread_id,
                                                             const serialization::pimpl::data &predicate);
-
-                /**
-                 * Returns true if this map contains an entry for the specified value.
-                 */
-                ClientMessage HAZELCAST_API
-                transactionalmap_containsvalue_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                      int64_t thread_id, const serialization::pimpl::data &value);
 
                 /**
                  * Stores a key-value pair in the multimap.
@@ -2479,7 +2197,9 @@ namespace hazelcast {
                 /**
                  * Returns the number of key-value pairs in the multimap.
                  */
-                ClientMessage HAZELCAST_API transactionalmultimap_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id,
+                                                  int64_t thread_id);
 
                 /**
                  * Add new item to transactional set.
@@ -2498,7 +2218,8 @@ namespace hazelcast {
                 /**
                  * Returns the size of the set.
                  */
-                ClientMessage HAZELCAST_API transactionalset_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Adds a new item to the transactional list.
@@ -2517,7 +2238,8 @@ namespace hazelcast {
                 /**
                  * Returns the size of the list
                  */
-                ClientMessage HAZELCAST_API transactionallist_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
@@ -2528,41 +2250,38 @@ namespace hazelcast {
                                                 const serialization::pimpl::data &item, int64_t timeout);
 
                 /**
-                 * Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
-                 */
-                ClientMessage HAZELCAST_API transactionalqueue_take_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
-
-                /**
                  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
                  * to become available.
                  */
-                ClientMessage HAZELCAST_API transactionalqueue_poll_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout);
-
-                /**
-                 * Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
-                 */
-                ClientMessage HAZELCAST_API transactionalqueue_peek_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout);
+                ClientMessage HAZELCAST_API
+                transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
+                                               int64_t timeout);
 
                 /**
                  * Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
                  * elements, returns Integer.MAX_VALUE.
                  */
-                ClientMessage HAZELCAST_API transactionalqueue_size_encode(const std::string  & name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Commits the transaction with the given id.
                  */
-                ClientMessage HAZELCAST_API transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
 
                 /**
                  * Creates a transaction with the given parameters.
                  */
-                ClientMessage HAZELCAST_API transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type,
+                                          int64_t thread_id);
 
                 /**
                  * Rollbacks the transaction with the given id.
                  */
-                ClientMessage HAZELCAST_API transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API
+                transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
 
                 /**
                  * Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
@@ -2619,13 +2338,13 @@ namespace hazelcast {
                 ClientMessage HAZELCAST_API ringbuffer_readone_encode(const std::string  & name, int64_t sequence);
 
                 /**
-                 * Adds all the items of a collection to the tail of the Ringbuffer. A add_all is likely to outperform multiple calls
+                 * Adds all the items of a collection to the tail of the Ringbuffer. A addAll is likely to outperform multiple calls
                  * to add(Object) due to better io utilization and a reduced number of executed operations. If the batch is empty,
                  * the call is ignored. When the collection is not empty, the content is copied into a different data-structure.
                  * This means that: after this call completes, the collection can be re-used. the collection doesn't need to be serializable.
                  * If the collection is larger than the capacity of the ringbuffer, then the items that were written first will be
                  * overwritten. Therefor this call will not block. The items are inserted in the order of the Iterator of the collection.
-                 * If an add_all is executed concurrently with an add or add_all, no guarantee is given that items are contiguous.
+                 * If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
                  * The result of the future contains the sequenceId of the last written item
                  */
                 ClientMessage HAZELCAST_API ringbuffer_addall_encode(const std::string &name,
@@ -2648,7 +2367,8 @@ namespace hazelcast {
                 /**
                  * Fetches a new batch of ids for the given flake id generator.
                  */
-                ClientMessage HAZELCAST_API flakeidgenerator_newidbatch_encode(const std::string  & name, int32_t batch_size);
+                ClientMessage HAZELCAST_API
+                flakeidgenerator_newidbatch_encode(const std::string &name, int32_t batch_size);
 
                 /**
                  * Query operation to retrieve the current value of the PNCounter.
@@ -2660,7 +2380,9 @@ namespace hazelcast {
                  * If smart routing is disabled, the actual member processing the client
                  * message may act as a proxy.
                  */
-                ClientMessage HAZELCAST_API pncounter_get_encode(const std::string  & name, const std::vector<std::pair<boost::uuids::uuid, int64_t>>  & replica_timestamps, boost::uuids::uuid target_replica_uuid);
+                ClientMessage HAZELCAST_API pncounter_get_encode(const std::string &name,
+                                                                 const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
+                                                                 boost::uuids::uuid target_replica_uuid);
 
                 /**
                  * Adds a delta to the PNCounter value. The delta may be negative for a
@@ -2673,7 +2395,10 @@ namespace hazelcast {
                  * If smart routing is disabled, the actual member processing the client
                  * message may act as a proxy.
                  */
-                ClientMessage HAZELCAST_API pncounter_add_encode(const std::string  & name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>>  & replica_timestamps, boost::uuids::uuid target_replica_uuid);
+                ClientMessage HAZELCAST_API
+                pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update,
+                                     const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
+                                     boost::uuids::uuid target_replica_uuid);
 
                 /**
                  * Returns the configured number of CRDT replicas for the PN counter with
@@ -2686,7 +2411,7 @@ namespace hazelcast {
                 /**
                  * Creates a new CP group with the given name
                  */
-                ClientMessage HAZELCAST_API cpgroup_createcpgroup_encode(const std::string  & proxy_name);
+                ClientMessage HAZELCAST_API cpgroup_createcpgroup_encode(const std::string &proxy_name);
 
                 /**
                  * Destroys the distributed object with the given name on the requested

--- a/hazelcast/include/hazelcast/client/iqueue.h
+++ b/hazelcast/include/hazelcast/client/iqueue.h
@@ -97,7 +97,7 @@ namespace hazelcast {
             */
             template<typename E>
             boost::future<boost::optional<E>> take() {
-                return poll<E>(std::chrono::milliseconds(-1));
+                return to_object<E>(proxy::IQueueImpl::take_data());
             }
 
             /**

--- a/hazelcast/include/hazelcast/client/proxy/IQueueImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IQueueImpl.h
@@ -76,25 +76,27 @@ namespace hazelcast {
 
                 boost::future<void> put(const serialization::pimpl::data& element);
 
-                boost::future<boost::optional<serialization::pimpl::data>>poll_data(std::chrono::milliseconds timeout);
+                boost::future<boost::optional<serialization::pimpl::data>> poll_data(std::chrono::milliseconds timeout);
 
-                boost::future<bool> remove(const serialization::pimpl::data& element);
+                boost::future<bool> remove(const serialization::pimpl::data &element);
 
-                boost::future<bool> contains(const serialization::pimpl::data& element);
+                boost::future<bool> contains(const serialization::pimpl::data &element);
 
                 boost::future<std::vector<serialization::pimpl::data>> drain_to_data(size_t max_elements);
 
                 boost::future<std::vector<serialization::pimpl::data>> drain_to_data();
 
-                boost::future<boost::optional<serialization::pimpl::data>>peek_data();
+                boost::future<boost::optional<serialization::pimpl::data>> take_data();
+
+                boost::future<boost::optional<serialization::pimpl::data>> peek_data();
 
                 boost::future<std::vector<serialization::pimpl::data>> to_array_data();
 
-                boost::future<bool> contains_all_data(const std::vector<serialization::pimpl::data>& elements);
+                boost::future<bool> contains_all_data(const std::vector<serialization::pimpl::data> &elements);
 
-                boost::future<bool> add_all_data(const std::vector<serialization::pimpl::data>& elements);
+                boost::future<bool> add_all_data(const std::vector<serialization::pimpl::data> &elements);
 
-                boost::future<bool> remove_all_data(const std::vector<serialization::pimpl::data>& elements);
+                boost::future<bool> remove_all_data(const std::vector<serialization::pimpl::data> &elements);
 
                 boost::future<bool> retain_all_data(const std::vector<serialization::pimpl::data>& elements);
 

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -876,6 +876,11 @@ namespace hazelcast {
                 return invoke_and_get_future<std::vector<serialization::pimpl::data>>(request, partition_id_);
             }
 
+            boost::future<boost::optional<serialization::pimpl::data>> IQueueImpl::take_data() {
+                auto request = protocol::codec::queue_take_encode(get_name());
+                return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(request, partition_id_);
+            }
+
             boost::future<boost::optional<serialization::pimpl::data>> IQueueImpl::peek_data() {
                 auto request = protocol::codec::queue_peek_encode(get_name());
                 return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(request, partition_id_);

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1633,7 +1633,7 @@ namespace hazelcast {
 
             TEST_F(ClientMessageTest, testOperationNameAfterRequestEncoding) {
                 auto request = protocol::codec::map_size_encode("map_name");
-                ASSERT_EQ(request.get_operation_name(), "Map.Size");
+                ASSERT_EQ(request.get_operation_name(), "map.size");
             }
 
             TEST_F(ClientMessageTest, testFragmentedMessageHandling) {


### PR DESCRIPTION
Removed unused codec methods. Increased the line coverage from 84% to 87%.

Also, a fix for iqueue to use relevant codec for `take` method.

Please check related protocol PR for auto generated code changes https://github.com/hazelcast/hazelcast-client-protocol/pull/364

