### PR TITLE
Replaced `boost::launch::async` continuation with thread pool based continuation

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -61,12 +61,14 @@ namespace hazelcast {
                             if (ec == boost::asio::error::operation_aborted) {
                                 return;
                             }
+                            resolver_.cancel();
                             close();
                             return;
                         });
                         try {
-                            auto addresses = resolver_.resolve(remote_endpoint_.get_host(),
-                                                               std::to_string(remote_endpoint_.get_port()));
+                            auto addresses = resolver_.async_resolve(remote_endpoint_.get_host(),
+                                                                     std::to_string(remote_endpoint_.get_port()),
+                                                                     boost::asio::use_future).get();
                             boost::asio::async_connect(socket_.lowest_layer(), addresses,
                                                        boost::asio::use_future).get();
                             post_connect();

--- a/hazelcast/include/hazelcast/client/spi/ProxyManager.h
+++ b/hazelcast/include/hazelcast/client/spi/ProxyManager.h
@@ -46,7 +46,7 @@ namespace hazelcast {
                 boost::shared_future<std::shared_ptr<T>> get_or_create_proxy(const std::string &service, const std::string &id) {
                     DefaultObjectNamespace ns(service, id);
 
-                    std::lock_guard<std::mutex> guard(lock_);
+                    std::lock_guard<std::recursive_mutex> guard(lock_);
                     auto it = proxies_.find(ns);
                     if (it != proxies_.end()) {
                         auto proxy_future = it->second;
@@ -60,7 +60,7 @@ namespace hazelcast {
                             f.get();
                             return client_proxy;
                         } catch (...) {
-                            std::lock_guard<std::mutex> guard(lock_);
+                            std::lock_guard<std::recursive_mutex> guard(lock_);
                             proxies_.erase(ns);
                             throw;
                         }
@@ -103,7 +103,7 @@ namespace hazelcast {
                 }
 
                 proxy_map proxies_;
-                std::mutex lock_;
+                std::recursive_mutex lock_;
                 ClientContext &client_;
             };
         }

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientExecutionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientExecutionServiceImpl.h
@@ -73,7 +73,6 @@ namespace hazelcast {
                     std::unique_ptr<hazelcast::util::hz_thread_pool> internal_executor_;
                     spi::lifecycle_service &lifecycle_service_;
                     const client_properties &client_properties_;
-                    int user_executor_pool_size_;
 
                     template<typename CompletionToken>
                     std::shared_ptr<boost::asio::steady_timer> schedule_with_repetition_internal(CompletionToken token,

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -204,7 +204,7 @@ namespace hazelcast {
 
                     std::shared_ptr<protocol::ClientMessage> copy_message();
 
-                    void set_exception(const exception::iexception &e, boost::exception_ptr exception_ptr);
+                    void set_exception(const std::exception &e, boost::exception_ptr exception_ptr);
 
                     void log_exception(exception::iexception &e);
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocationServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocationServiceImpl.h
@@ -18,7 +18,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <boost/thread/executors/basic_thread_pool.hpp>
 
 #include "hazelcast/util/export.h"
 #include "hazelcast/client/protocol/IMessageHandler.h"
@@ -73,8 +72,6 @@ namespace hazelcast {
 
                     void add_backup_listener();
 
-                    boost::basic_thread_pool &get_invocation_thread_pool();
-
                 private:
                     class BackupListenerMessageCodec : public ListenerMessageCodec {
                     public:
@@ -98,7 +95,6 @@ namespace hazelcast {
                     bool backup_acks_enabled_;
                     bool fail_on_indeterminate_operation_state_;
                     std::chrono::milliseconds backup_timeout_;
-                    boost::basic_thread_pool invocation_thread_pool_;
 
                     static void write_to_connection(connection::Connection &connection,
                                            const std::shared_ptr<ClientInvocation> &client_invocation);

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocationServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocationServiceImpl.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <boost/thread/executors/basic_thread_pool.hpp>
 
 #include "hazelcast/util/export.h"
 #include "hazelcast/client/protocol/IMessageHandler.h"
@@ -71,6 +72,9 @@ namespace hazelcast {
                     bool fail_on_indeterminate_state() const;
 
                     void add_backup_listener();
+
+                    boost::basic_thread_pool &get_invocation_thread_pool();
+
                 private:
                     class BackupListenerMessageCodec : public ListenerMessageCodec {
                     public:
@@ -94,6 +98,7 @@ namespace hazelcast {
                     bool backup_acks_enabled_;
                     bool fail_on_indeterminate_operation_state_;
                     std::chrono::milliseconds backup_timeout_;
+                    boost::basic_thread_pool invocation_thread_pool_;
 
                     static void write_to_connection(connection::Connection &connection,
                                            const std::shared_ptr<ClientInvocation> &client_invocation);

--- a/hazelcast/include/hazelcast/util/hz_thread_pool.h
+++ b/hazelcast/include/hazelcast/util/hz_thread_pool.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <boost/asio/thread_pool.hpp>
+#include <boost/thread/executors/work.hpp>
 
 #include "hazelcast/util/export.h"
 
@@ -28,13 +29,23 @@ namespace hazelcast {
     namespace util {
         class HAZELCAST_API hz_thread_pool {
         public:
-            hz_thread_pool(size_t num_threads);
+            explicit hz_thread_pool();
 
-            void shutdown_gracefully();
+            explicit hz_thread_pool(size_t num_threads);
+
+            void close();
+
+            bool closed();
+
+            void submit(boost::executors::work &&closure);
+
+            bool try_executing_one();
 
             boost::asio::thread_pool::executor_type get_executor() const;
+
         private:
             std::unique_ptr<boost::asio::thread_pool> pool_;
+            std::atomic<bool> closed_{false};
         };
     }
 }

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -251,7 +251,7 @@ namespace hazelcast {
             hazelcast_client_instance_impl::init_execution_service() {
                 return std::make_shared<spi::impl::ClientExecutionServiceImpl>(instance_name_, client_properties_,
                                                                                client_config_.get_executor_pool_size(),
-                                                                               lifecycle_service_);
+                                                                               lifecycle_service_, logger_);
             }
 
             std::shared_ptr<connection::ClientConnectionManagerImpl>

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -251,7 +251,7 @@ namespace hazelcast {
             hazelcast_client_instance_impl::init_execution_service() {
                 return std::make_shared<spi::impl::ClientExecutionServiceImpl>(instance_name_, client_properties_,
                                                                                client_config_.get_executor_pool_size(),
-                                                                               lifecycle_service_, logger_);
+                                                                               lifecycle_service_);
             }
 
             std::shared_ptr<connection::ClientConnectionManagerImpl>

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -1367,11 +1367,12 @@ namespace hazelcast {
                                                                                    processor,
                                                                                    key,
                                                                                    util::get_current_thread_id());
-                return invoke_on_partition(request, get_partition_id(key)).then([] (boost::future<protocol::ClientMessage> f) {
-                    auto msg = f.get();
-                    msg.skip_frame();
-                    return msg.get_nullable<serialization::pimpl::data>();
-                });
+                return invoke_on_partition(request, get_partition_id(key)).then(boost::launch::sync,
+                                                                                [](boost::future<protocol::ClientMessage> f) {
+                                                                                    auto msg = f.get();
+                                                                                    msg.skip_frame();
+                                                                                    return msg.get_nullable<serialization::pimpl::data>();
+                                                                                });
             }
 
             boost::future<EntryVector> IMapImpl::execute_on_keys_data(const std::vector<serialization::pimpl::data> &keys,

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -572,6 +572,7 @@ namespace hazelcast {
 
                 void ClientInvocationServiceImpl::shutdown() {
                     is_shutdown_.store(true);
+                    invocation_thread_pool_.interrupt_and_join();
                 }
 
                 std::chrono::milliseconds ClientInvocationServiceImpl::get_invocation_timeout() const {

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -102,7 +102,7 @@ namespace hazelcast {
             }
 
             void ProxyManager::destroy() {
-                std::lock_guard<std::mutex> guard(lock_);
+                std::lock_guard<std::recursive_mutex> guard(lock_);
                 for (auto &p : proxies_) {
                     try {
                         auto proxy = p.second.get();
@@ -134,7 +134,7 @@ namespace hazelcast {
                 DefaultObjectNamespace objectNamespace(proxy.get_service_name(), proxy.get_name());
                 std::shared_ptr<ClientProxy> registeredProxy;
                 {
-                    std::lock_guard<std::mutex> guard(lock_);
+                    std::lock_guard<std::recursive_mutex> guard(lock_);
                     auto it = proxies_.find(objectNamespace);
                     registeredProxy = it == proxies_.end() ? nullptr : it->second.get();
                     if (it != proxies_.end()) {

--- a/hazelcast/src/hazelcast/cp/cp.cpp
+++ b/hazelcast/src/hazelcast/cp/cp.cpp
@@ -337,7 +337,7 @@ namespace hazelcast {
         }
 
         boost::future<void> latch::wait() {
-            return to_void_future(wait_for((std::chrono::hours::max)()));
+            return to_void_future(wait_for(std::chrono::milliseconds(INT64_MAX)));
         }
 
         boost::future<std::cv_status> latch::wait_for(std::chrono::milliseconds timeout) {

--- a/hazelcast/src/hazelcast/logger.cpp
+++ b/hazelcast/src/hazelcast/logger.cpp
@@ -98,7 +98,7 @@ void logger::default_handler(const std::string &instance_name,
     {
         static std::mutex cout_lock;
         std::lock_guard<std::mutex> g(cout_lock);
-        std::cout << sstrm.str(); // TODO should we flush or not ?
+        std::cout << sstrm.str() << std::flush;
     }
 } 
 

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -958,12 +958,18 @@ namespace hazelcast {
             };
 
             TEST_P(ClusterTest, testBehaviourWhenClusterNotFound) {
-                ASSERT_THROW(hazelcast::new_client(GetParam()()).get(), exception::illegal_state);
+                auto c = GetParam()();
+                c.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(3));
+                ASSERT_THROW(hazelcast::new_client(std::move(c)).get(), exception::illegal_state);
             }
 
             TEST_P(ClusterTest, testDummyClientBehaviourWhenClusterNotFound) {
                 auto clientConfig = GetParam()();
                 clientConfig.get_network_config().set_smart_routing(false);
+                auto c = GetParam()();
+                clientConfig.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(3));
                 ASSERT_THROW(hazelcast::new_client(std::move(clientConfig)).get(), exception::illegal_state);
             }
 
@@ -1022,9 +1028,11 @@ namespace hazelcast {
                 boost::latch shuttingDownLatch(1);
                 boost::latch shutdownLatch(1);
                 auto listener = make_all_states_listener(startingLatch, startedLatch, connectedLatch, disconnectedLatch,
-                                                      shuttingDownLatch, shutdownLatch);
+                                                         shuttingDownLatch, shutdownLatch);
                 clientConfig.add_listener(std::move(listener));
 
+                clientConfig.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(3));
                 auto client = hazelcast::new_client(std::move(clientConfig)).get();
 
                 ASSERT_OPEN_EVENTUALLY(startingLatch);

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -1171,6 +1171,8 @@ namespace hazelcast {
                 HazelcastServer instance(*g_srvFactory);
                 client_config config;
                 config.set_cluster_name("invalid cluster");
+                config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(3));
 
                 ASSERT_THROW((hazelcast::new_client(std::move(config)).get()), exception::illegal_state);
             }


### PR DESCRIPTION
The problem at issue #764 seems to be failure to construct async detached thread for execution of the invocation response delivery. Hence, I decided that we use a limited thread pool instead of `boost::async` call which may have undetermined number of detached thread creation. Replaced `boost::launch::async` continuation with thread pool based continuation. The `boost::asio::thread_pool` default constructor is used for pool construction and it uses `hardware_concurrency() * 2;` with a minimum of 2 threads for execution. 

Minor fixes: 

1. Made the network address tcp/ip `resolver` work async so that cancellation work properly on cancel. 
2. Flush the log `cout` by default for every log. This is needed since in case of failures and crashes we lose some of the logs. Since, writing log is not in critical path, it will not be a problem in terms of performance.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/764