### PR TITLE
New client property to use a different cloud discovery query endoint

### DIFF
--- a/hazelcast/include/hazelcast/client/client_properties.h
+++ b/hazelcast/include/hazelcast/client/client_properties.h
@@ -73,8 +73,6 @@ namespace hazelcast {
 
             const client_property& get_aws_member_port() const;
 
-            const client_property &get_clean_resources_period_millis() const;
-
             const client_property &get_invocation_retry_pause_millis() const;
 
             const client_property &get_invocation_timeout_seconds() const;
@@ -96,6 +94,8 @@ namespace hazelcast {
             const client_property &backup_timeout_millis() const;
 
             const client_property &fail_on_indeterminate_state() const;
+
+            const client_property &cloud_base_url() const;
 
             /**
             * Client will be sending heartbeat messages to members and this is the timeout. If there is no any message
@@ -148,12 +148,6 @@ namespace hazelcast {
              */
             static const std::string PROP_AWS_MEMBER_PORT;
             static const std::string PROP_AWS_MEMBER_PORT_DEFAULT;
-
-            /**
-             * The period in milliseconds at which the resource cleaning is run (e.g. invocations).
-             */
-            static const std::string CLEAN_RESOURCES_PERIOD_MILLIS;
-            static const std::string CLEAN_RESOURCES_PERIOD_MILLIS_DEFAULT;
 
             /**
              * Pause time between each retry cycle of an invocation in milliseconds.
@@ -249,6 +243,13 @@ namespace hazelcast {
             static constexpr const char * FAIL_ON_INDETERMINATE_OPERATION_STATE_DEFAULT = "false";
 
             /**
+             * Internal client property to change base url of cloud discovery endpoint.
+             * Used for testing cloud discovery.
+             */
+            static constexpr const char * CLOUD_URL_BASE = "hazelcast.client.cloud.url";
+            static constexpr const char * CLOUD_URL_BASE_DEFAULT = "coordinator.hazelcast.cloud";
+
+            /**
              * Returns the configured boolean value of a {@link ClientProperty}.
              *
              * @param property the {@link ClientProperty} to get the value from
@@ -286,7 +287,6 @@ namespace hazelcast {
             client_property retry_count_;
             client_property retry_wait_time_;
             client_property aws_member_port_;
-            client_property clean_resources_period_;
             client_property invocation_retry_pause_millis_;
             client_property invocation_timeout_seconds_;
             client_property event_thread_count_;
@@ -298,6 +298,7 @@ namespace hazelcast {
             client_property statistics_period_seconds_;
             client_property backup_timeout_millis_;
             client_property fail_on_indeterminate_state_;
+            client_property cloud_base_url_;
 
             std::unordered_map<std::string, std::string> properties_map_;
         };

--- a/hazelcast/include/hazelcast/client/spi/impl/discovery/cloud_discovery.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/discovery/cloud_discovery.h
@@ -33,12 +33,12 @@ namespace hazelcast {
                 namespace discovery {
                     class HAZELCAST_API cloud_discovery {
                     public:
-                        static constexpr const char *CLOUD_SERVER = "coordinator.hazelcast.cloud";
                         static constexpr const char *CLOUD_URL_PATH = "/cluster/discovery?token=";
                         static constexpr const char *PRIVATE_ADDRESS_PROPERTY = "private-address";
                         static constexpr const char *PUBLIC_ADDRESS_PROPERTY = "public-address";
 
-                        cloud_discovery(config::cloud_config &config, std::chrono::steady_clock::duration timeout);
+                        cloud_discovery(config::cloud_config &config, std::string cloud_base_url,
+                                        std::chrono::steady_clock::duration timeout);
 
                         std::unordered_map<address, address> get_addresses();
 
@@ -47,6 +47,7 @@ namespace hazelcast {
 
                     private:
                         config::cloud_config &cloud_config_;
+                        std::string cloud_base_url_;
                         std::chrono::steady_clock::duration timeout_;
 
                         static address create_address(const std::string &hostname, int default_port);

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -60,6 +60,7 @@
 #include "hazelcast/client/proxy/flake_id_generator_impl.h"
 #include "hazelcast/logger.h"
 #include "hazelcast/client/member_selectors.h"
+#include "hazelcast/client/client_properties.h"
 
 #ifndef HAZELCAST_VERSION
 #define HAZELCAST_VERSION "NOT_FOUND"
@@ -285,6 +286,7 @@ namespace hazelcast {
                 auto connect_timeout = networkConfig.get_connection_timeout();
                 if (cloud_enabled) {
                     auto cloud_provider = std::make_shared<spi::impl::discovery::cloud_discovery>(cloudConfig,
+                                                                                                  client_properties_.get_string(client_properties_.cloud_base_url()),
                                                                                                   connect_timeout);
                     return std::unique_ptr<connection::AddressProvider>(
                             new spi::impl::discovery::remote_address_provider([=]() {
@@ -583,9 +585,6 @@ namespace hazelcast {
         const std::string client_properties::PROP_AWS_MEMBER_PORT = "hz-port";
         const std::string client_properties::PROP_AWS_MEMBER_PORT_DEFAULT = "5701";
 
-        const std::string client_properties::CLEAN_RESOURCES_PERIOD_MILLIS = "hazelcast.client.internal.clean.resources.millis";
-        const std::string client_properties::CLEAN_RESOURCES_PERIOD_MILLIS_DEFAULT = "100";
-
         const std::string client_properties::INVOCATION_RETRY_PAUSE_MILLIS = "hazelcast.client.invocation.retry.pause.millis";
         const std::string client_properties::INVOCATION_RETRY_PAUSE_MILLIS_DEFAULT = "1000";
 
@@ -643,8 +642,6 @@ namespace hazelcast {
                   retry_count_(PROP_REQUEST_RETRY_COUNT, PROP_REQUEST_RETRY_COUNT_DEFAULT),
                   retry_wait_time_(PROP_REQUEST_RETRY_WAIT_TIME, PROP_REQUEST_RETRY_WAIT_TIME_DEFAULT),
                   aws_member_port_(PROP_AWS_MEMBER_PORT, PROP_AWS_MEMBER_PORT_DEFAULT),
-                  clean_resources_period_(CLEAN_RESOURCES_PERIOD_MILLIS,
-                                          CLEAN_RESOURCES_PERIOD_MILLIS_DEFAULT),
                   invocation_retry_pause_millis_(INVOCATION_RETRY_PAUSE_MILLIS,
                                                  INVOCATION_RETRY_PAUSE_MILLIS_DEFAULT),
                   invocation_timeout_seconds_(INVOCATION_TIMEOUT_SECONDS,
@@ -662,6 +659,7 @@ namespace hazelcast {
                   backup_timeout_millis_(OPERATION_BACKUP_TIMEOUT_MILLIS, OPERATION_BACKUP_TIMEOUT_MILLIS_DEFAULT),
                   fail_on_indeterminate_state_(FAIL_ON_INDETERMINATE_OPERATION_STATE,
                                                FAIL_ON_INDETERMINATE_OPERATION_STATE_DEFAULT),
+                  cloud_base_url_(CLOUD_URL_BASE, CLOUD_URL_BASE_DEFAULT),
                   properties_map_(properties) {
         }
 
@@ -675,10 +673,6 @@ namespace hazelcast {
 
         const client_property &client_properties::get_aws_member_port() const {
             return aws_member_port_;
-        }
-
-        const client_property &client_properties::get_clean_resources_period_millis() const {
-            return clean_resources_period_;
         }
 
         const client_property &client_properties::get_invocation_retry_pause_millis() const {
@@ -750,6 +744,10 @@ namespace hazelcast {
 
         const client_property &client_properties::fail_on_indeterminate_state() const {
             return fail_on_indeterminate_state_;
+        }
+
+        const client_property &client_properties::cloud_base_url() const {
+            return cloud_base_url_;
         }
 
         namespace exception {

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -2294,20 +2294,20 @@ namespace hazelcast {
                         return boost::none;
                     }
 
-                    cloud_discovery::cloud_discovery(config::cloud_config &config,
+                    cloud_discovery::cloud_discovery(config::cloud_config &config, std::string cloud_base_url,
                                                      std::chrono::steady_clock::duration timeout)
-                                                     : cloud_config_(config), timeout_(timeout) {}
+                            : cloud_config_(config), cloud_base_url_(cloud_base_url), timeout_(timeout) {}
 
                     std::unordered_map<address, address> cloud_discovery::get_addresses() {
 #ifdef HZ_BUILD_WITH_SSL
                         try {
-                            util::SyncHttpsClient httpsConnection(CLOUD_SERVER, std::string(CLOUD_URL_PATH) +
+                            util::SyncHttpsClient httpsConnection(cloud_base_url_, std::string(CLOUD_URL_PATH) +
                                                                                 cloud_config_.discovery_token, timeout_);
                             auto &conn_stream = httpsConnection.connect_and_get_response();
                             return parse_json_response(conn_stream);
                         } catch (std::exception &e) {
                             std::throw_with_nested(boost::enable_current_exception(
-                                    exception::hazelcast_("cloud_discovery::get_addresses",
+                                    exception::illegal_state("cloud_discovery::get_addresses",
                                                           e.what())));
                         }
 #else

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1585,17 +1585,29 @@ namespace hazelcast {
                     auto config = get_config();
                     config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
                             std::chrono::milliseconds(100));
-                    auto cloudConfig = config.get_network_config().get_cloud_config();
+                    auto &cloudConfig = config.get_network_config().get_cloud_config();
                     cloudConfig.enabled = true;
                     cloudConfig.discovery_token = "invalid_discovery_token";
                     ASSERT_THROW(hazelcast::new_client(std::move(config)).get(), exception::illegal_state);
                 }
 
+                TEST_F(cloud_discovery_test, non_existent_base_url) {
+                    auto config = get_config();
+                    config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                            std::chrono::milliseconds(100));
+                    auto &cloudConfig = config.get_network_config().get_cloud_config();
+                    config.set_property(client_properties::CLOUD_URL_BASE, "https://my.url.com");
+                    cloudConfig.enabled = true;
+                    cloudConfig.discovery_token = "abc";
+                    ASSERT_THROW(hazelcast::new_client(std::move(config)).get(), exception::illegal_state);
+                }
+
                 TEST_F(cloud_discovery_test, parse_json) {
                     config::cloud_config config;
-                    config. enabled = true;
-                    config .discovery_token = "my_token";
-                    spi::impl::discovery::cloud_discovery d(config, std::chrono::seconds(1));
+                    config.enabled = true;
+                    config.discovery_token = "my_token";
+                    spi::impl::discovery::cloud_discovery d(config, client_properties::CLOUD_URL_BASE_DEFAULT,
+                                                            std::chrono::seconds(1));
                     auto test_stream = std::istringstream(
                             R"([{"private-address":"100.103.97.89","public-address":"3.92.127.167:30964"},{"private-address":"100.97.31.19","public-address":"54.227.206.253:30964"},{"private-address":"100.127.33.250","public-address":"54.80.210.250:30964"}])");
                     auto addresses = d.parse_json_response(test_stream);


### PR DESCRIPTION
Added a client property to use a different cloud discovery query endpoint than the default which is needed by cloud tests.

fixes #834 