### PR TITLE
Change `boost::launch::deferred` continuations to `boost::launch::async` 

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
+++ b/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
@@ -227,7 +227,7 @@ namespace hazelcast {
                 wait_strategy wait_strategy_;
 
                 // following fields are updated inside synchronized(clientStateMutex)
-                std::mutex client_state_mutex_;
+                std::recursive_mutex client_state_mutex_;
                 util::SynchronizedMap<boost::uuids::uuid, Connection, boost::hash<boost::uuids::uuid>> active_connections_;
                 util::SynchronizedMap<int32_t, Connection> active_connection_ids_;
 #ifdef __linux__

--- a/hazelcast/include/hazelcast/client/hazelcast_client.h
+++ b/hazelcast/include/hazelcast/client/hazelcast_client.h
@@ -156,7 +156,7 @@ namespace hazelcast {
             */
             boost::shared_future<std::shared_ptr<reliable_topic>> get_reliable_topic(const std::string &name) {
                 return get_distributed_object<ringbuffer>(std::string(reliable_topic::TOPIC_RB_PREFIX) + name).then(
-                        boost::launch::async, [=](boost::shared_future<std::shared_ptr<ringbuffer>> f) {
+                        boost::launch::sync, [=](boost::shared_future<std::shared_ptr<ringbuffer>> f) {
                             auto rb = f.get();
                             return std::shared_ptr<reliable_topic>(new reliable_topic(rb, name, &rb->get_context()));
                         });

--- a/hazelcast/include/hazelcast/client/hazelcast_client.h
+++ b/hazelcast/include/hazelcast/client/hazelcast_client.h
@@ -156,7 +156,7 @@ namespace hazelcast {
             */
             boost::shared_future<std::shared_ptr<reliable_topic>> get_reliable_topic(const std::string &name) {
                 return get_distributed_object<ringbuffer>(std::string(reliable_topic::TOPIC_RB_PREFIX) + name).then(
-                        boost::launch::deferred, [=](boost::shared_future<std::shared_ptr<ringbuffer>> f) {
+                        boost::launch::async, [=](boost::shared_future<std::shared_ptr<ringbuffer>> f) {
                             auto rb = f.get();
                             return std::shared_ptr<reliable_topic>(new reliable_topic(rb, name, &rb->get_context()));
                         });

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -595,7 +595,7 @@ namespace hazelcast {
                     futures.push_back(get_all_internal(entry.first, entry.second));
                 }
 
-                return boost::when_all(futures.begin(), futures.end()).then(boost::launch::async,
+                return boost::when_all(futures.begin(), futures.end()).then(boost::launch::sync,
                                                                             [=](boost::future<boost::csbl::vector<boost::future<EntryVector>>> results_data) {
                                                                                 std::unordered_map<K, V> result;
                                                                                 for (auto &entryVectorFuture : results_data.get()) {
@@ -954,7 +954,7 @@ namespace hazelcast {
                     auto partitionId = partitionEntry.first;
                     resultFutures.push_back(put_all_internal(partitionId, std::move(partitionEntry.second)));
                 }
-                return boost::when_all(resultFutures.begin(), resultFutures.end()).then(boost::launch::async,
+                return boost::when_all(resultFutures.begin(), resultFutures.end()).then(boost::launch::sync,
                                                                                         [](boost::future<boost::csbl::vector<boost::future<protocol::ClientMessage>>> futures) {
                                                                                             for (auto &f : futures.get()) {
                                                                                                 f.get();

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -595,15 +595,18 @@ namespace hazelcast {
                     futures.push_back(get_all_internal(entry.first, entry.second));
                 }
 
-                return boost::when_all(futures.begin(), futures.end()).then(boost::launch::deferred,
+                return boost::when_all(futures.begin(), futures.end()).then(boost::launch::async,
                                                                             [=](boost::future<boost::csbl::vector<boost::future<EntryVector>>> results_data) {
                                                                                 std::unordered_map<K, V> result;
                                                                                 for (auto &entryVectorFuture : results_data.get()) {
-                                                                                    for(auto &entry : entryVectorFuture.get()) {
-                                                                                        auto val = to_object<V>(entry.second);
+                                                                                    for (auto &entry : entryVectorFuture.get()) {
+                                                                                        auto val = to_object<V>(
+                                                                                                entry.second);
                                                                                         // it is guaranteed that all values are non-null
                                                                                         assert(val.has_value());
-                                                                                        result[to_object<K>(entry.first).value()] = std::move(val.value());
+                                                                                        result[to_object<K>(
+                                                                                                entry.first).value()] = std::move(
+                                                                                                val.value());
                                                                                     }
                                                                                 }
                                                                                 return result;
@@ -951,7 +954,7 @@ namespace hazelcast {
                     auto partitionId = partitionEntry.first;
                     resultFutures.push_back(put_all_internal(partitionId, std::move(partitionEntry.second)));
                 }
-                return boost::when_all(resultFutures.begin(), resultFutures.end()).then(boost::launch::deferred,
+                return boost::when_all(resultFutures.begin(), resultFutures.end()).then(boost::launch::async,
                                                                                         [](boost::future<boost::csbl::vector<boost::future<protocol::ClientMessage>>> futures) {
                                                                                             for (auto &f : futures.get()) {
                                                                                                 f.get();

--- a/hazelcast/include/hazelcast/client/iqueue.h
+++ b/hazelcast/include/hazelcast/client/iqueue.h
@@ -138,7 +138,7 @@ namespace hazelcast {
             */
             template<typename E>
             boost::future<size_t> drain_to(std::vector<E> &elements) {
-                return proxy::IQueueImpl::drain_to_data().then(boost::launch::async,
+                return proxy::IQueueImpl::drain_to_data().then(boost::launch::sync,
                                                                [&](boost::future<std::vector<serialization::pimpl::data>> f) {
                                                                    return drain_items(std::move(f), elements);
                                                                });
@@ -153,7 +153,7 @@ namespace hazelcast {
             */
             template<typename E>
             boost::future<size_t> drain_to(std::vector<E> &elements, size_t max_elements) {
-                return proxy::IQueueImpl::drain_to_data(max_elements).then(boost::launch::async,
+                return proxy::IQueueImpl::drain_to_data(max_elements).then(boost::launch::sync,
                                                                            [&](boost::future<std::vector<serialization::pimpl::data>> f) {
                                                                                return drain_items(std::move(f),
                                                                                                   elements);

--- a/hazelcast/include/hazelcast/client/iqueue.h
+++ b/hazelcast/include/hazelcast/client/iqueue.h
@@ -138,9 +138,10 @@ namespace hazelcast {
             */
             template<typename E>
             boost::future<size_t> drain_to(std::vector<E> &elements) {
-                return proxy::IQueueImpl::drain_to_data().then(boost::launch::deferred, [&](boost::future<std::vector<serialization::pimpl::data>> f)  {
-                    return drain_items(std::move(f), elements);
-                });
+                return proxy::IQueueImpl::drain_to_data().then(boost::launch::async,
+                                                               [&](boost::future<std::vector<serialization::pimpl::data>> f) {
+                                                                   return drain_items(std::move(f), elements);
+                                                               });
             }
 
             /**
@@ -152,9 +153,11 @@ namespace hazelcast {
             */
             template<typename E>
             boost::future<size_t> drain_to(std::vector<E> &elements, size_t max_elements) {
-                return proxy::IQueueImpl::drain_to_data(max_elements).then(boost::launch::deferred, [&](boost::future<std::vector<serialization::pimpl::data>> f)  {
-                    return drain_items(std::move(f), elements);
-                });
+                return proxy::IQueueImpl::drain_to_data(max_elements).then(boost::launch::async,
+                                                                           [&](boost::future<std::vector<serialization::pimpl::data>> f) {
+                                                                               return drain_items(std::move(f),
+                                                                                                  elements);
+                                                                           });
             }
 
             /**

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -129,7 +129,7 @@ namespace hazelcast {
                     try {
                         auto future = imap::get_internal(*key);
                         if (marked) {
-                            return future.then(boost::launch::async,
+                            return future.then(boost::launch::sync,
                                                [=](boost::future<boost::optional<serialization::pimpl::data>> f) {
                                                    auto data = f.get();
                                                    auto cachedValue = data
@@ -332,7 +332,7 @@ namespace hazelcast {
                         }
 
                         return imap::get_all_internal(partition_id, remainingKeys).then(
-                                boost::launch::async, [=](boost::future<EntryVector> f) {
+                                boost::launch::sync, [=](boost::future<EntryVector> f) {
                                     EntryVector allEntries(result);
                                     for (auto &entry : f.get()) {
                                         auto key = std::make_shared<serialization::pimpl::data>(std::move(entry.first));

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -129,13 +129,16 @@ namespace hazelcast {
                     try {
                         auto future = imap::get_internal(*key);
                         if (marked) {
-                            return future.then(boost::launch::deferred, [=](boost::future<boost::optional<serialization::pimpl::data>> f) {
-                                auto data = f.get();
-                                auto cachedValue = data ? std::make_shared<serialization::pimpl::data>(*data)
-                                                        : internal::nearcache::NearCache<K, V>::NULL_OBJECT;
-                                try_to_put_near_cache(key, cachedValue);
-                                return data;
-                            });
+                            return future.then(boost::launch::async,
+                                               [=](boost::future<boost::optional<serialization::pimpl::data>> f) {
+                                                   auto data = f.get();
+                                                   auto cachedValue = data
+                                                                      ? std::make_shared<serialization::pimpl::data>(
+                                                                   *data)
+                                                                      : internal::nearcache::NearCache<K, V>::NULL_OBJECT;
+                                                   try_to_put_near_cache(key, cachedValue);
+                                                   return data;
+                                               });
                         }
                         return future;
                     } catch (exception::iexception &) {
@@ -329,17 +332,18 @@ namespace hazelcast {
                         }
 
                         return imap::get_all_internal(partition_id, remainingKeys).then(
-                                boost::launch::deferred, [=](boost::future<EntryVector> f) {
-                            EntryVector allEntries(result);
-                            for (auto &entry : f.get()) {
-                                auto key = std::make_shared<serialization::pimpl::data>(std::move(entry.first));
-                                auto value = std::make_shared<serialization::pimpl::data>(std::move(entry.second));
-                                bool marked = false;
-                                auto foundEntry = markers->find(key);
-                                if (foundEntry != markers->end()) {
-                                    marked = foundEntry->second;
-                                    markers->erase(foundEntry);
-                                }
+                                boost::launch::async, [=](boost::future<EntryVector> f) {
+                                    EntryVector allEntries(result);
+                                    for (auto &entry : f.get()) {
+                                        auto key = std::make_shared<serialization::pimpl::data>(std::move(entry.first));
+                                        auto value = std::make_shared<serialization::pimpl::data>(
+                                                std::move(entry.second));
+                                        bool marked = false;
+                                        auto foundEntry = markers->find(key);
+                                        if (foundEntry != markers->end()) {
+                                            marked = foundEntry->second;
+                                            markers->erase(foundEntry);
+                                        }
 
                                 if (marked) {
                                     try_to_put_near_cache(key, value);

--- a/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
@@ -198,7 +198,7 @@ namespace hazelcast {
                     }
                     auto request = protocol::codec::replicatedmap_get_encode(get_name(), *sharedKey);
                     return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
-                            request, key).then(boost::launch::async,
+                            request, key).then(boost::launch::sync,
                                                [=](boost::future<boost::optional<serialization::pimpl::data>> f) {
                                                    try {
                                                        auto response = f.get();

--- a/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
@@ -198,17 +198,19 @@ namespace hazelcast {
                     }
                     auto request = protocol::codec::replicatedmap_get_encode(get_name(), *sharedKey);
                     return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
-                            request, key).then(boost::launch::deferred, [=] (boost::future<boost::optional<serialization::pimpl::data>> f) {
-                                try {
-                                    auto response = f.get();
-                                    if (!response) {
-                                        return boost::optional<serialization::pimpl::data>();
-                                    }
+                            request, key).then(boost::launch::async,
+                                               [=](boost::future<boost::optional<serialization::pimpl::data>> f) {
+                                                   try {
+                                                       auto response = f.get();
+                                                       if (!response) {
+                                                           return boost::optional<serialization::pimpl::data>();
+                                                       }
 
-                                    auto sharedValue = std::make_shared<serialization::pimpl::data>(std::move(*response));
-                                    if (near_cache_) {
-                                        near_cache_->put(sharedKey, sharedValue);
-                                    }
+                                                       auto sharedValue = std::make_shared<serialization::pimpl::data>(
+                                                               std::move(*response));
+                                                       if (near_cache_) {
+                                                           near_cache_->put(sharedKey, sharedValue);
+                                                       }
                                     return boost::make_optional(*sharedValue);
                                 } catch (...) {
                                     invalidate(sharedKey);

--- a/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
@@ -47,7 +47,7 @@ namespace hazelcast {
             public:
                 template<typename T>
                 static boost::future<void> to_void_future(boost::future<T> message_future) {
-                    return message_future.then(boost::launch::async, [](boost::future<T> f) {
+                    return message_future.then(boost::launch::sync, [](boost::future<T> f) {
                                                    f.get();
                                                }
                     );
@@ -135,14 +135,14 @@ namespace hazelcast {
 
                 template<typename T>
                 boost::future<boost::optional<T>> to_object(boost::future<serialization::pimpl::data> f) {
-                    return f.then(boost::launch::async, [=](boost::future<serialization::pimpl::data> f) {
+                    return f.then(boost::launch::sync, [=](boost::future<serialization::pimpl::data> f) {
                         return to_object<T>(f.get());
                     });
                 }
 
                 template<typename T>
                 boost::future<boost::optional<T>> to_object(boost::future<std::unique_ptr<serialization::pimpl::data>> f) {
-                    return f.then(boost::launch::async,
+                    return f.then(boost::launch::sync,
                                   [=](boost::future<std::unique_ptr<serialization::pimpl::data>> f) {
                                       return to_object<T>(f.get());
                                   });
@@ -151,7 +151,7 @@ namespace hazelcast {
                 template<typename T>
                 inline boost::future<std::vector<T>>
                 to_object_vector(boost::future<std::vector<serialization::pimpl::data>> data_future) {
-                    return data_future.then(boost::launch::async,
+                    return data_future.then(boost::launch::sync,
                                             [=](boost::future<std::vector<serialization::pimpl::data>> f) {
                                                 auto dataResult = f.get();
                                                 std::vector<T> result;
@@ -166,7 +166,7 @@ namespace hazelcast {
 
                 template<typename K, typename V>
                 boost::future<std::unordered_map<K, boost::optional<V>>> to_object_map(boost::future<EntryVector> entries_data) {
-                    return entries_data.then(boost::launch::async, [=](boost::future<EntryVector> f) {
+                    return entries_data.then(boost::launch::sync, [=](boost::future<EntryVector> f) {
                         auto entries = f.get();
                         std::unordered_map<K, boost::optional<V>> result;
                         result.reserve(entries.size());
@@ -180,7 +180,7 @@ namespace hazelcast {
                 template<typename K, typename V>
                 inline boost::future<std::vector<std::pair<K, V>>>
                 to_entry_object_vector(boost::future<EntryVector> data_future) {
-                    return data_future.then(boost::launch::async, [=](boost::future<EntryVector> f) {
+                    return data_future.then(boost::launch::sync, [=](boost::future<EntryVector> f) {
                         auto dataEntryVector = f.get();
                         std::vector<std::pair<K, V>> result;
                         result.reserve(dataEntryVector.size());
@@ -233,7 +233,7 @@ namespace hazelcast {
                 template<typename T>
                 static boost::future<boost::optional<T>>
                 decode_optional_var_sized(boost::future<protocol::ClientMessage> f) {
-                    return f.then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
+                    return f.then(boost::launch::sync, [](boost::future<protocol::ClientMessage> f) {
                         auto msg = f.get();
                         return msg.get_first_optional_var_sized_field<T>();
                     });
@@ -242,7 +242,7 @@ namespace hazelcast {
                 template<typename T>
                 typename std::enable_if<std::is_trivial<T>::value, boost::future<T>>::type
                 static decode(boost::future<protocol::ClientMessage> f) {
-                    return f.then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
+                    return f.then(boost::launch::sync, [](boost::future<protocol::ClientMessage> f) {
                         auto msg = f.get();
                         return msg.get_first_fixed_sized_field<T>();
                     });
@@ -251,7 +251,7 @@ namespace hazelcast {
                 template<typename T>
                 typename std::enable_if<!std::is_trivial<T>::value, boost::future<T>>::type
                 static decode(boost::future<protocol::ClientMessage> f) {
-                    return f.then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
+                    return f.then(boost::launch::sync, [](boost::future<protocol::ClientMessage> f) {
                         auto msg = f.get();
                         return *msg.get_first_var_sized_field<T>();
                     });

--- a/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
@@ -47,8 +47,9 @@ namespace hazelcast {
             public:
                 template<typename T>
                 static boost::future<void> to_void_future(boost::future<T> message_future) {
-                    return message_future.then(boost::launch::deferred, [](boost::future<T> f) {
-                        f.get(); }
+                    return message_future.then(boost::launch::async, [](boost::future<T> f) {
+                                                   f.get();
+                                               }
                     );
                 }
 
@@ -134,37 +135,38 @@ namespace hazelcast {
 
                 template<typename T>
                 boost::future<boost::optional<T>> to_object(boost::future<serialization::pimpl::data> f) {
-                    return f.then(boost::launch::deferred, [=] (boost::future<serialization::pimpl::data> f) {
+                    return f.then(boost::launch::async, [=](boost::future<serialization::pimpl::data> f) {
                         return to_object<T>(f.get());
                     });
                 }
 
                 template<typename T>
                 boost::future<boost::optional<T>> to_object(boost::future<std::unique_ptr<serialization::pimpl::data>> f) {
-                    return f.then(boost::launch::deferred, [=] (boost::future<std::unique_ptr<serialization::pimpl::data>> f) {
-                        return to_object<T>(f.get());
-                    });
+                    return f.then(boost::launch::async,
+                                  [=](boost::future<std::unique_ptr<serialization::pimpl::data>> f) {
+                                      return to_object<T>(f.get());
+                                  });
                 }
 
                 template<typename T>
                 inline boost::future<std::vector<T>>
                 to_object_vector(boost::future<std::vector<serialization::pimpl::data>> data_future) {
-                    return data_future.then(boost::launch::deferred,
-                                           [=](boost::future<std::vector<serialization::pimpl::data>> f) {
-                                               auto dataResult = f.get();
-                                               std::vector<T> result;
-                                               result.reserve(dataResult.size());
-                                               for (const auto &d : dataResult) {
-                                                   // The object is guaranteed to exist (non-null)
-                                                   result.push_back(std::move(to_object<T>(d).value()));
-                                               }
-                                               return result;
-                                           });
+                    return data_future.then(boost::launch::async,
+                                            [=](boost::future<std::vector<serialization::pimpl::data>> f) {
+                                                auto dataResult = f.get();
+                                                std::vector<T> result;
+                                                result.reserve(dataResult.size());
+                                                for (const auto &d : dataResult) {
+                                                    // The object is guaranteed to exist (non-null)
+                                                    result.push_back(std::move(to_object<T>(d).value()));
+                                                }
+                                                return result;
+                                            });
                 }
 
                 template<typename K, typename V>
                 boost::future<std::unordered_map<K, boost::optional<V>>> to_object_map(boost::future<EntryVector> entries_data) {
-                    return entries_data.then(boost::launch::deferred, [=](boost::future<EntryVector> f) {
+                    return entries_data.then(boost::launch::async, [=](boost::future<EntryVector> f) {
                         auto entries = f.get();
                         std::unordered_map<K, boost::optional<V>> result;
                         result.reserve(entries.size());
@@ -178,7 +180,7 @@ namespace hazelcast {
                 template<typename K, typename V>
                 inline boost::future<std::vector<std::pair<K, V>>>
                 to_entry_object_vector(boost::future<EntryVector> data_future) {
-                    return data_future.then(boost::launch::deferred, [=](boost::future<EntryVector> f) {
+                    return data_future.then(boost::launch::async, [=](boost::future<EntryVector> f) {
                         auto dataEntryVector = f.get();
                         std::vector<std::pair<K, V>> result;
                         result.reserve(dataEntryVector.size());
@@ -231,7 +233,7 @@ namespace hazelcast {
                 template<typename T>
                 static boost::future<boost::optional<T>>
                 decode_optional_var_sized(boost::future<protocol::ClientMessage> f) {
-                    return f.then(boost::launch::deferred, [](boost::future<protocol::ClientMessage> f) {
+                    return f.then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
                         auto msg = f.get();
                         return msg.get_first_optional_var_sized_field<T>();
                     });
@@ -240,7 +242,7 @@ namespace hazelcast {
                 template<typename T>
                 typename std::enable_if<std::is_trivial<T>::value, boost::future<T>>::type
                 static decode(boost::future<protocol::ClientMessage> f) {
-                    return f.then(boost::launch::deferred, [](boost::future<protocol::ClientMessage> f) {
+                    return f.then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
                         auto msg = f.get();
                         return msg.get_first_fixed_sized_field<T>();
                     });
@@ -249,7 +251,7 @@ namespace hazelcast {
                 template<typename T>
                 typename std::enable_if<!std::is_trivial<T>::value, boost::future<T>>::type
                 static decode(boost::future<protocol::ClientMessage> f) {
-                    return f.then(boost::launch::deferred, [](boost::future<protocol::ClientMessage> f) {
+                    return f.then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
                         auto msg = f.get();
                         return *msg.get_first_var_sized_field<T>();
                     });

--- a/hazelcast/include/hazelcast/client/spi/ProxyManager.h
+++ b/hazelcast/include/hazelcast/client/spi/ProxyManager.h
@@ -55,7 +55,7 @@ namespace hazelcast {
 
                     auto concrete_proxy = std::shared_ptr<T>(new T(id, &client_));
                     auto client_proxy = std::static_pointer_cast<ClientProxy>(concrete_proxy);
-                    auto proxy_future = initialize(client_proxy).then(boost::launch::async, [=](boost::future<void> f) {
+                    auto proxy_future = initialize(client_proxy).then(boost::launch::sync, [=](boost::future<void> f) {
                         try {
                             f.get();
                             return client_proxy;
@@ -96,7 +96,7 @@ namespace hazelcast {
                 template <typename T>
                 boost::shared_future<std::shared_ptr<T>>
                 convert_to_concrete_proxy_future(boost::shared_future<std::shared_ptr<ClientProxy>> proxy_future) {
-                    return proxy_future.then(boost::launch::async,
+                    return proxy_future.then(boost::launch::sync,
                                              [](boost::shared_future<std::shared_ptr<ClientProxy>> f) {
                                                  return std::static_pointer_cast<T>(f.get());
                                              });

--- a/hazelcast/include/hazelcast/client/spi/ProxyManager.h
+++ b/hazelcast/include/hazelcast/client/spi/ProxyManager.h
@@ -55,7 +55,7 @@ namespace hazelcast {
 
                     auto concrete_proxy = std::shared_ptr<T>(new T(id, &client_));
                     auto client_proxy = std::static_pointer_cast<ClientProxy>(concrete_proxy);
-                    auto proxy_future = initialize(client_proxy).then(boost::launch::deferred, [=] (boost::future<void> f) {
+                    auto proxy_future = initialize(client_proxy).then(boost::launch::async, [=](boost::future<void> f) {
                         try {
                             f.get();
                             return client_proxy;
@@ -96,9 +96,10 @@ namespace hazelcast {
                 template <typename T>
                 boost::shared_future<std::shared_ptr<T>>
                 convert_to_concrete_proxy_future(boost::shared_future<std::shared_ptr<ClientProxy>> proxy_future) {
-                    return proxy_future.then(boost::launch::deferred, [] (boost::shared_future<std::shared_ptr<ClientProxy>> f) {
-                        return std::static_pointer_cast<T>(f.get());
-                    });
+                    return proxy_future.then(boost::launch::async,
+                                             [](boost::shared_future<std::shared_ptr<ClientProxy>> f) {
+                                                 return std::static_pointer_cast<T>(f.get());
+                                             });
                 }
 
                 proxy_map proxies_;

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -143,7 +143,6 @@ namespace hazelcast {
 
                     logger &logger_;
                     lifecycle_service &lifecycle_service_;
-                    ClientClusterServiceImpl &client_cluster_service_;
                     ClientInvocationServiceImpl &invocation_service_;
                     std::shared_ptr<ClientExecutionServiceImpl> execution_service_;
                     boost::atomic_shared_ptr<std::shared_ptr<protocol::ClientMessage>> client_message_;

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -103,7 +103,7 @@ namespace hazelcast {
         }
 
         boost::future<void> hazelcast_client::shutdown() {
-            return boost::async(boost::launch::async, [=]() { client_impl_->shutdown(); });
+            return boost::async([=]() { client_impl_->shutdown(); });
         }
 
         spi::lifecycle_service &hazelcast_client::get_lifecycle_service() {
@@ -340,7 +340,7 @@ namespace hazelcast {
                 auto nearCacheConfig = client_config_.get_near_cache_config(name);
                 if (nearCacheConfig) {
                     return proxy_manager_.get_or_create_proxy<map::NearCachedClientMapProxy<serialization::pimpl::data, serialization::pimpl::data>>(
-                            imap::SERVICE_NAME, name).then(boost::launch::async,
+                            imap::SERVICE_NAME, name).then(boost::launch::sync,
                                                            [=](boost::shared_future<std::shared_ptr<map::NearCachedClientMapProxy<serialization::pimpl::data, serialization::pimpl::data>>> f) {
                                                                return std::static_pointer_cast<imap>(f.get());
                                                            });

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -340,7 +340,7 @@ namespace hazelcast {
                 auto nearCacheConfig = client_config_.get_near_cache_config(name);
                 if (nearCacheConfig) {
                     return proxy_manager_.get_or_create_proxy<map::NearCachedClientMapProxy<serialization::pimpl::data, serialization::pimpl::data>>(
-                            imap::SERVICE_NAME, name).then(boost::launch::deferred,
+                            imap::SERVICE_NAME, name).then(boost::launch::async,
                                                            [=](boost::shared_future<std::shared_ptr<map::NearCachedClientMapProxy<serialization::pimpl::data, serialization::pimpl::data>>> f) {
                                                                return std::static_pointer_cast<imap>(f.get());
                                                            });

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -375,7 +375,7 @@ namespace hazelcast {
                     try {
                         do_connect_to_cluster();
 
-                        std::lock_guard<std::mutex> guard(client_state_mutex_);
+                        std::lock_guard<std::recursive_mutex> guard(client_state_mutex_);
                         connect_to_cluster_task_submitted_ = false;
                         if (active_connections_.empty()) {
                             HZ_LOG(logger_, finest,
@@ -527,7 +527,7 @@ namespace hazelcast {
                     return;
                 }
 
-                std::lock_guard<std::mutex> guard(client_state_mutex_);
+                std::lock_guard<std::recursive_mutex> guard(client_state_mutex_);
                 if (active_connections_.remove(member_uuid, connection)) {
                     active_connection_ids_.remove(connection->get_connection_id());
 
@@ -577,7 +577,7 @@ namespace hazelcast {
             ClientConnectionManagerImpl::on_authenticated(const std::shared_ptr<Connection> &connection,
                                                           auth_response &response) {
                 {
-                    std::lock_guard<std::mutex> guard(client_state_mutex_);
+                    std::lock_guard<std::recursive_mutex> guard(client_state_mutex_);
                     check_partition_count(response.partition_count);
                     connection->set_connected_server_version(response.server_version);
                     connection->set_remote_address(std::move(response.server_address));

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -496,7 +496,7 @@ namespace hazelcast {
                 try {
                     auto timestamps = observed_clock_.get()->entry_set();
                     auto request = protocol::codec::pncounter_get_encode(get_name(), timestamps, target->get_uuid());
-                    return invoke_on_member(request, target->get_uuid()).then(boost::launch::async,
+                    return invoke_on_member(request, target->get_uuid()).then(boost::launch::sync,
                                                                               [=](boost::future<protocol::ClientMessage> f) {
                                                                                   try {
                                                                                       return get_and_update_timestamps(
@@ -534,7 +534,7 @@ namespace hazelcast {
                 try {
                     auto request = protocol::codec::pncounter_add_encode(
                             get_name(), delta, getBeforeUpdate, observed_clock_.get()->entry_set(), target->get_uuid());
-                    return invoke_on_member(request, target->get_uuid()).then(boost::launch::async,
+                    return invoke_on_member(request, target->get_uuid()).then(boost::launch::sync,
                                                                               [=](boost::future<protocol::ClientMessage> f) {
                                                                                   try {
                                                                                       return get_and_update_timestamps(
@@ -811,7 +811,7 @@ namespace hazelcast {
                 try {
                     return boost::make_ready_future(new_id_internal());
                 } catch (std::overflow_error &) {
-                    return new_id_batch(batch_size_).then(boost::launch::async,
+                    return new_id_batch(batch_size_).then(boost::launch::sync,
                                                           [=](boost::future<flake_id_generator_impl::IdBatch> f) {
                                                               auto newBlock = boost::make_shared<Block>(f.get(),
                                                                                                         validity_);
@@ -826,7 +826,7 @@ namespace hazelcast {
             boost::future<flake_id_generator_impl::IdBatch> flake_id_generator_impl::new_id_batch(int32_t size) {
                 auto request = protocol::codec::flakeidgenerator_newidbatch_encode(
                         get_name(), size);
-                return invoke(request).then(boost::launch::async, [](boost::future<protocol::ClientMessage> f) {
+                return invoke(request).then(boost::launch::sync, [](boost::future<protocol::ClientMessage> f) {
                     auto msg = f.get();
                     msg.rd_ptr(protocol::ClientMessage::RESPONSE_HEADER_LEN);
 
@@ -1284,7 +1284,7 @@ namespace hazelcast {
             boost::future<std::pair<std::vector<serialization::pimpl::data>, query::anchor_data_list>> IMapImpl::key_set_for_paging_predicate_data(
                     protocol::codec::holder::paging_predicate_holder const & predicate) {
                 auto request = protocol::codec::map_keysetwithpagingpredicate_encode(get_name(), predicate);
-                return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
+                return invoke(request).then(boost::launch::sync, [=](boost::future<protocol::ClientMessage> f) {
                     return get_paging_predicate_response<std::vector<serialization::pimpl::data>>(std::move(f));
                 });
             }
@@ -1302,7 +1302,7 @@ namespace hazelcast {
             boost::future<std::pair<EntryVector, query::anchor_data_list>> IMapImpl::entry_set_for_paging_predicate_data(
                     protocol::codec::holder::paging_predicate_holder const & predicate) {
                 auto request = protocol::codec::map_entrieswithpagingpredicate_encode(get_name(), predicate);
-                return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
+                return invoke(request).then(boost::launch::sync, [=](boost::future<protocol::ClientMessage> f) {
                     return get_paging_predicate_response<EntryVector>(std::move(f));
                 });
             }
@@ -1320,7 +1320,7 @@ namespace hazelcast {
             boost::future<std::pair<std::vector<serialization::pimpl::data>, query::anchor_data_list>>
             IMapImpl::values_for_paging_predicate_data(protocol::codec::holder::paging_predicate_holder const & predicate) {
                 auto request = protocol::codec::map_valueswithpagingpredicate_encode(get_name(), predicate);
-                return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
+                return invoke(request).then(boost::launch::sync, [=](boost::future<protocol::ClientMessage> f) {
                     return get_paging_predicate_response<std::vector<serialization::pimpl::data>>(std::move(f));
                 });
             }

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -124,7 +124,7 @@ namespace hazelcast {
                         client_proxy->get_service_name());
                 return spi::impl::ClientInvocation::create(client_, clientMessage,
                                                            client_proxy->get_service_name())->invoke().then(
-                        boost::launch::deferred, [=](boost::future<protocol::ClientMessage> f) {
+                        boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
                             f.get();
                             client_proxy->on_initialize();
                         });
@@ -521,8 +521,9 @@ namespace hazelcast {
             boost::future<void> ClientProxy::destroy_remotely() {
                 auto clientMessage = protocol::codec::client_destroyproxy_encode(
                         get_name(), get_service_name());
-                return spi::impl::ClientInvocation::create(get_context(), std::make_shared<protocol::ClientMessage>(std::move(clientMessage)), get_name())->invoke().then(
-                        boost::launch::deferred, [](boost::future<protocol::ClientMessage> f) { f.get(); });
+                return spi::impl::ClientInvocation::create(get_context(), std::make_shared<protocol::ClientMessage>(
+                        std::move(clientMessage)), get_name())->invoke().then(
+                        boost::launch::async, [](boost::future<protocol::ClientMessage> f) { f.get(); });
             }
 
             boost::future<boost::uuids::uuid>

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1090,7 +1090,6 @@ namespace hazelcast {
                     // for back pressure
                     call_id_sequence_->force_next();
                     invoke_on_selection();
-                    hazelcast::util::hz_thread_pool p(1);
                     auto id_seq = call_id_sequence_;
                     return invocation_promise_.get_future().then(boost::launch::async,
                                                                  [=](boost::future<protocol::ClientMessage> f) {

--- a/hazelcast/src/hazelcast/client/transactions.cpp
+++ b/hazelcast/src/hazelcast/client/transactions.cpp
@@ -96,7 +96,7 @@ namespace hazelcast {
                     auto request = protocol::codec::transaction_create_encode(
                             std::chrono::duration_cast<std::chrono::milliseconds>(get_timeout()).count(), options_.get_durability(),
                             static_cast<int32_t>(options_.get_transaction_type()), thread_id_);
-                    return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
+                    return invoke(request).then(boost::launch::sync, [=](boost::future<protocol::ClientMessage> f) {
                         try {
                             auto msg = f.get();
                             // skip header
@@ -125,7 +125,7 @@ namespace hazelcast {
                     check_timeout();
 
                     auto request = protocol::codec::transaction_commit_encode(txn_id_, thread_id_);
-                    return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
+                    return invoke(request).then(boost::launch::sync, [=](boost::future<protocol::ClientMessage> f) {
                         try {
                             f.get();
                             state_ = TxnState::COMMITTED;
@@ -154,7 +154,7 @@ namespace hazelcast {
                     check_thread();
                     try {
                         auto request = protocol::codec::transaction_rollback_encode(txn_id_, thread_id_);
-                        return invoke(request).then(boost::launch::async,
+                        return invoke(request).then(boost::launch::sync,
                                                     [=](boost::future<protocol::ClientMessage> f) {
                                                         try {
                                                             state_ = TxnState::ROLLED_BACK;

--- a/hazelcast/src/hazelcast/client/transactions.cpp
+++ b/hazelcast/src/hazelcast/client/transactions.cpp
@@ -96,7 +96,7 @@ namespace hazelcast {
                     auto request = protocol::codec::transaction_create_encode(
                             std::chrono::duration_cast<std::chrono::milliseconds>(get_timeout()).count(), options_.get_durability(),
                             static_cast<int32_t>(options_.get_transaction_type()), thread_id_);
-                    return invoke(request).then(boost::launch::deferred, [=] (boost::future<protocol::ClientMessage> f) {
+                    return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
                         try {
                             auto msg = f.get();
                             // skip header
@@ -125,7 +125,7 @@ namespace hazelcast {
                     check_timeout();
 
                     auto request = protocol::codec::transaction_commit_encode(txn_id_, thread_id_);
-                    return invoke(request).then(boost::launch::deferred, [=] (boost::future<protocol::ClientMessage> f) {
+                    return invoke(request).then(boost::launch::async, [=](boost::future<protocol::ClientMessage> f) {
                         try {
                             f.get();
                             state_ = TxnState::COMMITTED;
@@ -154,17 +154,19 @@ namespace hazelcast {
                     check_thread();
                     try {
                         auto request = protocol::codec::transaction_rollback_encode(txn_id_, thread_id_);
-                        return invoke(request).then(boost::launch::deferred, [=] (boost::future<protocol::ClientMessage> f) {
-                            try {
-                                state_ = TxnState::ROLLED_BACK;
-                                transaction_exists_.store(false);
-                                f.get();
-                            } catch (exception::iexception &e) {
-                                HZ_LOG(client_context_.get_logger(), warning,
-                                    boost::str(boost::format("Exception while rolling back the transaction. "
-                                                             "Exception: %1%")
-                                                             % e)
-                                );
+                        return invoke(request).then(boost::launch::async,
+                                                    [=](boost::future<protocol::ClientMessage> f) {
+                                                        try {
+                                                            state_ = TxnState::ROLLED_BACK;
+                                                            transaction_exists_.store(false);
+                                                            f.get();
+                                                        } catch (exception::iexception &e) {
+                                                            HZ_LOG(client_context_.get_logger(), warning,
+                                                                   boost::str(boost::format(
+                                                                           "Exception while rolling back the transaction. "
+                                                                           "Exception: %1%")
+                                                                              % e)
+                                                            );
                             }
                         });
                     } catch (exception::iexception &exception) {

--- a/hazelcast/src/hazelcast/cp/cp.cpp
+++ b/hazelcast/src/hazelcast/cp/cp.cpp
@@ -114,7 +114,7 @@ namespace hazelcast {
         boost::future<raft_group_id> raft_proxy_factory::get_group_id(const std::string &proxy_name, const std::string &object_name) {
             auto request = cpgroup_createcpgroup_encode(proxy_name);
             return client::spi::impl::ClientInvocation::create(context_, request, object_name)->invoke().then(
-                    boost::launch::async, [](boost::future<client::protocol::ClientMessage> f) {
+                    boost::launch::sync, [](boost::future<client::protocol::ClientMessage> f) {
                         return *f.get().get_first_var_sized_field<raft_group_id>();
                     });
         }
@@ -306,7 +306,7 @@ namespace hazelcast {
 
         boost::future<void> latch::count_down() {
             auto invocation_uid = get_context().get_hazelcast_client_implementation()->random_uuid();
-            return get_round().then(boost::launch::async, [=](boost::future<int32_t> f) {
+            return get_round().then(boost::launch::sync, [=](boost::future<int32_t> f) {
                 auto round = f.get();
                 for (;;) {
                     try {
@@ -321,7 +321,7 @@ namespace hazelcast {
         }
 
         boost::future<bool> latch::try_wait() {
-            return get_count().then(boost::launch::async, [](boost::future<int32_t> f) {
+            return get_count().then(boost::launch::sync, [](boost::future<int32_t> f) {
                 return f.get() == 0;
             });
         }
@@ -344,7 +344,7 @@ namespace hazelcast {
             auto timeout_millis = std::max<int64_t>(0, timeout.count());
             auto invoation_uid = get_context().get_hazelcast_client_implementation()->random_uuid();
             auto request = countdownlatch_await_encode(group_id_, object_name_, invoation_uid, timeout_millis);
-            return invoke_and_get_future<bool>(request).then(boost::launch::async, [](boost::future<bool> f) {
+            return invoke_and_get_future<bool>(request).then(boost::launch::sync, [](boost::future<bool> f) {
                 return f.get() ? std::cv_status::no_timeout : std::cv_status::timeout;
             });
         }
@@ -378,7 +378,7 @@ namespace hazelcast {
             auto do_lock_once = [=] () {
                 auto session_id = session_manager_.acquire_session(group_id_);
                 verify_locked_session_id_if_present(thread_id, session_id, true);
-                return do_lock(session_id, thread_id, invocation_uid).then(boost::launch::async,
+                return do_lock(session_id, thread_id, invocation_uid).then(boost::launch::sync,
                                                                            [=](boost::future<int64_t> f) {
                                                                                try {
                                                                                    auto fence = f.get();
@@ -412,7 +412,7 @@ namespace hazelcast {
                 });
             };
 
-            return do_lock_once().then(boost::launch::async, [=](boost::future<int64_t> f) {
+            return do_lock_once().then(boost::launch::sync, [=](boost::future<int64_t> f) {
                 auto result = f.get();
                 if (result != INVALID_FENCE) {
                     return result;
@@ -479,7 +479,7 @@ namespace hazelcast {
 
         boost::future<fenced_lock::lock_ownership_state> fenced_lock::do_get_lock_ownership_state(){
             auto request = client::protocol::codec::fencedlock_getlockownership_encode(group_id_, object_name_);
-            return invoke(request).then(boost::launch::async, [](boost::future<client::protocol::ClientMessage> f) {
+            return invoke(request).then(boost::launch::sync, [](boost::future<client::protocol::ClientMessage> f) {
                 auto msg = f.get();
                 fenced_lock::lock_ownership_state state;
                 state.fence = msg.get_first_fixed_sized_field<int64_t>();
@@ -495,13 +495,13 @@ namespace hazelcast {
         }
 
         boost::future<bool> fenced_lock::try_lock() {
-            return try_lock_and_get_fence().then(boost::launch::async, [](boost::future<int64_t> f) {
+            return try_lock_and_get_fence().then(boost::launch::sync, [](boost::future<int64_t> f) {
                 return f.get() != INVALID_FENCE;
             });
         }
 
         boost::future<bool> fenced_lock::try_lock(std::chrono::milliseconds timeout) {
-            return try_lock_and_get_fence(timeout).then(boost::launch::async, [](boost::future<int64_t> f) {
+            return try_lock_and_get_fence(timeout).then(boost::launch::sync, [](boost::future<int64_t> f) {
                 return f.get() != INVALID_FENCE;
             });
         }
@@ -520,7 +520,7 @@ namespace hazelcast {
                 auto start = steady_clock::now();
                 auto session_id = session_manager_.acquire_session(group_id_);
                 verify_locked_session_id_if_present(thread_id, session_id, true);
-                return do_try_lock(session_id, thread_id, invocation_uid, timeout).then(boost::launch::async,
+                return do_try_lock(session_id, thread_id, invocation_uid, timeout).then(boost::launch::sync,
                                                                                         [=](boost::future<int64_t> f) {
                                                                                             try {
                                                                                                 auto fence = f.get();
@@ -558,7 +558,7 @@ namespace hazelcast {
                 });
             };
 
-            return do_try_lock_once().then(boost::launch::async, [=](boost::future<std::pair<int64_t, bool>> f) {
+            return do_try_lock_once().then(boost::launch::sync, [=](boost::future<std::pair<int64_t, bool>> f) {
                 auto result = f.get();
                 if (!result.second) {
                     return result.first;
@@ -580,7 +580,7 @@ namespace hazelcast {
                 throw_illegal_monitor_state();
             }
 
-            return do_unlock(session_id, thread_id, get_context().random_uuid()).then(boost::launch::async,
+            return do_unlock(session_id, thread_id, get_context().random_uuid()).then(boost::launch::sync,
                                                                                       [=](boost::future<bool> f) {
                                                                                           try {
                                                                                               auto still_locked_by_current_thread = f.get();
@@ -620,7 +620,7 @@ namespace hazelcast {
                 throw_illegal_monitor_state();
             }
 
-            return do_get_lock_ownership_state().then(boost::launch::async, [=](boost::future<lock_ownership_state> f) {
+            return do_get_lock_ownership_state().then(boost::launch::sync, [=](boost::future<lock_ownership_state> f) {
                 auto ownership = f.get();
                 if (ownership.is_locked_by(session_id, thread_id)) {
                     locked_session_ids_.put(thread_id, std::make_shared<int64_t>(session_id));
@@ -639,7 +639,7 @@ namespace hazelcast {
 
             verify_locked_session_id_if_present(thread_id, session_id, false);
 
-            return do_get_lock_ownership_state().then(boost::launch::async, [=](boost::future<lock_ownership_state> f) {
+            return do_get_lock_ownership_state().then(boost::launch::sync, [=](boost::future<lock_ownership_state> f) {
                 auto ownership = f.get();
                 if (ownership.is_locked_by(session_id, thread_id)) {
                     locked_session_ids_.put(thread_id, std::make_shared<int64_t>(session_id));
@@ -657,7 +657,7 @@ namespace hazelcast {
 
             verify_locked_session_id_if_present(thread_id, session_id, false);
 
-            return do_get_lock_ownership_state().then(boost::launch::async, [=](boost::future<lock_ownership_state> f) {
+            return do_get_lock_ownership_state().then(boost::launch::sync, [=](boost::future<lock_ownership_state> f) {
                 auto ownership = f.get();
                 auto locked_by_current_thread = ownership.is_locked_by(session_id, thread_id);
                 if (locked_by_current_thread) {
@@ -676,7 +676,7 @@ namespace hazelcast {
 
             verify_locked_session_id_if_present(thread_id, session_id, false);
 
-            return do_get_lock_ownership_state().then(boost::launch::async, [=](boost::future<lock_ownership_state> f) {
+            return do_get_lock_ownership_state().then(boost::launch::sync, [=](boost::future<lock_ownership_state> f) {
                 auto ownership = f.get();
                 if (ownership.is_locked_by(session_id, thread_id)) {
                     locked_session_ids_.put(thread_id, std::make_shared<int64_t>(session_id));
@@ -732,7 +732,7 @@ namespace hazelcast {
 
             auto request = client::protocol::codec::semaphore_init_encode(group_id_, object_name_, permits);
             return client::spi::impl::ClientInvocation::create(context_, request, object_name_)->invoke().then(
-                    boost::launch::async, [](boost::future<client::protocol::ClientMessage> f) {
+                    boost::launch::sync, [](boost::future<client::protocol::ClientMessage> f) {
                         return f.get().get_first_fixed_sized_field<bool>();
                     });
         }
@@ -794,7 +794,7 @@ namespace hazelcast {
             auto invocation_uid = get_context().get_hazelcast_client_implementation()->random_uuid();
             auto request = client::protocol::codec::semaphore_acquire_encode(group_id_, object_name_, internal::session::proxy_session_manager::NO_SESSION_ID, cluster_wide_threadId, invocation_uid, permits, timeout_ms.count());
             return client::spi::impl::ClientInvocation::create(context_, request, object_name_)->invoke().then(
-                    boost::launch::async, [=](boost::future<client::protocol::ClientMessage> f) {
+                    boost::launch::sync, [=](boost::future<client::protocol::ClientMessage> f) {
                         try {
                             return f.get().get_first_fixed_sized_field<bool>();
                         } catch (client::exception::wait_key_cancelled &) {
@@ -863,7 +863,7 @@ namespace hazelcast {
                                                                                  thread_id, invocation_uid, permits,
                                                                                  timeout.count());
                 return client::spi::impl::ClientInvocation::create(context_, request, object_name_)->invoke().then(
-                        boost::launch::async, [=](boost::future<client::protocol::ClientMessage> f) {
+                        boost::launch::sync, [=](boost::future<client::protocol::ClientMessage> f) {
                             try {
                                 auto acquired = f.get().get_first_fixed_sized_field<bool>();
                                 if (!acquired) {
@@ -892,7 +892,7 @@ namespace hazelcast {
                         });
             });
 
-            return do_try_acquire_once().then(boost::launch::async, [=](boost::future<std::pair<bool, bool>> f) {
+            return do_try_acquire_once().then(boost::launch::sync, [=](boost::future<std::pair<bool, bool>> f) {
                 auto result = f.get();
                 if (!result.second) {
                     return result.first;
@@ -950,7 +950,7 @@ namespace hazelcast {
                                                                                session_id,
                                                                                thread_id, invocation_uid);
                 return client::spi::impl::ClientInvocation::create(context_, request, object_name_)->invoke().then(
-                        boost::launch::async, [=](boost::future<client::protocol::ClientMessage> f) {
+                        boost::launch::sync, [=](boost::future<client::protocol::ClientMessage> f) {
                             try {
                                 auto count = f.get().get_first_fixed_sized_field<int32_t>();
                                 session_manager_.release_session(group_id_, session_id,
@@ -963,7 +963,7 @@ namespace hazelcast {
                         });
             });
 
-            return do_drain_once().then(boost::launch::async, [=](boost::future<int32_t> f) {
+            return do_drain_once().then(boost::launch::sync, [=](boost::future<int32_t> f) {
                 int32_t count = f.get();
                 if (count != -1) {
                     return count;
@@ -982,7 +982,7 @@ namespace hazelcast {
                                                                             session_id,
                                                                             thread_id, invocation_uid, delta);
             return client::spi::impl::ClientInvocation::create(context_, request, object_name_)->invoke().then(
-                    boost::launch::async, [=](boost::future<client::protocol::ClientMessage> f) {
+                    boost::launch::sync, [=](boost::future<client::protocol::ClientMessage> f) {
                         try {
                             f.get();
                             session_manager_.release_session(group_id_, session_id);

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1487,13 +1487,6 @@ namespace hazelcast {
 
                 ASSERT_EQ(3 * 5, result);
 
-                result = map->get<int, int>(1)
-                        .then(boost::launch::async, [](boost::future<boost::optional<int>> f) {
-                            return 4 * f.get().value();
-                        }).get();
-
-                ASSERT_EQ(4 * 5, result);
-
                 boost::latch success_deferred(1);
                 map->lock<int>(1).then(boost::launch::deferred, [](boost::future<void> f) {
                     f.get();


### PR DESCRIPTION
Changed `boost::launch::deferred` continuations to `boost::launch::sync` except for the `ClientInvocation::invoke` and `ClientInvocation::invoke_urgent` methods, since these methods are being executed by the io thread which we do not want to block. This way, the io thread receives the message and composes the client message for delivery and the async thread does the message decoding and any continuations in a sync manner (a boost::async call for each client invocation result delivery to the user).

Current thread structure for an example imap::get call:

io_thread prepares the client_message -> a new thread is spawn to process the rest of the delivery of the message and other processing using boost::launch::async continuation. The rest of the processing occurs on this spawned thread, hence all the rest future continuations work in boost::launch::sync way.

Also added a new test `testIssue753 ` to test the problem.

fixes #753