### PR TITLE
Revert the thread_pool destruction on shutdown, revert back the fix for issue https://github.com/chriskohlhoff/asio/issues/431

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -24,6 +24,7 @@
 #include <boost/asio/thread_pool.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/smart_ptr/atomic_shared_ptr.hpp>
+#include <boost/asio/steady_timer.hpp>
 
 #include "hazelcast/util/Sync.h"
 #include "hazelcast/client/exception/protocol_exceptions.h"
@@ -178,6 +179,8 @@ namespace hazelcast {
                      * The time when the response of the primary has been received.
                      */
                     std::chrono::steady_clock::time_point pending_response_received_time_;
+
+                    std::shared_ptr<boost::asio::steady_timer> retry_timer_;
 
                     ClientInvocation(spi::ClientContext &client_context,
                                      std::shared_ptr<protocol::ClientMessage> &&message,

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -386,11 +386,11 @@ namespace hazelcast {
                             submit_connect_to_cluster_task();
                         }
 
-                    } catch (exception::iexception &e) {
+                    } catch (std::exception &e) {
                         HZ_LOG(logger_, warning,
-                            boost::str(boost::format("Could not connect to any cluster, "
-                                                     "shutting down the client: %1%")
-                                                     % e)
+                               boost::str(boost::format("Could not connect to any cluster, "
+                                                        "shutting down the client: %1%")
+                                          % e.what())
                         );
 
                         shutdown_with_external_thread(client_.get_hazelcast_client_implementation());

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -645,6 +645,12 @@ namespace hazelcast {
                     on_connection_close(connection);
                     return nullptr;
                 }
+
+                // If the client is shutdown in parallel, we need to close this new connection.
+                if (!client_.get_lifecycle_service().is_running()) {
+                    connection->close("Client is shutdown");
+                }
+
                 return connection;
             }
 

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1458,7 +1458,7 @@ namespace hazelcast {
                         // progressive retry delay
                         int64_t delayMillis = util::min<int64_t>(static_cast<int64_t>(1) << (invoke_count_ - MAX_FAST_INVOCATION_COUNT),
                                                                  std::chrono::duration_cast<std::chrono::milliseconds>(retry_pause_).count());
-                        execution_service_->schedule(command, std::chrono::milliseconds(delayMillis));
+                        retry_timer_ = execution_service_->schedule(command, std::chrono::milliseconds(delayMillis));
                     }
                 }
 

--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -1023,16 +1023,6 @@ namespace hazelcast {
 
         void hz_thread_pool::shutdown_gracefully() {
             pool_->join();
-            pool_->stop();
-
-#if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
-            // needed due to bug https://github.com/chriskohlhoff/asio/issues/431
-            boost::asio::use_service<boost::asio::detail::win_iocp_io_context>(*pool_).stop();
-            // We need the following line so that the windows threads can be terminated. Otherwise,
-            // the threads stay dangling and cause resource leakage. Normally, the pool_ is destructed on client
-            // destruction but somehow it needs to be triggered at this point.
-            pool_.reset();
-#endif
         }
 
         boost::asio::thread_pool::executor_type hz_thread_pool::get_executor() const {


### PR DESCRIPTION
Removed destruction of the thread_pool on shutdown and left it to actual client destruction. Failing to do this causes illegal memory access during destruction of stands in the listener_service_impl.

Removed the work around of bug https://github.com/chriskohlhoff/asio/issues/431.

Added correct handling of the invocation retry timer. If it is not assigned to a timer variable in the invocation then it will actually be destroyed immediately, which will cause the timer cancelled immediately on destruction but this is not what we want.

Also added couble check client shutdown on connection opening.

fixes #739 