### PR TITLE
Fix boost version in cmake pkg config and fix multi config check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endif ()
 find_package(Threads REQUIRED)
 
 # find Boost
-find_package(Boost 1.71 REQUIRED COMPONENTS headers thread chrono)
+find_package(Boost 1.71 REQUIRED COMPONENTS thread chrono)
 
 # find OpenSSL if building WITH_OPENSSL
 if (WITH_OPENSSL)
@@ -131,7 +131,7 @@ function(add_hazelcast_library name type)
     # add Boost::thread and Boost::chrono as dependencies
     target_link_libraries(
         ${name}
-        PUBLIC Boost::headers Boost::thread Boost::chrono
+        PUBLIC Boost::boost Boost::thread Boost::chrono
     )
     # set the Boost thread version
     target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,9 @@ project(hazelcast-cpp-client
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set the default build type if not given
-if ((NOT GENERATOR_IS_MULTI_CONFIG) AND (NOT CMAKE_BUILD_TYPE))
+# Set the default build type for single-config generators if not given
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if ((NOT is_multi_config) AND (NOT CMAKE_BUILD_TYPE))
     message(STATUS "CMAKE_BUILD_TYPE was not set, using Release as the default.")
     set(CMAKE_BUILD_TYPE Release)
 endif ()
@@ -87,7 +88,7 @@ endif ()
 find_package(Threads REQUIRED)
 
 # find Boost
-find_package(Boost 1.71 REQUIRED COMPONENTS thread chrono)
+find_package(Boost 1.71 REQUIRED COMPONENTS headers thread chrono)
 
 # find OpenSSL if building WITH_OPENSSL
 if (WITH_OPENSSL)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Boost 1.72 REQUIRED COMPONENTS thread chrono)
+find_dependency(Boost 1.71 REQUIRED COMPONENTS headers thread chrono)
 
 if (@WITH_OPENSSL@)
     find_dependency(OpenSSL REQUIRED)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Boost 1.71 REQUIRED COMPONENTS headers thread chrono)
+find_dependency(Boost 1.71 REQUIRED COMPONENTS thread chrono)
 
 if (@WITH_OPENSSL@)
     find_dependency(OpenSSL REQUIRED)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,10 +2,10 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Boost 1.71 REQUIRED COMPONENTS thread chrono)
+find_dependency(Boost 1.71 COMPONENTS thread chrono)
 
 if (@WITH_OPENSSL@)
-    find_dependency(OpenSSL REQUIRED)
+    find_dependency(OpenSSL)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/@name@-targets.cmake)


### PR DESCRIPTION
* The boost version in the cmake package config template is updated to 1.71.
* `GENERATOR_IS_MULTI_CONFIG` isn't a variable it's a global property, fixed the if condition to use it correctly.
* `Boost::headers` is replaced with `Boost::boost`. Because the `headers` target was added in a newer CMake version and it doesn't exists in 3.10.
* find_dependency macro in the package config file automatically infers the `REQUIRED` and `QUIET` keywords from the calling find_package command. So, the `REQUIRED` parameter is removed from the config.cmake.in file.

Fixes #752. Well the issue said not to repeat the version but on second thought, it's not something that would change that frequently and I guess an amount of repetition between the main CMakeLists.txt and the config.cmake.in is inevitable. We have to be careful when we update our package dependencies and keep the two files in sync.