### PR TITLE
Separate client construction and start - client start returns async future

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,10 +1046,13 @@ The following example shows how you can set the cluster connection timeout to 30
 
 ## 5.5. Advanced Cluster Connection Retry Configuration
 
-When client is disconnected from the cluster, it searches for new connections to reconnect. You can configure the frequency of the reconnection attempts and client shutdown behavior using `connection_retry_config`.
-The following is an example configuration.
+When client is disconnected from the cluster, it searches for new connections to reconnect. You can configure the
+frequency of the reconnection attempts and client stop behavior using `connection_retry_config`. The following is an
+example configuration.
 
-Below is an example configuration. It configures a total timeout of 30 seconds to connect to a cluster, by initial backoff time being 100 milliseconds and doubling the time before every try with a jitter of 0.8  up to a maximum of 3 seconds backoff between each try..
+Below is an example configuration. It configures a total timeout of 30 seconds to connect to a cluster, by initial
+backoff time being 100 milliseconds and doubling the time before every try with a jitter of 0.8 up to a maximum of 3
+seconds backoff between each try..
 
 ```C++
     client_config().get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
@@ -1321,10 +1324,10 @@ As the final step, if you are done with your client, you can shut it down as sho
 
 ```C++
     // Shutdown this Hazelcast Client
-    client.shutdown().get();
+    client.stop().get();
 ```
 
-The client object destructor also shuts down the client upon destruction if you do not explicitly call the shutdown method.
+The client object destructor also shuts down the client upon destruction if you do not explicitly call the stop method.
 
 ## 7.2. C++ Client Operation Modes
 
@@ -1921,7 +1924,7 @@ This chapter explains when various events are fired and describes how you can ad
 You can add event listeners to a Hazelcast C++ client. You can configure the following listeners to listen to the events on the client side:
 
 * Membership Listener: Notifies when a member joins to/leaves the cluster, or when an attribute is changed in a member.
-* Lifecycle Listener: Notifies when the client is starting, started, shutting down and shutdown.
+* Lifecycle Listener: Notifies when the client is starting, started, shutting down and stop.
 
 #### 7.5.1.1. Listening for Member Events
 
@@ -2012,7 +2015,7 @@ The `lifecycle_listener` interface notifies for the following events:
 * `starting`: The client is starting.
 * `started`: The client has started.
 * `shutting_down`: The client is shutting down.
-* `shutdown`: The client’s shutdown has completed.
+* `stop`: The client’s stop has completed.
 * `client_connected`: The client is connected to the cluster.
 * `client_disconnected`: The client is disconnected from the cluster.
 
@@ -2046,8 +2049,8 @@ int main() {
 hazelcast::client::hazelcast_client hz(std::move(config));
 hz.start().get();
 
-hz.shutdown().get();
-    return 0;
+hz.stop().get();
+return 0;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -426,7 +426,9 @@ You can configure Hazelcast C++ Client programatically.
 You can start the client with no custom configuration like this:
 
 ```C++
-    hazelcast::client::hazelcast_client hz; // Connects to the cluster
+    hazelcast::client::hazelcast_client hz;
+
+hz.start().get(); // Connects to the cluster
 ```
 
 This section describes some network configuration settings to cover common use cases in connecting the client to a cluster. See the [Configuration Overview section](#3-configuration-overview)
@@ -437,9 +439,11 @@ pass this object to the client when starting it, as shown below.
 
 ```C++
     hazelcast::client::client_config config;
-    config.set_cluster_name("my-cluster"); // the server is configured to use the `my_cluster` as the cluster name hence we need to match it to be able to connect to the server.
-    config.get_network_config().add_address(address("192.168.1.10", 5701));    
-    hazelcast::client::hazelcast_client hz(std::move(config)); // Connects to the cluster member at ip address `192.168.1.10` and port 5701
+config.set_cluster_name("my-cluster"); // the server is configured to use the `my_cluster` as the cluster name hence we need to match it to be able to connect to the server.
+config.get_network_config().add_address(address("192.168.1.10", 5701));
+// Connects to the cluster member at ip address `192.168.1.10` and port 5701
+hazelcast::client::hazelcast_client hz(std::move(config));
+hz.start().get(); 
 ```
 
 If you run the Hazelcast IMDG members in a different server than the client, you most probably have configured the members' ports and cluster
@@ -502,11 +506,14 @@ Now that we have a working cluster and we know how to configure both our cluster
 The following example first creates a programmatic configuration object. Then, it starts a client.
 
 ```C++
-#include <hazelcast/client/hazelcast_client.h>
+#include
+<hazelcast/client/hazelcast_client.h>
 int main() {
-    hazelcast::client::hazelcast_client hz; // Connects to the cluster
-    std::cout << "Started the Hazelcast C++ client instance " << hz.get_name() << std::endl; // Prints client instance name
-    return 0;
+hazelcast::client::hazelcast_client hz;
+
+hz.start().get(); // Connects to the cluster
+std::cout << "Started the Hazelcast C++ client instance " << hz.get_name() << std::endl; // Prints client instance name
+return 0;
 }
 ```
 This should print logs about the cluster members and information about the client itself such as client type and local address port.
@@ -545,20 +552,23 @@ Then, you can run the application using the following command:
 **main.cpp**
 
 ```C++
-#include <hazelcast/client/hazelcast_client.h>
+#include
+<hazelcast/client/hazelcast_client.h>
 int main() {
-    hazelcast::client::hazelcast_client hz; // Connects to the cluster
+hazelcast::client::hazelcast_client hz;
 
-    auto personnel = hz.get_map("personnel_map").get();
-    personnel->put<std::string, std::string>("Alice", "IT").get();
-    personnel->put<std::string, std::string>("Bob", "IT").get();
-    personnel->put<std::string, std::string>("Clark", "IT").get();
-    std::cout << "Added IT personnel. Logging all known personnel" << std::endl;
-    for (const auto &entry : personnel->entry_set<std::string, std::string>().get()) {
-        std::cout << entry.first << " is in " << entry.second << " department." << std::endl;
-    }
-    
-    return 0;
+hz.start().get(); // Connects to the cluster
+
+auto personnel = hz.get_map("personnel_map").get();
+personnel->put<std::string, std::string>("Alice", "IT").get();
+personnel->put<std::string, std::string>("Bob", "IT").get();
+personnel->put<std::string, std::string>("Clark", "IT").get();
+std::cout << "Added IT personnel. Logging all known personnel" << std::endl;
+for (const auto &entry : personnel->entry_set<std::string, std::string>().get()) {
+std::cout << entry.first << " is in " << entry.second << " department." << std::endl;
+}
+
+return 0;
 }
 ```
 
@@ -603,19 +613,22 @@ Then, you can run the application using the following command:
 **Sales.cpp**
 
 ```C++
-#include <hazelcast/client/hazelcast_client.h>
+#include
+<hazelcast/client/hazelcast_client.h>
 int main() {
-    hazelcast::client::hazelcast_client hz; // Connects to the cluster
+hazelcast::client::hazelcast_client hz;
 
-    auto personnel = hz.get_map("personnel_map").get();
-    personnel->put<std::string, std::string>("Denise", "Sales").get();
-    personnel->put<std::string, std::string>("Erwing", "Sales").get();
-    personnel->put<std::string, std::string>("Fatih", "Sales").get();
-    personnel->put<std::string, std::string>("Bob", "IT").get();
-    personnel->put<std::string, std::string>("Clark", "IT").get();
-    std::cout << "Added all sales personnel. Logging all known personnel" << std::endl;
-    for (const auto &entry : personnel.entry_set().get()) {
-        std::cout << entry.first << " is in " << entry.second << " department." << std::endl;
+hz.start().get(); // Connects to the cluster
+
+auto personnel = hz.get_map("personnel_map").get();
+personnel->put<std::string, std::string>("Denise", "Sales").get();
+personnel->put<std::string, std::string>("Erwing", "Sales").get();
+personnel->put<std::string, std::string>("Fatih", "Sales").get();
+personnel->put<std::string, std::string>("Bob", "IT").get();
+personnel->put<std::string, std::string>("Clark", "IT").get();
+std::cout << "Added all sales personnel. Logging all known personnel" << std::endl;
+for (const auto &entry : personnel.entry_set().get()) {
+std::cout << entry.first << " is in " << entry.second << " department." << std::endl;
     }
 
     return 0;
@@ -711,8 +724,10 @@ desired aspects. An example is shown below.
 
 ```C++
     hazelcast::client::client_config config;
-    config.get_network_config().add_address({"your server ip", 5701 /* your server port*/});
-    hazelcast::client::hazelcast_client hz(std::move(config)); // Connects to the cluster
+config.get_network_config().add_address({ "your server ip", 5701 /* your server port*/});
+// Connects to the cluster
+hazelcast::client::hazelcast_client hz(std::move(config));
+hz.start().get(); 
 ```
 
 See the `client_config` class reference at the Hazelcast C++ client API Documentation for details.
@@ -905,10 +920,12 @@ In order to use JSON serialization, you should use the `hazelcast_json_value` ob
 ```C++
     hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("map").get();
+hz.start().get();
 
-    map->put("item1", hazelcast::client::hazelcast_json_value("{ \"age\": 4 }")).get();
-    map->put("item2", hazelcast::client::hazelcast_json_value("{ \"age\": 20 }")).get();
+auto map = hz.get_map("map").get();
+
+map->put("item1", hazelcast::client::hazelcast_json_value("{ \"age\": 4 }")).get();
+map->put("item2", hazelcast::client::hazelcast_json_value("{ \"age\": 20 }")).get();
 ```
 
 `hazelcast_json_value` is a simple wrapper and identifier for the JSON formatted strings. You can get the JSON string from the `hazelcast_json_value` object using the `to_string()` method. 
@@ -959,7 +976,8 @@ You should register the global serializer in the configuration.
 ```C++
     hazelcast::client::client_config config;
     config.get_serialization_config().set_global_serializer(std::make_shared<MyGlobalSerializer>());
-    hazelcast::client::hazelcast_client hz(std::move(config));
+hazelcast::client::hazelcast_client hz(std::move(config));
+hz.start().get();
 ```
 
 You need to utilize the `boost::any_cast` methods tyo actually use the objects provided for serialization and you are expected to return type `boost::any` from the `read` method. 
@@ -1562,25 +1580,27 @@ hazelcast::client::topic::reliable_listener make_listener(std::atomic<int> &n_re
             auto object = message.get_message_object().get<std::string>();
             if (object) {
                 std::cout << "[GenericListener::onMessage] Received message: " << *object << " for topic:" << message.get_name();
-            } else {
-                std::cout << "[GenericListener::onMessage] Received message with NULL object for topic:" <<
-                message.get_name();
-            }
-        });
+} else {
+std::cout << "[GenericListener::onMessage] Received message with NULL object for topic:" <<
+message.get_name();
+}
+});
 }
 
 void listen_with_default_config() {
-    hazelcast::client::hazelcast_client client;
+hazelcast::client::hazelcast_client client;
 
-    std::string topicName("MyReliableTopic");
-    auto topic = client.get_reliable_topic(topicName).get();
+client.start().get();
 
-    std::atomic<int> numberOfMessagesReceived{0};
-    auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
+std::string topicName("MyReliableTopic");
+auto topic = client.get_reliable_topic(topicName).get();
 
-    std::cout << "Registered the listener with listener id:" << listenerId << std::endl;
+std::atomic<int> numberOfMessagesReceived{ 0 };
+auto listenerId = topic->add_message_listener(make_listener(numberOfMessagesReceived));
 
-    while (numberOfMessagesReceived < 1) {
+std::cout << "Registered the listener with listener id:" << listenerId << std::endl;
+
+while (numberOfMessagesReceived < 1) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
@@ -1627,15 +1647,17 @@ A pn_counter usage example is shown below.
 ```C++
     hazelcast::client::hazelcast_client hz;
 
-    auto pnCounter = hz.get_pn_counter("pncounterexample").get();
+hz.start().get();
 
-    std::cout << "Counter started with value:" << pnCounter->get().get() << std::endl;
+auto pnCounter = hz.get_pn_counter("pncounterexample").get();
 
-    std::cout << "Counter new value after adding is: " << pnCounter->add_and_get(5).get() << std::endl;
+std::cout << "Counter started with value:" << pnCounter->get().get() << std::endl;
 
-    std::cout << "Counter new value before adding is: " << pnCounter->get_and_add(2).get() << std::endl;
+std::cout << "Counter new value after adding is: " << pnCounter->add_and_get(5).get() << std::endl;
 
-    std::cout << "Counter new value is: " << pnCounter->get().get() << std::endl;
+std::cout << "Counter new value before adding is: " << pnCounter->get_and_add(2).get() << std::endl;
+
+std::cout << "Counter new value is: " << pnCounter->get().get() << std::endl;
 
     std::cout << "Decremented counter by one to: " << pnCounter->decrement_and_get().get() << std::endl;
 ```
@@ -1946,23 +1968,25 @@ membership_listener make_initial_membership_listener() {
 }
 
 int main() {
-    auto memberListener = make_membership_listener();
-    auto initialMemberListener = make_initial_membership_listener();
+auto memberListener = make_membership_listener();
+auto initialMemberListener = make_initial_membership_listener();
 
-    hazelcast::client::cluster *clusterPtr = nullptr;
-    boost::uuids::uuid listenerId, initialListenerId;
-    try {
-        hazelcast::client::hazelcast_client hz;
+hazelcast::client::cluster *clusterPtr = nullptr;
+boost::uuids::uuid listenerId, initialListenerId;
+try {
+hazelcast::client::hazelcast_client hz;
 
-        hazelcast::client::cluster &cluster = hz.get_cluster().get();
-        clusterPtr = &cluster;
-        auto members = cluster.get_members();
-        std::cout << "The following are members in the cluster:" << std::endl;
-        for (const auto &member: members) {
-            std::cout << member.get_address() << std::endl;
-        }
+hz.start().get();
 
-        listenerId = cluster.add_membership_listener(std::move(memberListener));
+hazelcast::client::cluster &cluster = hz.get_cluster().get();
+clusterPtr = &cluster;
+auto members = cluster.get_members();
+std::cout << "The following are members in the cluster:" << std::endl;
+for (const auto &member: members) {
+std::cout << member.get_address() << std::endl;
+}
+
+listenerId = cluster.add_membership_listener(std::move(memberListener));
         initialListenerId = cluster.add_membership_listener(std::move(initialMemberListener));
 
         // sleep some time for the events to be delivered before exiting
@@ -2019,9 +2043,10 @@ int main() {
             });
     );
 
-    hazelcast::client::hazelcast_client hz(std::move(config));
+hazelcast::client::hazelcast_client hz(std::move(config));
+hz.start().get();
 
-    hz.shutdown().get();
+hz.shutdown().get();
     return 0;
 }
 ```
@@ -2062,17 +2087,19 @@ See the following example.
 
 ```C++
 int main() {
-    hazelcast::client::hazelcast_client hz;
+hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("EntryListenerExampleMap").get();
+hz.start().get();
 
-    auto registrationId = map->add_entry_listener(
-        entry_listener().
-            on_added([](hazelcast::client::EntryEvent &&event) {
-                std::cout << "Entry added:" << event.getKey().get<int>().value() 
-                    << " --> " << event.getValue().get<std::string>().value() << std::endl;
-            }).
-            on_removed([](hazelcast::client::EntryEvent &&event) {
+auto map = hz.get_map("EntryListenerExampleMap").get();
+
+auto registrationId = map->add_entry_listener(
+entry_listener().
+on_added([](hazelcast::client::EntryEvent &&event) {
+std::cout << "Entry added:" << event.getKey().get<int>().value()
+<< " --> " << event.getValue().get<std::string>().value() << std::endl;
+}).
+on_removed([](hazelcast::client::EntryEvent &&event) {
                 std::cout << "Entry removed:" << event.getKey().get<int>().value() 
                     << " --> " << event.getValue().get<std::string>().value() << std::endl;
             })
@@ -2093,18 +2120,20 @@ See the example below.
 
 ```C++
 int main() {
-    hazelcast::client::hazelcast_client hz;
+hazelcast::client::hazelcast_client hz;
 
-    auto map = hz.get_map("EntryListenerExampleMap").get();
+hz.start().get();
 
-    auto registrationId = map->add_entry_listener(
-        entry_listener().
-            on_map_cleared([](hazelcast::client::map_event &&event) {
-                std::cout << "Map cleared:" << event.getNumberOfEntriesAffected() << std::endl; // Map Cleared: 3
-            })    
-        , false).get();
+auto map = hz.get_map("EntryListenerExampleMap").get();
 
-    map->put(1, "Mali").get();
+auto registrationId = map->add_entry_listener(
+entry_listener().
+on_map_cleared([](hazelcast::client::map_event &&event) {
+std::cout << "Map cleared:" << event.getNumberOfEntriesAffected() << std::endl; // Map Cleared: 3
+})
+, false).get();
+
+map->put(1, "Mali").get();
     map->put(2, "Ahmet").get();
     map->put(3, "Furkan").get();
     map->clear().get();
@@ -2949,9 +2978,8 @@ Hazelcast Map can be configured to work with near cache enabled. You can enable 
     nearCacheConfig.get_eviction_config().set_eviction_policy(config::LRU)
             .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT).set_size(100);
     config.add_near_cache_config(nearCacheConfig);
-    hazelcast_client client(std::move(config));
-
-```
+hazelcast_client client(std::move(config));
+client.start().get();```
 
 Following are the descriptions of all configuration elements:
  - `set_in_memory_format`: Specifies in which format data will be stored in your Near Cache. Note that a map’s in-memory format can be different from that of its Near Cache. Available values are as follows:

--- a/examples/Org.Website.Samples/EntryProcessorSample.cpp
+++ b/examples/Org.Website.Samples/EntryProcessorSample.cpp
@@ -63,7 +63,7 @@ int main() {
     // Show that the IncEntryProcessor updated the value.
     std::cout << "new value:" << *map->get<std::string, std::string>("key").get();
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/ExecutorSample.cpp
+++ b/examples/Org.Website.Samples/ExecutorSample.cpp
@@ -144,7 +144,7 @@ int main() {
     ex->submit<MessagePrinter, std::string>(MessagePrinter{"Message when using the member selector"},
                                             MyMemberSelector());
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/GlobalSerializerSample.cpp
+++ b/examples/Org.Website.Samples/GlobalSerializerSample.cpp
@@ -52,6 +52,7 @@ int main() {
     config.set_serialization_config(serializationConfig);
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/IdentifiedDataSerializableSample.cpp
+++ b/examples/Org.Website.Samples/IdentifiedDataSerializableSample.cpp
@@ -58,7 +58,7 @@ namespace hazelcast {
 int main() {
     hazelcast_client hz;
     //Employee can be used here
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/ListSample.cpp
+++ b/examples/Org.Website.Samples/ListSample.cpp
@@ -43,7 +43,7 @@ int main() {
     f.get();
 
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/MapSample.cpp
+++ b/examples/Org.Website.Samples/MapSample.cpp
@@ -40,7 +40,7 @@ int main() {
     future.get();
 
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/MultiMapSample.cpp
+++ b/examples/Org.Website.Samples/MultiMapSample.cpp
@@ -35,7 +35,7 @@ int main() {
     // remove specific key/value pair
     multiMap->remove("my-key", "value2").get();
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/PortableSerializableSample.cpp
+++ b/examples/Org.Website.Samples/PortableSerializableSample.cpp
@@ -55,7 +55,7 @@ namespace hazelcast {
 int main() {
     hazelcast_client hz;
     //PortableSerializableSample can be used here
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/QuerySample.cpp
+++ b/examples/Org.Website.Samples/QuerySample.cpp
@@ -86,7 +86,7 @@ int main() {
     for (auto &value : result2) {
         std::cout << value << std::endl;
     }
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/QueueSample.cpp
+++ b/examples/Org.Website.Samples/QueueSample.cpp
@@ -32,7 +32,7 @@ int main() {
     queue->put("yetanotheritem");
     std::cout << *queue->take<std::string>().get() << std::endl;
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/ReplicatedMapSample.cpp
+++ b/examples/Org.Website.Samples/ReplicatedMapSample.cpp
@@ -31,7 +31,7 @@ int main() {
     // the value is retrieved from a random member in the cluster
     std::cout << "value for key = " << value.value_or("null");
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/RingBufferSample.cpp
+++ b/examples/Org.Website.Samples/RingBufferSample.cpp
@@ -30,6 +30,6 @@ int main() {
     sequence++;
     std::cout << *rb->read_one<int>(sequence).get() << std::endl;
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
 }

--- a/examples/Org.Website.Samples/SetSample.cpp
+++ b/examples/Org.Website.Samples/SetSample.cpp
@@ -41,7 +41,7 @@ int main() {
     future.get();
 
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/Org.Website.Samples/TopicSample.cpp
+++ b/examples/Org.Website.Samples/TopicSample.cpp
@@ -32,7 +32,7 @@ int main() {
     // Publish a message to the Topic
     topic->publish("Hello to distributed world").get();
     // Shutdown this Hazelcast Client
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/authentication/token_authentication.cpp
+++ b/examples/authentication/token_authentication.cpp
@@ -26,6 +26,7 @@ int main() {
             .set_credentials(std::make_shared<hazelcast::client::security::token_credentials>(my_token));
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
 

--- a/examples/authentication/username_password_authentication.cpp
+++ b/examples/authentication/username_password_authentication.cpp
@@ -25,6 +25,7 @@ int main() {
             std::make_shared<hazelcast::client::security::username_password_credentials>("test-user", "test-pass"));
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/aws/AwsClientWithKey.cpp
+++ b/examples/aws/AwsClientWithKey.cpp
@@ -40,6 +40,7 @@ int main() {
             set_region("us-east-1");
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
 

--- a/examples/aws/AwsClientWithNoKeyNoIAMRoleInsideAws.cpp
+++ b/examples/aws/AwsClientWithNoKeyNoIAMRoleInsideAws.cpp
@@ -30,6 +30,7 @@ int main() {
         set_tag_value("aws-tag-value-1").set_inside_aws(true);
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/aws/AwsClientWithNoKeyWithIAMRoleInsideAws.cpp
+++ b/examples/aws/AwsClientWithNoKeyWithIAMRoleInsideAws.cpp
@@ -30,6 +30,7 @@ int main() {
         set_tag_value("aws-tag-value-1").set_iam_role("MyInstanceRole").set_inside_aws(true);
     
     hazelcast::client::hazelcast_client hz(std::move(clientConfig));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/backpressure/EnableBackPressure.cpp
+++ b/examples/backpressure/EnableBackPressure.cpp
@@ -78,6 +78,7 @@ int main() {
     config.set_property("hazelcast.client.invocation.backoff.timeout.millis", "2000");
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/client-statistics/ClientStatistics.cpp
+++ b/examples/client-statistics/ClientStatistics.cpp
@@ -37,6 +37,7 @@ int main() {
 
     config.add_near_cache_config(config::near_cache_config("MyMap"));
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/cp/atomic_long.cpp
+++ b/examples/cp/atomic_long.cpp
@@ -19,12 +19,14 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     // Get an AtomicLong called 'my-atomic-long'
     auto atomic_counter = hz.get_cp_subsystem().get_atomic_long("my-atomic-long").get();
 
     // also present the future continuation capability. you can use sync version as well.
     // Get current value (returns a int64_t)
-    auto future = atomic_counter->get().then(boost::launch::deferred, [=] (boost::future<int64_t> f) {
+    auto future = atomic_counter->get().then(boost::launch::deferred, [=](boost::future<int64_t> f) {
         // Prints:
         // Value: 0
         std::cout << "Value: " << f.get() << "\n";

--- a/examples/cp/atomic_reference.cpp
+++ b/examples/cp/atomic_reference.cpp
@@ -19,6 +19,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     // Get an atomic_reference named 'my-ref'
     auto ref = hz.get_cp_subsystem().get_atomic_reference("my-ref").get();
 

--- a/examples/cp/counting_semphore.cpp
+++ b/examples/cp/counting_semphore.cpp
@@ -19,6 +19,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     // Get counting_semaphore named 'my-semaphore'
     auto semaphore = hz.get_cp_subsystem().get_semaphore("my-semaphore").get();
     // Try to initialize the semaphore

--- a/examples/cp/fenced_lock.cpp
+++ b/examples/cp/fenced_lock.cpp
@@ -19,6 +19,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     // Get an fenced_lock named 'my-lock'
     auto lock = hz.get_cp_subsystem().get_lock("my-lock").get();
 

--- a/examples/cp/latch.cpp
+++ b/examples/cp/latch.cpp
@@ -19,6 +19,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     // Get a latch called 'my-latch'
     auto latch = hz.get_cp_subsystem().get_latch("my-latch'").get();
 

--- a/examples/distributed-collections/blockingqueue/Consumer.cpp
+++ b/examples/distributed-collections/blockingqueue/Consumer.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto queue = hz.get_queue("queue").get();
 
     while (true) {

--- a/examples/distributed-collections/blockingqueue/Producer.cpp
+++ b/examples/distributed-collections/blockingqueue/Producer.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto queue = hz.get_queue("queue").get();
 
     for (int k = 1; k < 100; k++) {

--- a/examples/distributed-collections/itemlisteners/CollectionChanger.cpp
+++ b/examples/distributed-collections/itemlisteners/CollectionChanger.cpp
@@ -19,10 +19,12 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto queue = hz.get_queue("queue").get();
 
-    queue->put("foo").then([=] (boost::future<void> f) {
-       f.get();
+    queue->put("foo").then([=](boost::future<void> f) {
+        f.get();
         queue->put("bar").get();
     }).get();
 

--- a/examples/distributed-collections/itemlisteners/item_listener.cpp
+++ b/examples/distributed-collections/itemlisteners/item_listener.cpp
@@ -20,6 +20,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto queue = hz.get_queue("queue").get();
 
     std::atomic<int> numAdded(0);
@@ -27,8 +29,8 @@ int main() {
 
     hazelcast::client::item_listener listener;
     listener.
-        on_added([&numAdded](hazelcast::client::item_event &&event) {
-            std::cout << "Item added:" << event.get_item().get<std::string>().value() << std::endl;
+            on_added([&numAdded](hazelcast::client::item_event &&event) {
+        std::cout << "Item added:" << event.get_item().get<std::string>().value() << std::endl;
             ++numAdded;
         }).
         on_removed([&numRemoved](hazelcast::client::item_event &&event) {

--- a/examples/distributed-collections/list/Reader.cpp
+++ b/examples/distributed-collections/list/Reader.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto list = hz.get_list("list").get();
 
     for (auto &item : list->to_array<std::string>().get()) {

--- a/examples/distributed-collections/list/Writer.cpp
+++ b/examples/distributed-collections/list/Writer.cpp
@@ -18,15 +18,17 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto list = hz.get_list("list").get();
 
-    list->add("Tokyo").then(boost::launch::deferred, [=] (boost::future<bool> f) {
-       if (f.get()) {
-           std::cout << "First addition is successfull!!!" << '\n';
-           list->add("Paris").get();
-           list->add("London").get();
-           list->add("New York").get();
-       }
+    list->add("Tokyo").then(boost::launch::deferred, [=](boost::future<bool> f) {
+        if (f.get()) {
+            std::cout << "First addition is successfull!!!" << '\n';
+            list->add("Paris").get();
+            list->add("London").get();
+            list->add("New York").get();
+        }
     });
 
     std::cout << "Putting finished!" << std::endl;

--- a/examples/distributed-collections/ringbuffer/RingbufferExample.cpp
+++ b/examples/distributed-collections/ringbuffer/RingbufferExample.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto rb = hz.get_ringbuffer("myringbuffer").get();
 
     std::cout << "Capacity of the ringbuffer is:" << rb->capacity().get() << std::endl;

--- a/examples/distributed-collections/set/Reader.cpp
+++ b/examples/distributed-collections/set/Reader.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto set = hz.get_set("set").get();
 
     for (auto &item : set->to_array<std::string>().get()) {

--- a/examples/distributed-collections/set/Writer.cpp
+++ b/examples/distributed-collections/set/Writer.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto set = hz.get_set("set").get();
 
     set->add("Tokyo").get();

--- a/examples/distributed-map/basic/FillMap.cpp
+++ b/examples/distributed-map/basic/FillMap.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
     map->put<std::string, std::string>("1", "Tokyo").get();
     map->put<std::string, std::string>("2", "Paris").get();

--- a/examples/distributed-map/basic/PrintAll.cpp
+++ b/examples/distributed-map/basic/PrintAll.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
     auto entries = map->entry_set<std::string, std::string>().get();
     for (auto &entry : map->entry_set<std::string, std::string>().get()) {

--- a/examples/distributed-map/custom-attributes/CarAttributeDemo.cpp
+++ b/examples/distributed-map/custom-attributes/CarAttributeDemo.cpp
@@ -87,6 +87,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("cars").get();
 
     map->put(1, Car("Audi Q7", 250, 22000)).get();

--- a/examples/distributed-map/entry-listener/ModifyMap.cpp
+++ b/examples/distributed-map/entry-listener/ModifyMap.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("somemap").get();
 
     std::string key{"some string key"};

--- a/examples/distributed-map/entry-listener/main.cpp
+++ b/examples/distributed-map/entry-listener/main.cpp
@@ -48,6 +48,8 @@ hazelcast::client::entry_listener make_listener() {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("somemap").get();
 
     auto listenerId = map->add_entry_listener(make_listener(), true).get();

--- a/examples/distributed-map/entry-processor/main.cpp
+++ b/examples/distributed-map/entry-processor/main.cpp
@@ -20,6 +20,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto employees = hz.get_map("employees").get();
 
     employees->put("John", employee{1000}).get();

--- a/examples/distributed-map/eviction/EvictAll.cpp
+++ b/examples/distributed-map/eviction/EvictAll.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("evictiontestmap").get();
 
     int numberOfKeysToLock = 4;

--- a/examples/distributed-map/index/main.cpp
+++ b/examples/distributed-map/index/main.cpp
@@ -51,6 +51,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("personsWithIndex").get();
 
     map->add_index(hazelcast::client::config::index_config::index_type::SORTED, "name").get();

--- a/examples/distributed-map/locking/AbaProtectedOptimisticUpdate.cpp
+++ b/examples/distributed-map/locking/AbaProtectedOptimisticUpdate.cpp
@@ -49,12 +49,14 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
 
     map->put("1", Value{});
     std::cout << "Starting" << std::endl;
     for (int k = 0; k < 1000; k++) {
-        for (; ;) {
+        for (;;) {
             auto oldValue = map->get<std::string, Value>("1").get();
             Value newValue(*oldValue);
             std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/examples/distributed-map/locking/OptimisticUpdate.cpp
+++ b/examples/distributed-map/locking/OptimisticUpdate.cpp
@@ -50,6 +50,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
 
     std::string key("1");

--- a/examples/distributed-map/locking/PessimisticUpdate.cpp
+++ b/examples/distributed-map/locking/PessimisticUpdate.cpp
@@ -50,6 +50,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
 
     std::string key("1");

--- a/examples/distributed-map/locking/RacyUpdate.cpp
+++ b/examples/distributed-map/locking/RacyUpdate.cpp
@@ -50,6 +50,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
 
     std::string key("1");

--- a/examples/distributed-map/map-interceptor/main.cpp
+++ b/examples/distributed-map/map-interceptor/main.cpp
@@ -44,13 +44,16 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("themap").get();
 
     map->add_interceptor(MapInterceptor{}).get();
 
     map->put<std::string, std::string>("1", "1").get();
 
-    std::cout << "The modified value (modified by the interceptor) at the server:" << *map->get<std::string, std::string>("1").get() << std::endl;
+    std::cout << "The modified value (modified by the interceptor) at the server:"
+              << *map->get<std::string, std::string>("1").get() << std::endl;
 
     std::cout << "Finished" << std::endl;
 

--- a/examples/distributed-map/multimap/MultimapPut.cpp
+++ b/examples/distributed-map/multimap/MultimapPut.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_multi_map("map").get();
 
     map->put("a", "1").get();

--- a/examples/distributed-map/multimap/PrintValues.cpp
+++ b/examples/distributed-map/multimap/PrintValues.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_multi_map("map").get();
 
     for (auto &key : map->key_set<std::string>().get()) {

--- a/examples/distributed-map/near-cache/NearCacheWithEvictionPolicy.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithEvictionPolicy.cpp
@@ -26,6 +26,7 @@ int main() {
             .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT).set_size(100);
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
+    client.start().get();
 
     auto map = client.get_map(mapName).get();
 

--- a/examples/distributed-map/near-cache/NearCacheWithInvalidation.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithInvalidation.cpp
@@ -26,6 +26,7 @@ int main() {
             .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT);
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
+    client.start().get();
 
     hazelcast_client noNearCacheclient;
 

--- a/examples/distributed-map/near-cache/NearCacheWithMaxIdle.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithMaxIdle.cpp
@@ -31,6 +31,7 @@ int main() {
     nearCacheConfig.set_max_idle_seconds(1);
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
+    client.start().get();
 
     auto map = client.get_map(mapName).get();
 

--- a/examples/distributed-map/near-cache/NearCacheWithMemoryFormatBinary.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithMemoryFormatBinary.cpp
@@ -30,7 +30,7 @@ int main() {
             .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT);
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
-
+    client.start().get();
     auto map = client.get_map(mapName).get();
 
     // the first get() will populate the Near Cache

--- a/examples/distributed-map/near-cache/NearCacheWithMemoryFormatObject.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithMemoryFormatObject.cpp
@@ -28,6 +28,7 @@ int main() {
             .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT);
     config.add_near_cache_config(nearCacheConfig);
     hazelcast_client client(std::move(config));
+    client.start().get();
 
     auto map = client.get_map(mapName).get();
 

--- a/examples/distributed-map/near-cache/NearCacheWithTTL.cpp
+++ b/examples/distributed-map/near-cache/NearCacheWithTTL.cpp
@@ -29,6 +29,7 @@ int main() {
             .set_maximum_size_policy(config::eviction_config::ENTRY_COUNT);
     config.add_near_cache_config(nearCacheConfig);
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map(mapName).get();
 

--- a/examples/distributed-map/partitionaware/partitionAwarePutGet.cpp
+++ b/examples/distributed-map/partitionaware/partitionAwarePutGet.cpp
@@ -59,6 +59,8 @@ const std::string PartitionAwareString::desiredPartitionString = "desiredKeyStri
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     PartitionAwareString partitionKey{"MyString"};
 
     auto map = hz.get_map("paritionawaremap").get();

--- a/examples/distributed-map/query/queryExample.cpp
+++ b/examples/distributed-map/query/queryExample.cpp
@@ -118,6 +118,8 @@ public:
 void query_map_using_paging_predicate() {
     hazelcast::client::hazelcast_client client;
 
+    client.start().get();
+
     auto intMap = client.get_map("testIntMapValuesWithpaging_predicate").get();
 
     int predSize = 5;
@@ -176,6 +178,8 @@ void query_map_using_paging_predicate() {
 
 void query_map_using_different_predicates() {
     hazelcast::client::hazelcast_client client;
+
+    client.start().get();
 
     auto intMap = client.get_map("testValuesWithPredicateIntMap").get();
 

--- a/examples/distributed-map/removeAll/removeAllExample.cpp
+++ b/examples/distributed-map/removeAll/removeAllExample.cpp
@@ -60,13 +60,15 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto personMap = hz.get_map("personMap").get();
     personMap->put_all<std::string, Person>({{"1", Person{"Peter", true, 36}},
-                       {"2", Person{"John", true, 50}},
-                       {"3", Person{"Marry", false, 20}},
-                       {"4", Person{"Mike", true, 35}},
-                       {"5", Person{"Rob", true, 60}},
-                       {"6", Person{"Jane", false, 43}}}).get();
+                                             {"2", Person{"John", true, 50}},
+                                             {"3", Person{"Marry", false, 20}},
+                                             {"4", Person{"Mike", true, 35}},
+                                             {"5", Person{"Rob", true, 60}},
+                                             {"6", Person{"Jane", false, 43}}}).get();
 
     // Remove entries that whose name start with 'M'
     personMap->remove_all(query::like_predicate(hz, "name", "M%")).get();

--- a/examples/distributed-primitives/crdt-pncounter/CrdtPNCounter.cpp
+++ b/examples/distributed-primitives/crdt-pncounter/CrdtPNCounter.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto pnCounter = hz.get_pn_counter("pncounterexample").get();
 
     std::cout << "Counter started with value:" << pnCounter->get().get() << std::endl;

--- a/examples/distributed-topic/basic-pub-sub/Publisher.cpp
+++ b/examples/distributed-topic/basic-pub-sub/Publisher.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto topic = hz.get_topic("testtopic").get();
     topic->publish("first message").get();
     std::cout << "Published: Published the message." << std::endl;

--- a/examples/distributed-topic/basic-pub-sub/Subscriber.cpp
+++ b/examples/distributed-topic/basic-pub-sub/Subscriber.cpp
@@ -20,13 +20,15 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto topic = hz.get_topic("testtopic").get();
 
     topic->add_message_listener(
-        hazelcast::client::topic::listener().
-            on_received([](hazelcast::client::topic::message &&msg) {
+            hazelcast::client::topic::listener().
+                    on_received([](hazelcast::client::topic::message &&msg) {
                 std::cout << "Message received:"
-                    << msg.get_message_object().get<std::string>().value() << std::endl;
+                          << msg.get_message_object().get<std::string>().value() << std::endl;
             })
     ).get();
 

--- a/examples/distributed-topic/reliabletopic/Publisher.cpp
+++ b/examples/distributed-topic/reliabletopic/Publisher.cpp
@@ -18,6 +18,8 @@
 void publish_with_default_config() {
     hazelcast::client::hazelcast_client client;
 
+    client.start().get();
+
     auto topic = client.get_reliable_topic("MyReliableTopic").get();
     topic->publish(std::string("My first message")).get();
 }
@@ -29,6 +31,7 @@ void publish_with_non_default_config() {
     reliableTopicConfig.set_read_batch_size(5);
     clientConfig.add_reliable_topic_config(reliableTopicConfig);
     hazelcast::client::hazelcast_client client(std::move(clientConfig));
+    client.start().get();
 
     auto topic = client.get_reliable_topic(topicName).get();
 

--- a/examples/distributed-topic/reliabletopic/Subscriber.cpp
+++ b/examples/distributed-topic/reliabletopic/Subscriber.cpp
@@ -36,6 +36,8 @@ hazelcast::client::topic::reliable_listener make_listener(std::atomic<int> &n_re
 void listen_with_default_config() {
     hazelcast::client::hazelcast_client client;
 
+    client.start().get();
+
     std::string topicName("MyReliableTopic");
     auto topic = client.get_reliable_topic(topicName).get();
 
@@ -62,6 +64,7 @@ void listen_with_config() {
     reliableTopicConfig.set_read_batch_size(5);
     clientConfig.add_reliable_topic_config(reliableTopicConfig);
     hazelcast::client::hazelcast_client client(std::move(clientConfig));
+    client.start().get();
 
     auto topic = client.get_reliable_topic(topicName).get();
 

--- a/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
+++ b/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
@@ -79,7 +79,7 @@ int main() {
 
     std::cout << "Finished" << std::endl;
 
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
+++ b/examples/event-properties/SetEventThreadCountAndMaxQueueSize.cpp
@@ -37,6 +37,7 @@ int main() {
     config.set_property("hazelcast.client.event.queue.capacity", "50000");
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
 

--- a/examples/invocation-timeouts/SetInvocationTimeouts.cpp
+++ b/examples/invocation-timeouts/SetInvocationTimeouts.cpp
@@ -40,6 +40,7 @@ int main() {
     config.set_property("hazelcast.client.invocation.timeout.seconds", "30");
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/learning-basics/configure-logging/custom_log_handler.cpp
+++ b/examples/learning-basics/configure-logging/custom_log_handler.cpp
@@ -45,6 +45,7 @@ int main() {
     config.get_logger_config().handler(my_log_handler);
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     return 0;
 }

--- a/examples/learning-basics/configure-logging/disable_logging.cpp
+++ b/examples/learning-basics/configure-logging/disable_logging.cpp
@@ -25,6 +25,7 @@ int main() {
     config.get_logger_config().level(hazelcast::logger::level::off);
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     return 0;
 }

--- a/examples/learning-basics/configure-logging/set_level.cpp
+++ b/examples/learning-basics/configure-logging/set_level.cpp
@@ -23,6 +23,7 @@ int main() {
     config.get_logger_config().level(hazelcast::logger::level::finest);
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     return 0;
 }

--- a/examples/learning-basics/destroying-instances/main.cpp
+++ b/examples/learning-basics/destroying-instances/main.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto q1 = hz.get_queue("q").get();
     auto q2 = hz.get_queue("q").get();
 

--- a/examples/learning-basics/unique-names/main.cpp
+++ b/examples/learning-basics/unique-names/main.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto flakeIdGenerator = hz.get_flake_id_generator("idGenerator").get();
     std::ostringstream out("somemap");
     out << flakeIdGenerator->new_id().get();

--- a/examples/monitoring/cluster/main.cpp
+++ b/examples/monitoring/cluster/main.cpp
@@ -58,6 +58,8 @@ int main() {
     try {
         hazelcast::client::hazelcast_client hz;
 
+        hz.start().get();
+
         hazelcast::client::cluster &cluster = hz.get_cluster();
         clusterPtr = &cluster;
         auto members = cluster.get_members();

--- a/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
+++ b/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
@@ -63,7 +63,7 @@ int main() {
         std::cout << "The client did not connect to the cluster 10 seconds after disconnection as expected." << std::endl;
     }
 
-    hz.shutdown().get();
+    hz.stop().get();
     std::cout << "Finished" << std::endl;
 
     return 0;

--- a/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
+++ b/examples/network-configuration/connection-strategy/DoNotReconnectToCluster.cpp
@@ -35,6 +35,7 @@ int main() {
     config.get_connection_strategy_config().set_reconnect_mode(hazelcast::client::config::client_connection_strategy_config::OFF);
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
 

--- a/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
+++ b/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
@@ -64,7 +64,7 @@ int main() {
         std::cout << "The client is connected to the cluster within 10 seconds after disconnection as expected." << std::endl;
     }
 
-    hz.shutdown().get();
+    hz.stop().get();
     std::cout << "Finished" << std::endl;
 
     return 0;

--- a/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
+++ b/examples/network-configuration/connection-strategy/ReconnectAsync.cpp
@@ -45,6 +45,7 @@ int main() {
     config.get_connection_strategy_config().set_reconnect_mode(hazelcast::client::config::client_connection_strategy_config::ASYNC);
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
 

--- a/examples/network-configuration/connection-strategy/StartAsync.cpp
+++ b/examples/network-configuration/connection-strategy/StartAsync.cpp
@@ -58,7 +58,7 @@ int main() {
 
     std::cout << "Finished" << std::endl;
 
-    hz.shutdown().get();
+    hz.stop().get();
 
     return 0;
 }

--- a/examples/network-configuration/connection-strategy/StartAsync.cpp
+++ b/examples/network-configuration/connection-strategy/StartAsync.cpp
@@ -44,6 +44,7 @@ int main() {
     );
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto connection_future = connected.get_future();
     if (connection_future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {

--- a/examples/network-configuration/connection-strategy/cluster_connection_retry.cpp
+++ b/examples/network-configuration/connection-strategy/cluster_connection_retry.cpp
@@ -45,6 +45,7 @@ int main() {
             std::chrono::milliseconds(100)).set_max_backoff_duration(std::chrono::seconds(3));
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
 

--- a/examples/network-configuration/connection-strategy/cluster_connection_retry.cpp
+++ b/examples/network-configuration/connection-strategy/cluster_connection_retry.cpp
@@ -64,7 +64,7 @@ int main() {
         std::cout << "The client is connected to the cluster within 10 seconds after disconnection as expected." << std::endl;
     }
 
-    hz.shutdown().get();
+    hz.stop().get();
     std::cout << "Finished" << std::endl;
 
     return 0;

--- a/examples/network-configuration/shuffle-memberlist/ShuffleMemberList.cpp
+++ b/examples/network-configuration/shuffle-memberlist/ShuffleMemberList.cpp
@@ -36,6 +36,7 @@ int main() {
     // "Trying to connect to 127.0.0.1:5702 as owner member" but this will fail since no such member exist.
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     std::cout << "Finished" << std::endl;
 

--- a/examples/network-configuration/socket-interceptor/main.cpp
+++ b/examples/network-configuration/socket-interceptor/main.cpp
@@ -27,6 +27,7 @@ int main() {
     );
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     std::cout << "Finished" << std::endl;
 

--- a/examples/network-configuration/tcpip/main.cpp
+++ b/examples/network-configuration/tcpip/main.cpp
@@ -24,6 +24,7 @@ int main() {
                                                                             {"192.168.1.10", 5701}});
 
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("test map");
 

--- a/examples/pipeline/PipeliningDemo.cpp
+++ b/examples/pipeline/PipeliningDemo.cpp
@@ -30,7 +30,10 @@ using namespace hazelcast::util;
 
 class PipeliningDemo {
 public:
-    PipeliningDemo() : client_(), map_(client_.get_map("map").get()), gen_(rd_()) {}
+    PipeliningDemo() : gen_(rd_()) {
+        client_.start().get();
+        map_ = client_.get_map("map").get();
+    }
 
     void init() {
         for (int l = 0; l < keyDomain; l++) {

--- a/examples/replicated-map/basics/FillReplicatedMap.cpp
+++ b/examples/replicated-map/basics/FillReplicatedMap.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_replicated_map("map").get();
 
     map->put<std::string, std::string>("1", "Tokyo").get();

--- a/examples/replicated-map/basics/PrintAllReplicatedMap.cpp
+++ b/examples/replicated-map/basics/PrintAllReplicatedMap.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_replicated_map("map").get();
     for (auto &entry : map->entry_set<std::string, std::string>().get()) {
         std::cout << entry.first << " " << entry.second << std::endl;

--- a/examples/replicated-map/entry-listener/ListeningReplicatedMap.cpp
+++ b/examples/replicated-map/entry-listener/ListeningReplicatedMap.cpp
@@ -19,6 +19,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_replicated_map("map").get();
 
     auto listener_id = map->add_entry_listener(

--- a/examples/replicated-map/entry-listener/ModifyReplicatedMap.cpp
+++ b/examples/replicated-map/entry-listener/ModifyReplicatedMap.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_replicated_map("somemap").get();
 
     std::ostringstream out;

--- a/examples/serialization/custom/main.cpp
+++ b/examples/serialization/custom/main.cpp
@@ -55,6 +55,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
     map->put("foo", Person{"bar", true, 40}).get();
     std::cout << *(map->get<std::string, Person>("foo").get()) << std::endl;

--- a/examples/serialization/globalserializer/main.cpp
+++ b/examples/serialization/globalserializer/main.cpp
@@ -46,6 +46,7 @@ int main() {
     hazelcast::client::client_config config;
     config.get_serialization_config().set_global_serializer(std::make_shared<MyGlobalSerializer>());
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("map").get();
     map->put("foo", Person{"first last name", false, 19}).get();

--- a/examples/serialization/identified-data-serializable/main.cpp
+++ b/examples/serialization/identified-data-serializable/main.cpp
@@ -58,6 +58,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
     map->put("foo", Person{"bar", true, 40}).get();
     std::cout << *(map->get<std::string, Person>("foo").get()) << std::endl;

--- a/examples/serialization/json/main.cpp
+++ b/examples/serialization/json/main.cpp
@@ -20,6 +20,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
 
     map->put("item1", hazelcast::client::hazelcast_json_value("{ \"age\": 4 }")).get();

--- a/examples/serialization/portable/main.cpp
+++ b/examples/serialization/portable/main.cpp
@@ -59,6 +59,8 @@ namespace hazelcast {
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_map("map").get();
     map->put("foo", Person{"bar", true, 40}).get();
     std::cout << *(map->get<std::string, Person>("foo").get()) << std::endl;

--- a/examples/soak-test/soak_test.cpp
+++ b/examples/soak-test/soak_test.cpp
@@ -61,6 +61,7 @@ int main(int argc, char *args[]) {
 
     config.get_network_config().add_address(hazelcast::client::address(server_address, 5701));
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
     hazelcast::client::spi::ClientContext context(hz);
     auto &logger_ = context.get_logger();
     auto map = hz.get_map("test").get();

--- a/examples/spi/proxy/main.cpp
+++ b/examples/spi/proxy/main.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     auto map = hz.get_distributed_object<hazelcast::client::iqueue>("queue distributed object").get();
 
     std::cout << "Finished" << std::endl;

--- a/examples/tls/BasicTLSClient.cpp
+++ b/examples/tls/BasicTLSClient.cpp
@@ -30,6 +30,7 @@ int main() {
                                        // https://www.openssl.org/docs/man1.0.2/apps/ciphers.html)
     
     hazelcast::client::hazelcast_client hz(std::move(config));
+    hz.start().get();
 
     auto map = hz.get_map("MyMap").get();
     

--- a/examples/transactions/transaction-basic/TransactionBasic.cpp
+++ b/examples/transactions/transaction-basic/TransactionBasic.cpp
@@ -18,6 +18,8 @@
 int main() {
     hazelcast::client::hazelcast_client hz;
 
+    hz.start().get();
+
     hazelcast::client::transaction_options txOptions;
     txOptions.set_timeout(std::chrono::seconds(10));
 

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
@@ -2750,7 +2750,7 @@ namespace hazelcast {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
-                    msg.set_operation_name("executorservice.shutdown");
+                    msg.set_operation_name("executorservice.stop");
 
                     msg.set_message_type(static_cast<int32_t>(524544));
                     msg.set_partition_id(-1);

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
@@ -1502,7 +1502,7 @@ namespace hazelcast {
                 fencedlock_getlockownership_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
-                 * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
+                 * Initiates an orderly stop in which previously submitted tasks are executed, but no new tasks will be accepted.
                  * Invocation has no additional effect if already shut down.
                  */
                 ClientMessage HAZELCAST_API executorservice_shutdown_encode(const std::string  & name);

--- a/hazelcast/include/hazelcast/client/config/connection_retry_config.h
+++ b/hazelcast/include/hazelcast/client/config/connection_retry_config.h
@@ -77,7 +77,7 @@ namespace hazelcast {
 
                 /**
                  * Timeout value for the client to give up to connect to the current cluster
-                 *  Theclient can shutdown after reaching the timeout.
+                 * The client can stop after reaching the timeout.
                  *
                  * @return cluster_connect_timeout_
                  */
@@ -85,7 +85,7 @@ namespace hazelcast {
 
                 /**
                  * @param cluster_connect_timeout timeout for the client to give up to connect to the current cluster
-                 *                                    The client can shutdown after reaching the timeout.
+                 *                                    The client can stop after reaching the timeout.
                  * @return updated connection_retry_config
                  */
                 connection_retry_config &

--- a/hazelcast/include/hazelcast/client/hazelcast_client.h
+++ b/hazelcast/include/hazelcast/client/hazelcast_client.h
@@ -48,18 +48,24 @@ namespace hazelcast {
             friend class spi::ClientContext;
         public:
             /**
-            * Constructs a hazelcastClient with default configurations.
+            * Constructs a hazelcast_client with default configurations.
             */
             hazelcast_client();
-            
+
             /**
-            * Constructs a hazelcastClient with given ClientConfig.
-            * Note: client_config will be copied.
+            * Constructs a hazelcast_client with given config.
             * @param config client configuration to start the client with
             */
             explicit hazelcast_client(client_config config);
 
             virtual ~hazelcast_client();
+
+            /**
+             * Initializes the client. Connects to the cluster. Throws exception if can not initialize.
+             *
+             * @return the future for start completion.
+             */
+            boost::future<void> start();
 
             /**
              * Returns the name of this Hazelcast instance.

--- a/hazelcast/include/hazelcast/client/hazelcast_client.h
+++ b/hazelcast/include/hazelcast/client/hazelcast_client.h
@@ -220,7 +220,7 @@ namespace hazelcast {
              * on the Hazelcast cluster.
              * <p>
              * <p><b>Note:</b> Note that it doesn't support {@code invokeAll/Any}
-             * and doesn't have standard shutdown behavior</p>
+             * and doesn't have standard stop behavior</p>
              *
              * @param name name of the executor service
              * @return the distributed executor service for the given name
@@ -290,12 +290,12 @@ namespace hazelcast {
             /**
             * Shuts down this hazelcast_client.
             */
-            boost::future<void> shutdown();
+            boost::future<void> stop();
 
             /**
              * Returns the lifecycle service for this instance.
              * <p>
-             * LifecycleService allows you to shutdown this HazelcastInstance and listen for the lifecycle events.
+             * LifecycleService allows you to stop this HazelcastInstance and listen for the lifecycle events.
              *
              * @return the lifecycle service for this instance
              */

--- a/hazelcast/include/hazelcast/client/impl/hazelcast_client_instance_impl.h
+++ b/hazelcast/include/hazelcast/client/impl/hazelcast_client_instance_impl.h
@@ -113,7 +113,7 @@ namespace hazelcast {
                 */
                 ~hazelcast_client_instance_impl();
 
-                void start();
+                boost::future<void> start();
 
                 /**
                  * Returns the name of this Hazelcast instance.
@@ -130,6 +130,7 @@ namespace hazelcast {
                 */
                 template<typename T>
                 boost::shared_future<std::shared_ptr<T>> get_distributed_object(const std::string& name) {
+                    check_started();
                     return proxy_manager_.get_or_create_proxy<T>(T::SERVICE_NAME, name);
                 }
 
@@ -187,7 +188,7 @@ namespace hazelcast {
                 /**
                 * Shuts down this hazelcast_client.
                 */
-                void shutdown();
+                boost::future<void> stop();
 
                 spi::lifecycle_service &get_lifecycle_service();
 
@@ -253,6 +254,8 @@ namespace hazelcast {
                 std::vector<std::shared_ptr<connection::AddressProvider> > create_address_providers();
 
                 void initalize_near_cache_manager();
+
+                void check_started() const;
             };
 
             template<>

--- a/hazelcast/include/hazelcast/client/lifecycle_listener.h
+++ b/hazelcast/include/hazelcast/client/lifecycle_listener.h
@@ -114,7 +114,7 @@ namespace hazelcast {
             }
 
             /**
-             * Set an handler function to be invoked when the client's shutdown has completed
+             * Set an handler function to be invoked when the client's stop has completed
              * \param h a `void` function object that is callable without any parameters.
              * \return `*this`
              */

--- a/hazelcast/include/hazelcast/client/spi/ClientProxy.h
+++ b/hazelcast/include/hazelcast/client/spi/ClientProxy.h
@@ -63,8 +63,8 @@ namespace hazelcast {
 
                 /**
                  * Internal API.
-                 * Called before client shutdown.
-                 * Overriding implementations can add shutdown specific logic here.
+                 * Called before client stop.
+                 * Overriding implementations can add stop specific logic here.
                  */
                 virtual void on_shutdown();
 

--- a/hazelcast/include/hazelcast/client/spi/lifecycle_service.h
+++ b/hazelcast/include/hazelcast/client/spi/lifecycle_service.h
@@ -65,11 +65,13 @@ namespace hazelcast {
 
                 bool is_running();
 
+                bool set_active();
+
             private:
                 ClientContext &client_context_;
                 std::unordered_map<boost::uuids::uuid, lifecycle_listener, boost::hash<boost::uuids::uuid>> listeners_;
                 std::mutex listener_lock_;
-                std::atomic<bool> active_{ false };
+                std::atomic<bool> active_{false};
                 boost::latch shutdown_completed_latch_;
                 std::mt19937 random_generator_{std::random_device{}()};
                 boost::uuids::basic_random_generator<std::mt19937> uuid_generator_{random_generator_};

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -116,9 +116,7 @@ namespace hazelcast {
             return client_impl_->get_local_endpoint();
         }
 
-        hazelcast_client::~hazelcast_client() {
-            client_impl_->stop().get();
-        }
+        hazelcast_client::~hazelcast_client() = default;
 
         cp::cp_subsystem &hazelcast_client::get_cp_subsystem() {
             return client_impl_->get_cp_subsystem();
@@ -186,7 +184,9 @@ namespace hazelcast {
                 statistics_.reset(new statistics::Statistics(client_context_));
             }
 
-            hazelcast_client_instance_impl::~hazelcast_client_instance_impl() = default;
+            hazelcast_client_instance_impl::~hazelcast_client_instance_impl() {
+                stop().get();
+            }
 
             boost::future<void> hazelcast_client_instance_impl::start() {
                 return lifecycle_service_.start().then(boost::launch::sync, [=](boost::future<bool> f) {

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -373,8 +373,8 @@ namespace hazelcast {
 
             void hazelcast_client_instance_impl::check_started() const {
                 if (!lifecycle_service_.is_started()) {
-                    throw exception::illegal_state("hazelcast_client_instance_impl::check_started",
-                                                   "Client is not started!");
+                    throw exception::hazelcast_client_not_active("hazelcast_client_instance_impl::check_started",
+                                                                 "Client is not started!");
                 }
             }
 

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -371,6 +371,7 @@ namespace hazelcast {
                     return;
                 }
 
+                std::weak_ptr<client::impl::hazelcast_client_instance_impl> this_client = client_.get_hazelcast_client_implementation();
                 boost::asio::post(executor_->get_executor(), [=]() {
                     try {
                         do_connect_to_cluster();
@@ -393,7 +394,7 @@ namespace hazelcast {
                                           % e.what())
                         );
 
-                        shutdown_with_external_thread(client_.get_hazelcast_client_implementation());
+                        shutdown_with_external_thread(this_client);
                     }
                 });
             }

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -353,13 +353,13 @@ namespace hazelcast {
                     }
 
                     try {
-                        clientInstance->get_lifecycle_service().shutdown();
+                        clientInstance->get_lifecycle_service().stop();
                     } catch (exception::iexception &e) {
                         HZ_LOG(*clientInstance->get_logger(), severe,
-                            boost::str(boost::format("Exception during client shutdown "
-                                                     "%1%.clientShutdown-:%2%")
-                                                     % clientInstance->get_name()
-                                                     % e)
+                               boost::str(boost::format("Exception during client stop "
+                                                        "%1%.stop()-:%2%")
+                                          % clientInstance->get_name()
+                                          % e)
                         );
                     }
                 }).detach();
@@ -558,9 +558,7 @@ namespace hazelcast {
                 connection_listeners_.add(connection_listener);
             }
 
-            ClientConnectionManagerImpl::~ClientConnectionManagerImpl() {
-                shutdown();
-            }
+            ClientConnectionManagerImpl::~ClientConnectionManagerImpl() = default;
 
             logger &ClientConnectionManagerImpl::get_logger() {
                 return client_.get_logger();
@@ -569,7 +567,7 @@ namespace hazelcast {
             void ClientConnectionManagerImpl::check_client_active() {
                 if (!client_.get_lifecycle_service().is_running()) {
                     BOOST_THROW_EXCEPTION(exception::hazelcast_client_not_active(
-                                                  "ClientConnectionManagerImpl::check_client_active", "Client is shutdown"));
+                                                  "ClientConnectionManagerImpl::check_client_active", "Client is stopped."));
                 }
             }
 
@@ -648,7 +646,7 @@ namespace hazelcast {
 
                 // If the client is shutdown in parallel, we need to close this new connection.
                 if (!client_.get_lifecycle_service().is_running()) {
-                    connection->close("Client is shutdown");
+                    connection->close("Client is stopped.");
                 }
 
                 return connection;

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -283,12 +283,15 @@ namespace hazelcast {
                 }
             }
 
-            bool lifecycle_service::start() {
+            bool lifecycle_service::set_active() {
                 bool expected = false;
                 if (!active_.compare_exchange_strong(expected, true)) {
                     return false;
                 }
+                return true;
+            }
 
+            bool lifecycle_service::start() {
                 fire_lifecycle_event(lifecycle_event::STARTED);
 
                 client_context_.get_client_execution_service().start();

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -840,10 +840,15 @@ namespace hazelcast {
 namespace hazelcast {
     namespace client {
         namespace test {
+            class StartStopTest : public ClientTestSupport {
+            };
+
             class ClientConnectionTest : public ClientTestSupport {
             protected:
 #ifdef HZ_BUILD_WITH_SSL
-                std::vector<hazelcast::client::internal::socket::SSLSocket::CipherInfo> get_ciphers(client_config config) {
+
+                std::vector<hazelcast::client::internal::socket::SSLSocket::CipherInfo>
+                get_ciphers(client_config config) {
                     hazelcast_client client(std::move(config));
                     client.start().get();
                     spi::ClientContext context(client);
@@ -1017,7 +1022,6 @@ namespace hazelcast {
 
                 auto start_time = std::chrono::steady_clock::now();
                 hazelcast_client client(std::move(clientConfig));
-                client.start().get();
                 ASSERT_THROW(client.start().get(), exception::illegal_state);
                 ASSERT_GE(std::chrono::steady_clock::now() - start_time, timeout);
             }
@@ -1043,7 +1047,7 @@ namespace hazelcast {
                 ASSERT_OPEN_EVENTUALLY(startedLatch);
                 ASSERT_OPEN_EVENTUALLY(connectedLatch);
 
-                client.shutdown().get();
+                client.stop().get();
 
                 ASSERT_OPEN_EVENTUALLY(shuttingDownLatch);
                 ASSERT_OPEN_EVENTUALLY(shutdownLatch);
@@ -2216,13 +2220,13 @@ namespace hazelcast {
             }
 
             ClientTxnTest::~ClientTxnTest() {
-                client_->shutdown().get();
+                client_->stop().get();
                 server_->shutdown();
                 second_->shutdown();
             }
 
             TEST_F(ClientTxnTest, testTxnConnectAfterClientShutdown) {
-                client_->shutdown().get();
+                client_->stop().get();
                 ASSERT_THROW(client_->new_transaction_context(), exception::hazelcast_client_not_active);
             }
 
@@ -2305,7 +2309,7 @@ namespace hazelcast {
                 std::string value = random_string();
                 queue->offer(value).get();
 
-                client_->shutdown().get();
+                client_->stop().get();
 
                 ASSERT_THROW(context.commit_transaction().get(), exception::transaction);
             }

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -499,6 +499,7 @@ namespace hazelcast {
                 HazelcastServer instance(*g_srvFactory);
                 auto test_name = get_test_name();
                 hazelcast_client client(std::move(client_config().set_instance_name(test_name)));
+                client.start().get();
                 ASSERT_EQ(test_name, client.get_name());
             }
 
@@ -569,6 +570,7 @@ namespace hazelcast {
                 TEST_F(ConfiguredBehaviourTest, testAsyncStartTrueNoCluster) {
                     client_config_.get_connection_strategy_config().set_async_start(true);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
 
                     ASSERT_THROW((client.get_map(random_map_name()).get()),
                                  exception::hazelcast_client_offline);
@@ -579,6 +581,7 @@ namespace hazelcast {
                 TEST_F(ConfiguredBehaviourTest, testAsyncStartTrueNoCluster_thenShutdown) {
                     client_config_.get_connection_strategy_config().set_async_start(true);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
                     client.shutdown().get();
                     ASSERT_THROW((client.get_map(random_map_name()).get()), exception::hazelcast_client_not_active);
 
@@ -603,6 +606,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_async_start(true);
 
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
 
                     ASSERT_TRUE(client.get_lifecycle_service().is_running());
 
@@ -622,6 +626,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_reconnect_mode(
                             config::client_connection_strategy_config::OFF);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
                     boost::latch shutdownLatch(1);
                     client.add_lifecycle_listener(
                         lifecycle_listener()
@@ -649,6 +654,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_reconnect_mode(
                             config::client_connection_strategy_config::OFF);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
                     boost::latch shutdownLatch(1);
                     client.add_lifecycle_listener(
                         lifecycle_listener()
@@ -710,6 +716,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_reconnect_mode(
                             config::client_connection_strategy_config::ASYNC);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
                     ASSERT_TRUE(client.get_lifecycle_service().is_running());
                     ASSERT_OPEN_EVENTUALLY(connectedLatch);
 
@@ -736,6 +743,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_reconnect_mode(
                             config::client_connection_strategy_config::ASYNC);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
 
                     ASSERT_OPEN_EVENTUALLY(initialConnectionLatch);
 
@@ -776,6 +784,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_reconnect_mode(
                             config::client_connection_strategy_config::ASYNC);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
 
                     ASSERT_TRUE(client.get_lifecycle_service().is_running());
 
@@ -820,6 +829,7 @@ namespace hazelcast {
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(client_config());
+                    client->start().get();
 
                     map = client->get_map(MAP_NAME).get();
                     expected = new std::vector<int>;
@@ -1726,6 +1736,7 @@ namespace hazelcast {
                     config.get_serialization_config().set_byte_order(GetParam());
 
                     client_.reset(new hazelcast_client(std::move(config)));
+                    client_->start().get();
                     map_ = client_->get_map("serialization_with_server_map").get();
                 }
 

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -575,17 +575,17 @@ namespace hazelcast {
                     ASSERT_THROW((client.get_map(random_map_name()).get()),
                                  exception::hazelcast_client_offline);
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testAsyncStartTrueNoCluster_thenShutdown) {
                     client_config_.get_connection_strategy_config().set_async_start(true);
                     hazelcast_client client(std::move(client_config_));
                     client.start().get();
-                    client.shutdown().get();
+                    client.stop().get();
                     ASSERT_THROW((client.get_map(random_map_name()).get()), exception::hazelcast_client_not_active);
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testAsyncStartTrue) {
@@ -617,7 +617,7 @@ namespace hazelcast {
                     auto map = client.get_map(random_map_name()).get();
                     map->size().get();
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testReconnectModeOFFSingleMember) {
@@ -644,7 +644,7 @@ namespace hazelcast {
 
                     ASSERT_THROW(map->put(1, 5).get(), exception::hazelcast_client_not_active);
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testReconnectModeOFFTwoMembers) {
@@ -673,7 +673,7 @@ namespace hazelcast {
 
                     ASSERT_THROW(map->put(1, 5).get(), exception::hazelcast_client_not_active);
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testReconnectModeASYNCSingleMemberInitiallyOffline) {
@@ -682,6 +682,7 @@ namespace hazelcast {
                     client_config_.get_connection_strategy_config().set_reconnect_mode(
                             config::client_connection_strategy_config::OFF);
                     hazelcast_client client(std::move(client_config_));
+                    client.start().get();
                     boost::latch shutdownLatch(1);
                     client.add_lifecycle_listener(
                         lifecycle_listener()
@@ -690,7 +691,7 @@ namespace hazelcast {
                             })
                     );
 
-// no exception at this point
+                    // no exception at this point
                     auto map = client.get_map(random_map_name()).get();
                     map->put(1, 5).get();
 
@@ -699,7 +700,7 @@ namespace hazelcast {
 
                     ASSERT_THROW(map->put(1, 5).get(), exception::hazelcast_client_not_active);
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testReconnectModeASYNCSingleMember) {
@@ -723,7 +724,7 @@ namespace hazelcast {
                     auto map = client.get_map(random_map_name()).get();
                     map->size().get();
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testReconnectModeASYNCSingleMemberStartLate) {
@@ -764,7 +765,7 @@ namespace hazelcast {
                     auto map = client.get_map(random_map_name()).get();
                     map->size().get();
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
 
                 TEST_F(ConfiguredBehaviourTest, testReconnectModeASYNCTwoMembers) {
@@ -814,7 +815,7 @@ namespace hazelcast {
 
                     map->get<int, int>(1).get();
 
-                    client.shutdown().get();
+                    client.stop().get();
                 }
             }
         }

--- a/hazelcast/test/src/HazelcastTests3.cpp
+++ b/hazelcast/test/src/HazelcastTests3.cpp
@@ -229,7 +229,9 @@ namespace hazelcast {
                 static hazelcast_client* create_client() {
                     auto config = get_config();
                     config.set_cluster_name("replicated-map-binary-test");
-                    return new hazelcast_client(std::move(config));
+                    auto client = new hazelcast_client(std::move(config));
+                    client->start().get();
+                    return client;
                 }
 
                 static void SetUpTestCase() {
@@ -512,7 +514,9 @@ namespace hazelcast {
                 std::string mapName = random_string();
 
                 hazelcast_client client1(get_client_config_with_near_cache_invalidation_enabled());
+                client1.start().get();
                 hazelcast_client client2(get_client_config_with_near_cache_invalidation_enabled());
+                client2.start().get();
 
                 auto replicatedMap1 = client1.get_replicated_map(mapName).get();
 
@@ -606,7 +610,9 @@ namespace hazelcast {
                     instance1 = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
+                    client->start().get();
                     client2 = new hazelcast_client(get_config());
+                    client2->start().get();
                 }
 
                 static void TearDownTestCase() {
@@ -820,6 +826,7 @@ namespace hazelcast {
 
                 void create_no_near_cache_context() {
                     client_ = std::unique_ptr<hazelcast_client>(new hazelcast_client(get_config()));
+                    client_->start().get();
                     no_near_cache_map_ = client_->get_replicated_map(get_test_name()).get();
                 }
 
@@ -828,6 +835,7 @@ namespace hazelcast {
                     nearCachedClientConfig.add_near_cache_config(near_cache_config_);
                     near_cached_client_ = std::unique_ptr<hazelcast_client>(
                             new hazelcast_client(std::move(nearCachedClientConfig)));
+                    near_cached_client_->start().get();
                     near_cached_map_ = near_cached_client_->get_replicated_map(get_test_name()).get();
                     spi::ClientContext clientContext(*near_cached_client_);
                     near_cache_manager_ = &clientContext.get_near_cache_manager();
@@ -1256,6 +1264,7 @@ namespace hazelcast {
                     client_config_->add_near_cache_config(config);
 
                     client_ = std::unique_ptr<hazelcast_client>(new hazelcast_client(std::move(*client_config_)));
+                    client_->start().get();
                     map_ = client_->get_replicated_map(mapName).get();
                     return map_;
                 }

--- a/hazelcast/test/src/HazelcastTests3.cpp
+++ b/hazelcast/test/src/HazelcastTests3.cpp
@@ -719,10 +719,10 @@ namespace hazelcast {
                         no_near_cache_map_->destroy().get();
                     }
                     if (client_) {
-                        client_->shutdown().get();
+                        client_->stop().get();
                     }
                     if (near_cached_client_) {
-                        near_cached_client_->shutdown().get();
+                        near_cached_client_->stop().get();
                     }
                 }
 

--- a/hazelcast/test/src/HazelcastTests5.cpp
+++ b/hazelcast/test/src/HazelcastTests5.cpp
@@ -395,6 +395,7 @@ namespace hazelcast {
                     clientConfig.get_serialization_config().set_global_serializer(
                             std::make_shared<WriteReadIntGlobalSerializer>());
                     client = new hazelcast_client(std::move(clientConfig));
+                    client->start().get();
                     unknown_object_map = client->get_map("UnknownObject").get();
                 }
 
@@ -443,6 +444,7 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
+                    client->start().get();
                     int_map = client->get_map("IntMap").get();
                 }
 
@@ -510,6 +512,7 @@ namespace hazelcast {
                     client_config clientConfig(get_config());
                     clientConfig.set_property(client_properties::PROP_HEARTBEAT_TIMEOUT, "20");
                     client = new hazelcast_client(std::move(clientConfig));
+                    client->start().get();
                     map = client->get_map("map").get();
                 }
 
@@ -689,10 +692,11 @@ namespace hazelcast {
                     return config;
                 }
 
-                ClientMapTest() : client_(hazelcast_client(GetParam()())),
-                                  imap_(client_.get_map(imapName).get()),
-                                  int_map_(client_.get_map(intMapName).get()),
-                                  employees_(client_.get_map(employeesMapName).get()) {
+                ClientMapTest() : client_(hazelcast_client(GetParam()())) {
+                    client_.start().get();
+                    imap_ = client_.get_map(imapName).get();
+                    int_map_ = client_.get_map(intMapName).get();
+                    employees_ = client_.get_map(employeesMapName).get();
                 }
 
                 static void SetUpTestCase() {

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -141,6 +141,7 @@ namespace hazelcast {
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
+                    client->start().get();
                     mm = client->get_multi_map("MyMultiMap").get();
                 }
 
@@ -372,6 +373,7 @@ namespace hazelcast {
                     client_config clientConfig = get_config();
 #endif // HZ_BUILD_WITH_SSL
                     client = new hazelcast_client(std::move(clientConfig));
+                    client->start().get();
                     list = client->get_list("MyList").get();
                 }
 
@@ -572,6 +574,7 @@ namespace hazelcast {
                     instance = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(std::move(get_config().backup_acks_enabled(false)));
+                    client->start().get();
                     q = client->get_queue("MyQueue").get();
                 }
 
@@ -845,6 +848,7 @@ namespace hazelcast {
                         instances.push_back(new HazelcastServer(*factory));
                     }
                     client = new hazelcast_client(std::move(client_config().set_cluster_name("executor-test")));
+                    client->start().get();
                 }
 
                 static void TearDownTestCase() {
@@ -1687,7 +1691,7 @@ namespace hazelcast {
 
                     clientConfig.set_property(client_properties::PROP_AWS_MEMBER_PORT, "-1");
 
-                    ASSERT_THROW(hazelcast_client hazelcastClient(std::move(clientConfig)),
+                    ASSERT_THROW(hazelcast_client(std::move(clientConfig)).start().get(),
                                  exception::invalid_configuration);
                 }
             }
@@ -1712,7 +1716,8 @@ namespace hazelcast {
 
                     clientConfig.set_property(client_properties::PROP_AWS_MEMBER_PORT, "60000");
                     clientConfig.get_network_config().get_aws_config().set_enabled(true).
-                            set_access_key(std::getenv("AWS_ACCESS_KEY_ID")).set_secret_key(std::getenv("AWS_SECRET_ACCESS_KEY")).
+                            set_access_key(std::getenv("AWS_ACCESS_KEY_ID")).set_secret_key(
+                            std::getenv("AWS_SECRET_ACCESS_KEY")).
                             set_tag_key("aws-test-tag").set_tag_value("aws-tag-value-1");
 
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -1721,6 +1726,7 @@ namespace hazelcast {
                     clientConfig.get_network_config().get_aws_config().set_inside_aws(false);
 #endif
                     hazelcast_client hazelcastClient(std::move(clientConfig));
+                    hazelcastClient.start().get();
                     auto map = hazelcastClient.get_map("myMap").get();
                     map->put(5, 20).get();
                     auto val = map->get<int, int>(5).get();
@@ -1743,6 +1749,7 @@ namespace hazelcast {
 #endif
 
                     hazelcast_client hazelcastClient(std::move(clientConfig));
+                    hazelcastClient.start().get();
                     auto map = hazelcastClient.get_map("myMap").get();
                     map->put(5, 20).get();
                     auto val = map->get<int, int>(5).get();
@@ -1770,6 +1777,7 @@ namespace hazelcast {
                     FIPS_mode_set(1);
 
                     hazelcast_client hazelcastClient(std::move(clientConfig));
+                    hazelcastClient.start().get();
                     auto map = hazelcastClient.get_map("myMap").get();
                     map->put(5, 20);
                     auto val = map->get<int, int>(5).get();
@@ -1790,7 +1798,7 @@ namespace hazelcast {
                             "aws-test-tag").set_tag_value("aws-tag-value-1").set_inside_aws(true);
 
                     hazelcast_client hazelcastClient(std::move(clientConfig));
-                }
+                hazelcastClient.start().get();                }
 
                 TEST_F (AwsClientTest, testRetrieveCredentialsFromInstanceProfileDefaultIamRoleAndConnect) {
                     client_config clientConfig = get_config();
@@ -1800,7 +1808,7 @@ namespace hazelcast {
                             "aws-test-tag").set_tag_value("aws-tag-value-1").set_inside_aws(true);
 
                     hazelcast_client hazelcastClient(std::move(clientConfig));
-                }
+                hazelcastClient.start().get();                }
 #endif
             }
         }

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -248,6 +248,7 @@ namespace hazelcast {
 
                 void create_no_near_cache_context() {
                     client_ = std::unique_ptr<hazelcast_client>(new hazelcast_client(get_config()));
+                    client_->start().get();
                     no_near_cache_map_ = client_->get_map(get_test_name()).get();
                 }
 
@@ -256,6 +257,7 @@ namespace hazelcast {
                     near_cached_client_config_.add_near_cache_config(near_cache_config_);
                     near_cached_client_ = std::unique_ptr<hazelcast_client>(
                             new hazelcast_client(std::move(near_cached_client_config_)));
+                    near_cached_client_->start().get();
                     near_cached_map_ = near_cached_client_->get_map(get_test_name()).get();
                     spi::ClientContext clientContext(*near_cached_client_);
                     near_cache_manager_ = &clientContext.get_near_cache_manager();
@@ -695,6 +697,7 @@ namespace hazelcast {
                     client_config_->add_near_cache_config(config);
 
                     client_.reset(new hazelcast_client(std::move(*client_config_)));
+                    client_->start().get();
                     map_ = client_->get_map(mapName).get();
                     return map_;
                 }
@@ -799,6 +802,7 @@ namespace hazelcast {
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
+                    client->start().get();
                     set = client->get_set("MySet").get();
                 }
 
@@ -967,6 +971,7 @@ namespace hazelcast {
                 static void SetUpTestCase() {
                     instance = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client(get_config());
+                    client->start().get();
                 }
 
                 static void TearDownTestCase() {
@@ -1085,6 +1090,7 @@ namespace hazelcast {
                 relConfig.set_read_batch_size(2);
                 clientConfig.add_reliable_topic_config(relConfig);
                 hazelcast_client configClient(std::move(clientConfig));
+                configClient.start().get();
 
                 ASSERT_NO_THROW(topic_ = configClient.get_reliable_topic("testConfig").get());
 
@@ -1338,7 +1344,7 @@ namespace hazelcast {
                         });
 
                         hazelcast_client hazelcastClient(std::move(clientConfig));
-
+                        hazelcastClient.start().get();
                         auto map = hazelcastClient.get_map("cppDefault").get();
 
                         std::vector<std::future<void>> futures;
@@ -1405,6 +1411,7 @@ namespace hazelcast {
                 clientConfig.get_network_config().set_smart_routing(false);
 
                 hazelcast_client client(std::move(clientConfig));
+                client.start().get();
 
                 auto map = client.get_map("m").get();
                 int expected = 1000;
@@ -1430,6 +1437,7 @@ namespace hazelcast {
                         std::chrono::seconds(10));
 
                 hazelcast_client client(std::move(clientConfig));
+                client.start().get();
 
                 // 3. Get a map
                 auto map = client.get_map("IssueTest_map").get();
@@ -1464,6 +1472,7 @@ namespace hazelcast {
 
                 // start a client
                 hazelcast_client client(get_config());
+                client.start().get();
 
                 auto map = client.get_map("Issue221_test_map").get();
 

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -140,10 +140,10 @@ namespace hazelcast {
                         no_near_cache_map_->destroy().get();
                     }
                     if (client_) {
-                        client_->shutdown().get();
+                        client_->stop().get();
                     }
                     if (near_cached_client_) {
-                        near_cached_client_->shutdown().get();
+                        near_cached_client_->stop().get();
                     }
                 }
 

--- a/hazelcast/test/src/cp_test.cpp
+++ b/hazelcast/test/src/cp_test.cpp
@@ -38,6 +38,7 @@ namespace hazelcast {
 
                     virtual void SetUp() {
                         client_.reset(new hazelcast_client(get_client_config()));
+                        client_->start().get();
                         auto test_name = get_test_name();
                         cp_structure_ = get_cp_structure(test_name + "@cp_test_group");
                     }
@@ -703,6 +704,7 @@ namespace hazelcast {
                 TEST_F(basic_lock_test, test_lock_auto_release_on_client_shutdown) {
                     hazelcast_client c(
                             std::move(get_config().set_cluster_name(client_->get_client_config().get_cluster_name())));
+                    c.start().get();
                     auto proxy_name = get_test_name();
                     auto l = c.get_cp_subsystem().get_lock(proxy_name).get();
                     l->lock().get();
@@ -1036,6 +1038,7 @@ namespace hazelcast {
                 TEST_F(basic_sessionless_semaphore_test, test_acquire_on_multiple_proxies) {
                     hazelcast_client client2(
                             std::move(client_config().set_cluster_name(client_->get_client_config().get_cluster_name())));
+                    client2.start().get();
                     auto semaphore2 = client2.get_cp_subsystem().get_semaphore(cp_structure_->get_name()).get();
                     ASSERT_TRUE(cp_structure_->init(1).get());
                     ASSERT_TRUE(cp_structure_->try_acquire().get());
@@ -1392,6 +1395,7 @@ namespace hazelcast {
                 TEST_F(basic_session_semaphore_test, test_acquire_on_multiple_proxies) {
                     hazelcast_client client2(
                             std::move(client_config().set_cluster_name(client_->get_client_config().get_cluster_name())));
+                    client2.start().get();
                     auto semaphore2 = client2.get_cp_subsystem().get_semaphore(cp_structure_->get_name()).get();
                     ASSERT_TRUE(cp_structure_->init(1).get());
                     ASSERT_TRUE(cp_structure_->try_acquire().get());

--- a/hazelcast/test/src/cp_test.cpp
+++ b/hazelcast/test/src/cp_test.cpp
@@ -709,7 +709,7 @@ namespace hazelcast {
                     auto l = c.get_cp_subsystem().get_lock(proxy_name).get();
                     l->lock().get();
 
-                    c.shutdown().get();
+                    c.stop().get();
 
                     std::ostringstream script;
                     script << "result = instance_0.getCPSubsystem().getLock(\"" << proxy_name


### PR DESCRIPTION
Separated client construction and start. The client start returns async future.

Made the lifecycle_service start and stop which are user api, return future.
    
Renamed client `shutdown` to `stop`.

