### PR TITLE
Increase the default value for cluster connection timeout

### DIFF
--- a/hazelcast/include/hazelcast/client/config/connection_retry_config.h
+++ b/hazelcast/include/hazelcast/client/config/connection_retry_config.h
@@ -112,7 +112,7 @@ namespace hazelcast {
             private:
                 static constexpr std::chrono::milliseconds INITIAL_BACKOFF{1000};
                 static constexpr std::chrono::milliseconds MAX_BACKOFF{30000};
-                static constexpr std::chrono::milliseconds CLUSTER_CONNECT_TIMEOUT{20000};
+                static constexpr std::chrono::milliseconds CLUSTER_CONNECT_TIMEOUT{120000};
                 static constexpr double JITTER = 0;
                 std::chrono::milliseconds initial_backoff_duration_ = INITIAL_BACKOFF;
                 std::chrono::milliseconds max_backoff_duration_ = MAX_BACKOFF;

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1465,7 +1465,10 @@ namespace hazelcast {
                 HazelcastServer server(*g_srvFactory);
 
                 // start a client
-                hazelcast_client client{new_client(get_config()).get()};
+                auto config = get_config();
+                config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(3));
+                hazelcast_client client{new_client(std::move(config)).get()};
 
                 auto map = client.get_map("Issue221_test_map").get();
 


### PR DESCRIPTION
Changed the default value for cluster connection from 20 secs to 120 secs.

backport of Java PR https://github.com/hazelcast/hazelcast/pull/18019