### PR TITLE
Make lib and cmake target names the same as repository name, do NOT support cmake install multiple configurations simultaneously

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ option(WITH_OPENSSL
        "Build with OpenSSL. Setting this option to ON enables SSL-related features."
        OFF)
 
-option(BUILD_SHARED_LIB
+option(BUILD_SHARED_LIBS
        "Build shared library."
        ON)
 
@@ -233,7 +233,7 @@ function(add_hazelcast_library type)
 endfunction()
 
 # add library
-if (BUILD_SHARED_LIB)
+if (BUILD_SHARED_LIBS)
     set(LIB_TYPE SHARED)
 else()
     set(LIB_TYPE STATIC)
@@ -252,16 +252,10 @@ install(
     FILES_MATCHING PATTERN "*.h"
 )
 
-set(DEFAULT_LIBRARY_FOR_TESTS_AND_EXAMPLES ${PROJECT_NAME})
-
 if (BUILD_TESTS)
-    set(LIBRARY_FOR_TESTS ${PROJECT_NAME})
-
     add_subdirectory(hazelcast/test)
 endif ()
 
 if (BUILD_EXAMPLES)
-    set(LIBRARY_FOR_EXAMPLES ${PROJECT_NAME})
-
     add_subdirectory(examples)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,146 +92,6 @@ if (WITH_OPENSSL)
     find_package(OpenSSL REQUIRED)
 endif ()
 
-
-function(add_hazelcast_library type)
-    # add the library target
-    add_library(
-        ${PROJECT_NAME}
-        ${type}
-        ${SOURCE_FILES} ${HEADER_FILES}
-    )
-
-    # set library's version and soversion
-    set_target_properties(
-        ${PROJECT_NAME}
-        PROPERTIES
-            VERSION ${PROJECT_VERSION}
-            SOVERSION ${PROJECT_VERSION}
-    )
-
-    # library requires c++11
-    target_compile_features(
-        ${PROJECT_NAME}
-        PUBLIC cxx_std_11
-    )
-
-    # links the library against the system's thread library
-    target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
-
-    # add Boost::thread and Boost::chrono as dependencies
-    target_link_libraries(
-        ${PROJECT_NAME}
-        PUBLIC Boost::boost Boost::thread Boost::chrono
-    )
-    # set the Boost thread version
-    target_compile_definitions(
-        ${PROJECT_NAME}
-        PUBLIC BOOST_THREAD_VERSION=5
-    )
-
-    # If building WITH_OPENSSL, add OpenSSL::SSL and OpenSSL::Crypto as dependencies
-    # Both we and the user defines HZ_BUILD_WITH_SSL.
-    if (WITH_OPENSSL)
-        target_compile_definitions(
-            ${PROJECT_NAME}
-            PUBLIC HZ_BUILD_WITH_SSL
-        )
-        target_link_libraries(${PROJECT_NAME} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
-    endif()
-
-    # MSVC-specific compiler flags
-    if (MSVC)
-      target_compile_options(${PROJECT_NAME} PRIVATE /bigobj)
-    endif ()
-
-    # windows-specific compile flags
-    if (WIN32)
-        # speeds the build process
-        target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
-    endif ()
-
-    # add include directories
-    target_include_directories(
-        ${PROJECT_NAME}
-        PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hazelcast/include>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hazelcast/generated-sources/src>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
-
-    # add compile flags for version and git commit information
-    target_compile_definitions(
-        ${PROJECT_NAME}
-        PRIVATE
-            HAZELCAST_VERSION="${PROJECT_VERSION}"
-            HAZELCAST_GIT_COMMIT_DATE=${GIT_COMMIT_DATE}
-            HAZELCAST_GIT_COMMIT_ID=${GIT_COMMIT_ID}
-    )
-
-    if (DISABLE_LOGGING)
-        target_compile_definitions(${PROJECT_NAME} PUBLIC HZ_LOGGING_DISABLED)
-    endif ()
-
-    set_target_properties(${PROJECT_NAME} PROPERTIES DEFINE_SYMBOL HAZELCAST_EXPORTS)
-
-    generate_export_header(
-        ${PROJECT_NAME}
-        BASE_NAME hazelcast
-        EXPORT_MACRO_NAME HAZELCAST_API
-        EXPORT_FILE_NAME include/hazelcast/util/export.h
-        NO_EXPORT_MACRO_NAME HAZELCAST_PRIVATE
-        STATIC_DEFINE HAZELCAST_USE_STATIC
-    )
-
-    if (type STREQUAL "STATIC")
-        target_compile_definitions(${PROJECT_NAME} PUBLIC HAZELCAST_USE_STATIC)
-    endif()
-
-    # install library target
-    install(
-        TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
-
-    # install the -targets.cmake file
-    install(
-        EXPORT ${PROJECT_NAME}-targets
-        FILE ${PROJECT_NAME}-targets.cmake
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-    )
-
-    # configure -config-version.cmake file
-    write_basic_package_version_file(
-        ${PROJECT_NAME}-config-version.cmake
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion
-    )
-
-    # configure -config.cmake file
-    set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
-    set(LIBRARY_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
-    configure_package_config_file(
-        cmake/config.cmake.in
-        ${PROJECT_NAME}-config.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-        PATH_VARS INCLUDE_INSTALL_DIR LIBRARY_INSTALL_DIR
-    )
-
-    # install -config.cmake and -config-version.cmake files
-    install(
-        FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-    )
-endfunction()
-
 # add library
 if (BUILD_SHARED_LIBS)
     set(LIB_TYPE SHARED)
@@ -239,7 +99,142 @@ else()
     set(LIB_TYPE STATIC)
 endif()
 
-add_hazelcast_library(${LIB_TYPE})
+# add the library target
+add_library(
+        ${PROJECT_NAME}
+        ${LIB_TYPE}
+        ${SOURCE_FILES} ${HEADER_FILES}
+)
+
+# set library's version and soversion
+set_target_properties(
+        ${PROJECT_NAME}
+        PROPERTIES
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION}
+)
+
+# library requires c++11
+target_compile_features(
+        ${PROJECT_NAME}
+        PUBLIC cxx_std_11
+)
+
+# links the library against the system's thread library
+target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
+
+# add Boost::thread and Boost::chrono as dependencies
+target_link_libraries(
+        ${PROJECT_NAME}
+        PUBLIC Boost::boost Boost::thread Boost::chrono
+)
+# set the Boost thread version
+target_compile_definitions(
+        ${PROJECT_NAME}
+        PUBLIC BOOST_THREAD_VERSION=5
+)
+
+# If building WITH_OPENSSL, add OpenSSL::SSL and OpenSSL::Crypto as dependencies
+# Both we and the user defines HZ_BUILD_WITH_SSL.
+if (WITH_OPENSSL)
+    target_compile_definitions(
+            ${PROJECT_NAME}
+            PUBLIC HZ_BUILD_WITH_SSL
+    )
+    target_link_libraries(${PROJECT_NAME} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
+# MSVC-specific compiler flags
+if (MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /bigobj)
+endif ()
+
+# windows-specific compile flags
+if (WIN32)
+    # speeds the build process
+    target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
+endif ()
+
+# add include directories
+target_include_directories(
+        ${PROJECT_NAME}
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hazelcast/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hazelcast/generated-sources/src>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# add compile flags for version and git commit information
+target_compile_definitions(
+        ${PROJECT_NAME}
+        PRIVATE
+        HAZELCAST_VERSION="${PROJECT_VERSION}"
+        HAZELCAST_GIT_COMMIT_DATE=${GIT_COMMIT_DATE}
+        HAZELCAST_GIT_COMMIT_ID=${GIT_COMMIT_ID}
+)
+
+if (DISABLE_LOGGING)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC HZ_LOGGING_DISABLED)
+endif ()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES DEFINE_SYMBOL HAZELCAST_EXPORTS)
+
+generate_export_header(
+        ${PROJECT_NAME}
+        BASE_NAME hazelcast
+        EXPORT_MACRO_NAME HAZELCAST_API
+        EXPORT_FILE_NAME include/hazelcast/util/export.h
+        NO_EXPORT_MACRO_NAME HAZELCAST_PRIVATE
+        STATIC_DEFINE HAZELCAST_USE_STATIC
+)
+
+if (type STREQUAL "STATIC")
+    target_compile_definitions(${PROJECT_NAME} PUBLIC HAZELCAST_USE_STATIC)
+endif()
+
+# install library target
+install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# install the -targets.cmake file
+install(
+        EXPORT ${PROJECT_NAME}-targets
+        FILE ${PROJECT_NAME}-targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+# configure -config-version.cmake file
+write_basic_package_version_file(
+        ${PROJECT_NAME}-config-version.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+)
+
+# configure -config.cmake file
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+set(LIBRARY_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+configure_package_config_file(
+        cmake/config.cmake.in
+        ${PROJECT_NAME}-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        PATH_VARS INCLUDE_INSTALL_DIR LIBRARY_INSTALL_DIR
+)
+
+# install -config.cmake and -config-version.cmake files
+install(
+        FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
 
 # install header files, this applies both to the shared and the static library
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,6 @@ option(WITH_OPENSSL
        "Build with OpenSSL. Setting this option to ON enables SSL-related features."
        OFF)
 
-option(BUILD_STATIC_LIB
-       "Build static library."
-       OFF)
-
 option(BUILD_SHARED_LIB
        "Build shared library."
        ON)
@@ -75,12 +71,6 @@ option(BUILD_TESTS
 option(BUILD_EXAMPLES
        "Build examples."
        OFF)
-
-# exit with an error message if none of BUILD_SHARED_LIB and BUILD_STATIC_LIB was set.
-if ((NOT BUILD_SHARED_LIB) AND (NOT BUILD_STATIC_LIB))
-    message(FATAL_ERROR
-            "Set at least one of BUILD_SHARED_LIB and BUILD_STATIC_LIB to ON.")
-endif ()
 
 # find dependencies
 
@@ -103,17 +93,17 @@ if (WITH_OPENSSL)
 endif ()
 
 
-function(add_hazelcast_library name type)
+function(add_hazelcast_library type)
     # add the library target
     add_library(
-        ${name}
+        ${PROJECT_NAME}
         ${type}
         ${SOURCE_FILES} ${HEADER_FILES}
     )
 
     # set library's version and soversion
     set_target_properties(
-        ${name}
+        ${PROJECT_NAME}
         PROPERTIES
             VERSION ${PROJECT_VERSION}
             SOVERSION ${PROJECT_VERSION}
@@ -121,21 +111,21 @@ function(add_hazelcast_library name type)
 
     # library requires c++11
     target_compile_features(
-        ${name}
+        ${PROJECT_NAME}
         PUBLIC cxx_std_11
     )
 
     # links the library against the system's thread library
-    target_link_libraries(${name} PUBLIC Threads::Threads)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
 
     # add Boost::thread and Boost::chrono as dependencies
     target_link_libraries(
-        ${name}
+        ${PROJECT_NAME}
         PUBLIC Boost::boost Boost::thread Boost::chrono
     )
     # set the Boost thread version
     target_compile_definitions(
-        ${name}
+        ${PROJECT_NAME}
         PUBLIC BOOST_THREAD_VERSION=5
     )
 
@@ -143,26 +133,26 @@ function(add_hazelcast_library name type)
     # Both we and the user defines HZ_BUILD_WITH_SSL.
     if (WITH_OPENSSL)
         target_compile_definitions(
-            ${name}
+            ${PROJECT_NAME}
             PUBLIC HZ_BUILD_WITH_SSL
         )
-        target_link_libraries(${name} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+        target_link_libraries(${PROJECT_NAME} PUBLIC OpenSSL::SSL OpenSSL::Crypto)
     endif()
 
     # MSVC-specific compiler flags
     if (MSVC)
-      target_compile_options(${name} PRIVATE /bigobj)
+      target_compile_options(${PROJECT_NAME} PRIVATE /bigobj)
     endif ()
 
     # windows-specific compile flags
     if (WIN32)
         # speeds the build process
-        target_compile_definitions(${name} PRIVATE WIN32_LEAN_AND_MEAN)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
     endif ()
 
     # add include directories
     target_include_directories(
-        ${name}
+        ${PROJECT_NAME}
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hazelcast/include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hazelcast/generated-sources/src>
@@ -172,7 +162,7 @@ function(add_hazelcast_library name type)
 
     # add compile flags for version and git commit information
     target_compile_definitions(
-        ${name}
+        ${PROJECT_NAME}
         PRIVATE
             HAZELCAST_VERSION="${PROJECT_VERSION}"
             HAZELCAST_GIT_COMMIT_DATE=${GIT_COMMIT_DATE}
@@ -180,13 +170,13 @@ function(add_hazelcast_library name type)
     )
 
     if (DISABLE_LOGGING)
-        target_compile_definitions(${name} PUBLIC HZ_LOGGING_DISABLED)
+        target_compile_definitions(${PROJECT_NAME} PUBLIC HZ_LOGGING_DISABLED)
     endif ()
 
-    set_target_properties(${name} PROPERTIES DEFINE_SYMBOL HAZELCAST_EXPORTS)
+    set_target_properties(${PROJECT_NAME} PROPERTIES DEFINE_SYMBOL HAZELCAST_EXPORTS)
 
     generate_export_header(
-        ${name}
+        ${PROJECT_NAME}
         BASE_NAME hazelcast
         EXPORT_MACRO_NAME HAZELCAST_API
         EXPORT_FILE_NAME include/hazelcast/util/export.h
@@ -195,13 +185,13 @@ function(add_hazelcast_library name type)
     )
 
     if (type STREQUAL "STATIC")
-        target_compile_definitions(${name} PUBLIC HAZELCAST_USE_STATIC)
+        target_compile_definitions(${PROJECT_NAME} PUBLIC HAZELCAST_USE_STATIC)
     endif()
 
     # install library target
     install(
-        TARGETS ${name}
-        EXPORT ${name}-targets
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -210,15 +200,15 @@ function(add_hazelcast_library name type)
 
     # install the -targets.cmake file
     install(
-        EXPORT ${name}-targets
-        FILE ${name}-targets.cmake
-        NAMESPACE hazelcast::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${name}
+        EXPORT ${PROJECT_NAME}-targets
+        FILE ${PROJECT_NAME}-targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
     )
 
     # configure -config-version.cmake file
     write_basic_package_version_file(
-        ${name}-config-version.cmake
+        ${PROJECT_NAME}-config-version.cmake
         VERSION ${PROJECT_VERSION}
         COMPATIBILITY SameMajorVersion
     )
@@ -228,41 +218,28 @@ function(add_hazelcast_library name type)
     set(LIBRARY_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
     configure_package_config_file(
         cmake/config.cmake.in
-        ${name}-config.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${name}
+        ${PROJECT_NAME}-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
         PATH_VARS INCLUDE_INSTALL_DIR LIBRARY_INSTALL_DIR
     )
 
     # install -config.cmake and -config-version.cmake files
     install(
         FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/${name}-config.cmake
-            ${CMAKE_CURRENT_BINARY_DIR}/${name}-config-version.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${name}
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
     )
 endfunction()
 
-# the base name for shared and static libraries
-set(BASE_LIBRARY_NAME hazelcastcxx)
-# add the _ssl suffix to the base name if building WITH_OPENSSL
-if (WITH_OPENSSL)
-    set(BASE_LIBRARY_NAME ${BASE_LIBRARY_NAME}_ssl)
-endif()
-
-# set the names for the shared and static libraries
-set(SHARED_LIBRARY_NAME ${BASE_LIBRARY_NAME})
-set(STATIC_LIBRARY_NAME ${BASE_LIBRARY_NAME}_static)
-
-# add static library if requested
-if (BUILD_STATIC_LIB)
-    add_hazelcast_library(${STATIC_LIBRARY_NAME} STATIC)
-endif()
-
-# add shared library if requested
+# add library
 if (BUILD_SHARED_LIB)
-    add_hazelcast_library(${SHARED_LIBRARY_NAME} SHARED)
+    set(LIB_TYPE SHARED)
+else()
+    set(LIB_TYPE STATIC)
 endif()
 
+add_hazelcast_library(${LIB_TYPE})
 
 # install header files, this applies both to the shared and the static library
 install(
@@ -275,23 +252,16 @@ install(
     FILES_MATCHING PATTERN "*.h"
 )
 
-# since shared and static libraries can be requested for the build at the same time,
-# we need a default one to use for tests and examples.
-# the static library is preferred to the shared library, because it is OFF by default.
-if (BUILD_STATIC_LIB)
-    set(DEFAULT_LIBRARY_FOR_TESTS_AND_EXAMPLES ${STATIC_LIBRARY_NAME})
-else ()
-    set(DEFAULT_LIBRARY_FOR_TESTS_AND_EXAMPLES ${SHARED_LIBRARY_NAME})
-endif ()
+set(DEFAULT_LIBRARY_FOR_TESTS_AND_EXAMPLES ${PROJECT_NAME})
 
 if (BUILD_TESTS)
-    set(LIBRARY_FOR_TESTS ${DEFAULT_LIBRARY_FOR_TESTS_AND_EXAMPLES})
+    set(LIBRARY_FOR_TESTS ${PROJECT_NAME})
 
     add_subdirectory(hazelcast/test)
 endif ()
 
 if (BUILD_EXAMPLES)
-    set(LIBRARY_FOR_EXAMPLES ${DEFAULT_LIBRARY_FOR_TESTS_AND_EXAMPLES})
+    set(LIBRARY_FOR_EXAMPLES ${PROJECT_NAME})
 
     add_subdirectory(examples)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ function(add_hazelcast_library type)
         EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}-targets.cmake
         NAMESPACE ${PROJECT_NAME}::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
     )
 
     # configure -config-version.cmake file
@@ -219,7 +219,7 @@ function(add_hazelcast_library type)
     configure_package_config_file(
         cmake/config.cmake.in
         ${PROJECT_NAME}-config.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
         PATH_VARS INCLUDE_INSTALL_DIR LIBRARY_INSTALL_DIR
     )
 
@@ -228,7 +228,7 @@ function(add_hazelcast_library type)
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
     )
 endfunction()
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ if you are using a custom installation location.
 
 #### 1.3.2. Linux and MacOS Users
 You can pass the `-lhazelcast-cpp-client` option to the compiler to link against 
-the client library. The name of library depends on how it was configured during build time. 
+the client library.
 
 The client library depends on Boost.Thread and Boost.Chrono. 
 You should also link your program against these libraries using `-lboost_thread` and `-lboost_chrono`.

--- a/README.md
+++ b/README.md
@@ -252,18 +252,17 @@ You can provide additional configuration options using the `-DVARIABLE=VALUE` sy
 Here are all the options that are supported:
 * `WITH_OPENSSL` : Set to `ON` to build the library with SSL support.
 This will require [OpenSSL](https://www.openssl.org) to be installed on your system. The default is `OFF`.
-* `BUILD_STATIC_LIB` : Set to `ON` or `OFF` depending on whether you want the static library. The default is `OFF`.
-* `BUILD_SHARED_LIB` : Set to `ON` or `OFF` depending on whether you want the shared library. The default is `ON`.
+* `BUILD_SHARED_LIBS` : Set to `ON` or `OFF` depending on whether you want the shared(ON) or static(OFF) library. The default is `ON`.
 * `DISABLE_LOGGING` : Setting this option to `ON` disables logging. The default is `OFF`.
 
 ##### 1.1.5.2.1 Example Configuration Commands
 Build only the static library with SSL support:
 ```sh
-cmake .. -DWITH_OPENSSL=ON -DBUILD_SHARED_LIB=OFF -DBUILD_STATIC_LIB=ON
+cmake .. -DWITH_OPENSSL=ON -DBUILD_SHARED_LIBS=OFF
 ```
-Build both the shared and static library without SSL support:
+Build both the shared library without SSL support:
 ```sh
-cmake .. -DWITH_OPENSSL=OFF -DBUILD_SHARED_LIB=ON -DBUILD_STATIC_LIB=ON
+cmake .. -DWITH_OPENSSL=OFF 
 ```
 
 ## 1.2. Starting Hazelcast IMDG Cluster
@@ -354,22 +353,17 @@ If you are not, then read the instructions specific to your platform:
 A Hazelcast IMDG C++ client installation comes with package configuration files for CMake. 
 If your project is using CMake, you can easily find and link against the client library:
 ```cmake
-find_package(hazelcastcxx)
+find_package(hazelcast-cpp-client CONFIG REQUIRED)
 
-target_link_libraries(mytarget PUBLIC hazelcast::hazelcastcxx)
-```  
-
-The package name depends on the specific library type you want to use. 
-Options are `hazelcastcxx`, `hazelcastcxx_ssl`, `hazelcastcxx_static`, and `hazelcastcxx_ssl_static`.
+target_link_libraries(mytarget PRIVATE hazelcast-cpp-client::hazelcast-cpp-client)
+```
 
 Make sure you add the installation prefix of the client library to `CMAKE_PREFIX_PATH` 
 if you are using a custom installation location. 
 
 #### 1.3.2. Linux and MacOS Users
-You can pass the `-lhazelcastcxx` or `-lhazelcastcxx_ssl` option to the compiler to link against 
+You can pass the `-lhazelcast-cpp-client` option to the compiler to link against 
 the client library. The name of library depends on how it was configured during build time. 
-If the library was built with `-DWITH_OPENSSL=ON`, then the name is `hazelcastcxx_ssl`.
-If it was built with `-DWITH_OPENSSL=OFF`, then the name is `hazelcastcxx`. 
 
 The client library depends on Boost.Thread and Boost.Chrono. 
 You should also link your program against these libraries using `-lboost_thread` and `-lboost_chrono`.
@@ -381,7 +375,7 @@ Here is how you can compile an example from the examples directory:
 g++ -std=c++11 \
     examples/path/to/example.cpp \
     -DBOOST_THREAD_VERSION=5 \
-    -lhazelcastcxx -lboost_thread -lboost_chrono
+    -lhazelcast-cpp-client -lboost_thread -lboost_chrono
 ``` 
 
 If a custom installation directory was used during installation, then you may also need to use the `-L` and `-I`
@@ -390,7 +384,7 @@ options to add the library and include paths to the compiler's search path.
 g++ -std=c++11 \
     examples/path/to/example.cpp \
     -I /path/to/install/include -L /path/to/install/lib \
-    -lhazelcastcxx -lboost_thread -lboost_chrono 
+    -lhazelcast-cpp-client -lboost_thread -lboost_chrono 
 ```
 
 #### 1.3.3. Windows Users
@@ -402,7 +396,7 @@ for necessary features such as futures and future continuations to be enabled.
 The following is a command that can be used to compile an example from the examples directory.
 ```bat
 cl.exe path\to\example.cpp ^
-    C:\path\to\hazelcast\lib\hazelcastcxx.lib ^
+    C:\path\to\hazelcast\lib\hazelcast-cpp-client.lib ^
     C:\path\to\boost\lib\boost_thread.lib C:\path\to\boost\lib\boost_chrono.lib ^
     /EHsc /DBOOST_THREAD_VERSION=5 ^
     /I C:\path\to\hazelcast\include /I C:\path\to\boost\include
@@ -596,7 +590,7 @@ Let's manipulate a distributed map on a cluster using the client.
 Save the following file as `IT.cpp` and compile it using a command similar to the following (Linux g++ compilation is used for demonstration):
 
 ```C++
-g++ IT.cpp -o IT -lhazelcastcxx -lboost_thread -lboost_chrono -DBOOST_THREAD_VERSION=5
+g++ IT.cpp -o IT -lhazelcast-cpp-client -lboost_thread -lboost_chrono -DBOOST_THREAD_VERSION=5
 ```
 Then, you can run the application using the following command:
  
@@ -651,7 +645,7 @@ Now create a `Sales.cpp` file, compile and run it as shown below.
 **Compile:**
 
 ```C++
-g++ Sales.cpp -o Sales -lhazelcastcxx -lboost_thread -lboost_chrono -DBOOST_THREAD_VERSION=5
+g++ Sales.cpp -o Sales -lhazelcast-cpp-client -lboost_thread -lboost_chrono -DBOOST_THREAD_VERSION=5
 ```
 **Run**
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ If your project is using CMake, you can easily find and link against the client 
 ```cmake
 find_package(hazelcast-cpp-client CONFIG REQUIRED)
 
-target_link_libraries(mytarget PRIVATE hazelcast-cpp-client::hazelcast-cpp-client)
+target_link_libraries(mytarget PRIVATE hazelcast-cpp-client)
 ```
 
 Make sure you add the installation prefix of the client library to `CMAKE_PREFIX_PATH` 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
     * [1.1.5. Advanced Installation](#115-advanced-installation)
       * [1.1.5.1. Custom Install Location](#1151-custom-install-location)
       * [1.1.5.2. CMake Configuration](#1152-cmake-configuration)
-        * [1.1.5.2.1 Example Configuration Commands](#11521-example-configuration-commands)
   * [1.2. Starting Hazelcast IMDG Cluster](#12-starting-hazelcast-imdg-cluster)
     * [1.2.1. Starting Hazelcast Server](#121-starting-hazelcast-server)
       * [1.2.1.1. Starting Server Using Hazelcast Docker Images](#1211-starting-server-using-hazelcast-docker-images)
@@ -255,14 +254,9 @@ This will require [OpenSSL](https://www.openssl.org) to be installed on your sys
 * `BUILD_SHARED_LIBS` : Set to `ON` or `OFF` depending on whether you want the shared(ON) or static(OFF) library. The default is `ON`.
 * `DISABLE_LOGGING` : Setting this option to `ON` disables logging. The default is `OFF`.
 
-##### 1.1.5.2.1 Example Configuration Commands
-Build only the static library with SSL support:
+For example, if you want to build the static library with SSL support, you can use the following command:
 ```sh
 cmake .. -DWITH_OPENSSL=ON -DBUILD_SHARED_LIBS=OFF
-```
-Build both the shared library without SSL support:
-```sh
-cmake .. -DWITH_OPENSSL=OFF 
 ```
 
 ## 1.2. Starting Hazelcast IMDG Cluster
@@ -355,7 +349,7 @@ If your project is using CMake, you can easily find and link against the client 
 ```cmake
 find_package(hazelcast-cpp-client CONFIG REQUIRED)
 
-target_link_libraries(mytarget PRIVATE hazelcast-cpp-client)
+target_link_libraries(mytarget PRIVATE hazelcast-cpp-client::hazelcast-cpp-client)
 ```
 
 Make sure you add the installation prefix of the client library to `CMAKE_PREFIX_PATH` 

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -8,10 +8,10 @@ if (@WITH_OPENSSL@)
     find_dependency(OpenSSL)
 endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/@name@-targets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/hazelcast-cpp-client-targets.cmake)
 
-set_and_check(@name@_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
-set_and_check(@name@_LIBRARY_DIRS @PACKAGE_LIBRARY_INSTALL_DIR@)
-set(@name@_LIBRARIES hazelcast::@name@)
+set_and_check(hazelcast-cpp-client_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
+set_and_check(hazelcast-cpp-client_LIBRARY_DIRS @PACKAGE_LIBRARY_INSTALL_DIR@)
+set(hazelcast-cpp-client_LIBRARIES hazelcast-cpp-client::hazelcast-cpp-client)
 
-check_required_components(@name@)
+check_required_components(hazelcast-cpp-client)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -8,10 +8,10 @@ if (@WITH_OPENSSL@)
     find_dependency(OpenSSL)
 endif()
 
-include(${CMAKE_CURRENT_LIST_DIR}/hazelcast-cpp-client-targets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
 
-set_and_check(hazelcast-cpp-client_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
-set_and_check(hazelcast-cpp-client_LIBRARY_DIRS @PACKAGE_LIBRARY_INSTALL_DIR@)
-set(hazelcast-cpp-client_LIBRARIES hazelcast-cpp-client::hazelcast-cpp-client)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS @PACKAGE_LIBRARY_INSTALL_DIR@)
+set(@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@)
 
-check_required_components(hazelcast-cpp-client)
+check_required_components(@PROJECT_NAME@)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,23 +25,18 @@ project (hazelcast-cpp-client-examples
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if (NOT LIBRARY_FOR_EXAMPLES)
-    message(FATAL_ERROR "Specify LIBRARY_FOR_EXAMPLES")
-endif()
+set(LIBRARY_FOR_EXAMPLES "hazelcast-cpp-client")
 
 if (NOT TARGET ${LIBRARY_FOR_EXAMPLES})
     message(STATUS "${LIBRARY_FOR_EXAMPLES} is not a valid target, using find_package to find it.")
-    find_package(${LIBRARY_FOR_EXAMPLES} REQUIRED)
-    # the found target will have the namespace hazelcast::
-    set(LIBRARY_FOR_EXAMPLES hazelcast::${LIBRARY_FOR_EXAMPLES})
+    find_package(${LIBRARY_FOR_EXAMPLES} CONFIG REQUIRED)
 endif()
 
 if (MSVC)
     add_compile_options(/bigobj)
 endif()
 
-message(STATUS "Examples will be built with ${LIBRARY_FOR_EXAMPLES}")
-link_libraries(${LIBRARY_FOR_EXAMPLES}) # TODO find a better way to do this
+link_libraries(hazelcast-cpp-client::hazelcast-cpp-client) # TODO find a better way to do this
 
 add_subdirectory(transactions)
 add_subdirectory(spi)
@@ -64,7 +59,7 @@ add_subdirectory(authentication)
 add_subdirectory(cp)
 add_subdirectory(soak-test)
 
-if (${LIBRARY_FOR_EXAMPLES} MATCHES "_ssl")
+if (${WITH_OPENSSL})
     add_subdirectory(tls)
     add_subdirectory(aws)
 endif ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -25,18 +25,17 @@ project (hazelcast-cpp-client-examples
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(LIBRARY_FOR_EXAMPLES "hazelcast-cpp-client")
-
-if (NOT TARGET ${LIBRARY_FOR_EXAMPLES})
-    message(STATUS "${LIBRARY_FOR_EXAMPLES} is not a valid target, using find_package to find it.")
-    find_package(${LIBRARY_FOR_EXAMPLES} CONFIG REQUIRED)
+if (NOT TARGET hazelcast-cpp-client)
+    message(STATUS "hazelcast-cpp-client is not a valid target, using find_package to find it.")
+    find_package(hazelcast-cpp-client REQUIRED)
+    link_libraries(hazelcast-cpp-client::hazelcast-cpp-client) # TODO find a better way to do this
+else()
+    link_libraries(hazelcast-cpp-client) # TODO find a better way to do this
 endif()
 
 if (MSVC)
     add_compile_options(/bigobj)
 endif()
-
-link_libraries(hazelcast-cpp-client::hazelcast-cpp-client) # TODO find a better way to do this
 
 add_subdirectory(transactions)
 add_subdirectory(spi)

--- a/hazelcast/test/src/CMakeLists.txt
+++ b/hazelcast/test/src/CMakeLists.txt
@@ -7,8 +7,7 @@ set(GOOGLETEST_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/hazelcast/test/googletest/googlet
 
 add_executable(client_test ${HZ_TEST_SOURCES} ${HZ_TEST_HEADERS})
 
-message(STATUS "${LIBRARY_FOR_TESTS} will be tested.")
-target_link_libraries(client_test PRIVATE ${LIBRARY_FOR_TESTS} gtest)
+target_link_libraries(client_test PRIVATE hazelcast-cpp-client gtest)
 
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     find_package(Thrift QUIET)

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -488,7 +488,7 @@ namespace hazelcast {
                     static void SetUpTestCase() {
                         instance = new HazelcastServer(*g_srvFactory);
                         client = new hazelcast_client{new_client(get_config()).get()};
-                        client2 = new hazelcast_client{new_client(std::move(get_config())).get()};
+                        client2 = new hazelcast_client{new_client(get_config()).get()};
                     }
 
                     static void TearDownTestCase() {

--- a/hazelcast/test/src/HazelcastTests3.cpp
+++ b/hazelcast/test/src/HazelcastTests3.cpp
@@ -606,7 +606,7 @@ namespace hazelcast {
                     instance1 = new HazelcastServer(*g_srvFactory);
                     instance2 = new HazelcastServer(*g_srvFactory);
                     client = new hazelcast_client{new_client(get_config()).get()};
-                    client2 = new hazelcast_client{new_client(std::move(get_config())).get()};
+                    client2 = new hazelcast_client{new_client(get_config()).get()};
                 }
 
                 static void TearDownTestCase() {
@@ -820,7 +820,7 @@ namespace hazelcast {
 
                 void create_no_near_cache_context() {
                     client_ = std::unique_ptr<hazelcast_client>(
-                            new hazelcast_client{new_client(std::move(get_config())).get()});
+                            new hazelcast_client{new_client(get_config()).get()});
                     no_near_cache_map_ = client_->get_replicated_map(get_test_name()).get();
                 }
 

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -248,7 +248,7 @@ namespace hazelcast {
 
                 void create_no_near_cache_context() {
                     client_ = std::unique_ptr<hazelcast_client>(
-                            new hazelcast_client{new_client(std::move(get_config())).get()});
+                            new hazelcast_client{new_client(get_config()).get()});
                     no_near_cache_map_ = client_->get_map(get_test_name()).get();
                 }
 

--- a/scripts/do-all-unix.sh
+++ b/scripts/do-all-unix.sh
@@ -33,7 +33,7 @@ fi
 ./scripts/build-unix.sh                      \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE           \
     -DCMAKE_INSTALL_PREFIX=$DESTINATION      \
-    -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS     \
+    -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS   \
     -DWITH_OPENSSL=$WITH_OPENSSL             \
     -DBUILD_TESTS=ON                         \
     -DBUILD_EXAMPLES=OFF

--- a/scripts/do-all-unix.sh
+++ b/scripts/do-all-unix.sh
@@ -24,20 +24,16 @@ fi
 
 DESTINATION=$(pwd)/destination
 
-# set BUILD_STATIC_LIB and BUILD_SHARED_LIB depending on LIBRARY_TYPE
-BUILD_STATIC_LIB=OFF
-BUILD_SHARED_LIB=OFF
-if [ "$LIBRARY_TYPE" == "SHARED" ]; then
-  BUILD_SHARED_LIB=ON;
-elif [ "$LIBRARY_TYPE" == "STATIC" ]; then
-  BUILD_STATIC_LIB=ON;
+# set BUILD_SHARED_LIBS depending on LIBRARY_TYPE
+BUILD_SHARED_LIBS=ON
+if [ "$LIBRARY_TYPE" == "STATIC" ]; then
+  BUILD_SHARED_LIBS=OFF;
 fi
 
 ./scripts/build-unix.sh                      \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE           \
     -DCMAKE_INSTALL_PREFIX=$DESTINATION      \
-    -DBUILD_STATIC_LIB=$BUILD_STATIC_LIB     \
-    -DBUILD_SHARED_LIB=$BUILD_SHARED_LIB     \
+    -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS     \
     -DWITH_OPENSSL=$WITH_OPENSSL             \
     -DBUILD_TESTS=ON                         \
     -DBUILD_EXAMPLES=OFF
@@ -53,16 +49,5 @@ fi
 
 export BUILD_DIR=build-examples
 
-# compute the library name depending on the parameters
-# hazelcastcxx, hazelcastcxx_ssl_static, hazecast_static etc.
-LIBRARY_FOR_EXAMPLES="hazelcastcxx"
-if [ "$WITH_OPENSSL" == "ON" ]; then
-  LIBRARY_FOR_EXAMPLES="${LIBRARY_FOR_EXAMPLES}_ssl"
-fi
-if [ "$LIBRARY_TYPE" == "STATIC" ]; then
-  LIBRARY_FOR_EXAMPLES="${LIBRARY_FOR_EXAMPLES}_static"
-fi
-
 ./scripts/verify-installation-unix.sh            \
-  -DCMAKE_PREFIX_PATH=$DESTINATION               \
-  -DLIBRARY_FOR_EXAMPLES=$LIBRARY_FOR_EXAMPLES
+  -DCMAKE_PREFIX_PATH=$DESTINATION -DWITH_OPENSSL=$WITH_OPENSSL

--- a/scripts/do-all-windows.bat
+++ b/scripts/do-all-windows.bat
@@ -13,21 +13,16 @@ set BUILD_CONFIGURATION=%BUILD_TYPE%
 
 set DESTINATION=%cd%\destination
 
-@REM set BUILD_STATIC_LIB and BUILD_SHARED_LIB depending on LIBRARY_TYPE
-set BUILD_STATIC_LIB=OFF
-set BUILD_SHARED_LIB=OFF
-if "%LIBRARY_TYPE%" == "SHARED" (
-    set BUILD_SHARED_LIB=ON
-)
+@REM set BUILD_SHARED_LIBS depending on LIBRARY_TYPE
+set BUILD_SHARED_LIBS=ON
 if "%LIBRARY_TYPE%" == "STATIC" (
-    set BUILD_STATIC_LIB=ON
+    set BUILD_SHARED_LIBS=OFF
 )
 
 call .\scripts\build-windows.bat                  ^
         -DCMAKE_CONFIGURATION_TYPES=%BUILD_TYPE%  ^
         -DCMAKE_INSTALL_PREFIX=%DESTINATION%      ^
-        -DBUILD_STATIC_LIB=%BUILD_STATIC_LIB%     ^
-        -DBUILD_SHARED_LIB=%BUILD_SHARED_LIB%     ^
+        -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%     ^
         -DWITH_OPENSSL=%WITH_OPENSSL%             ^
         -DBUILD_TESTS=ON                          ^
         -DBUILD_EXAMPLES=OFF                      ^
@@ -37,17 +32,7 @@ call .\scripts\test-windows.bat || exit /b 1
 
 set BUILD_DIR=build-examples
 
-@REM compute the library name depending on the parameters
-@REM hazelcastcxx, hazelcastcxx_ssl_static, hazecast_static etc.
-set LIBRARY_FOR_EXAMPLES=hazelcastcxx
-if "%WITH_OPENSSL%" == "ON" (
-    set LIBRARY_FOR_EXAMPLES=%LIBRARY_FOR_EXAMPLES%_ssl
-)
-if "%LIBRARY_TYPE%" == "STATIC" (
-    set LIBRARY_FOR_EXAMPLES=%LIBRARY_FOR_EXAMPLES%_static
-)
-
 call .\scripts\verify-installation-windows.bat     ^
     -DCMAKE_PREFIX_PATH=%DESTINATION%              ^
-    -DLIBRARY_FOR_EXAMPLES=%LIBRARY_FOR_EXAMPLES%  ^
+    -DWITH_OPENSSL=%WITH_OPENSSL%                  ^
      || exit /b 1

--- a/scripts/do-all-windows.bat
+++ b/scripts/do-all-windows.bat
@@ -22,7 +22,7 @@ if "%LIBRARY_TYPE%" == "STATIC" (
 call .\scripts\build-windows.bat                  ^
         -DCMAKE_CONFIGURATION_TYPES=%BUILD_TYPE%  ^
         -DCMAKE_INSTALL_PREFIX=%DESTINATION%      ^
-        -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%     ^
+        -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS%   ^
         -DWITH_OPENSSL=%WITH_OPENSSL%             ^
         -DBUILD_TESTS=ON                          ^
         -DBUILD_EXAMPLES=OFF                      ^

--- a/scripts/test-windows.bat
+++ b/scripts/test-windows.bat
@@ -48,7 +48,7 @@ exit /b 1
 
 echo "Starting the client test now."
 
-set PATH=%BUILD_DIR%\%BUILD_CONFIGURATION%;%PATH%
+set PATH=%BUILD_DIR%\%BUILD_CONFIGURATION%;%BUILD_DIR%\bin\%BUILD_CONFIGURATION%;%PATH%
 
 echo %TEST_EXECUTABLE%
 %TEST_EXECUTABLE% --gtest_output="xml:CPP_Client_Test_Report.xml"


### PR DESCRIPTION
It is a problem for users when out library and github name is different from the cmake find_package name and library names. It becomes too confusing to the users and it is NOT recommended by package managers such as conan and vcpkg. Also, supporting different targets for ssl and static was not a good idea and source of confusion. The user configures it anyway when using cmake or package managers, hence, deleted those options.

Eliminated the generation of different targets for static and ssl and it will be only controlled by cmake options. Only a single type is supported per installation. The library and target names are also changed to the same name as the project `hazelcast-cpp-client`.