### PR TITLE
Fix cmake install file path for generated cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,8 @@ function(add_hazelcast_library name type)
     # install -config.cmake and -config-version.cmake files
     install(
         FILES
-            ${CMAKE_BINARY_DIR}/${name}-config.cmake
-            ${CMAKE_BINARY_DIR}/${name}-config-version.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/${name}-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/${name}-config-version.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${name}
     )
 endfunction()


### PR DESCRIPTION
Use `CMAKE_CURRENT_BINARY_DIR` instead of `CMAKE_BINARY_DIR` for the generated files so that the project install works when included as a sub-project.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/809