### PR TITLE
Fix ClientStatisticsTests

### DIFF
--- a/hazelcast/test/src/ClientTestSupport.h
+++ b/hazelcast/test/src/ClientTestSupport.h
@@ -47,11 +47,10 @@ namespace hazelcast {
             protected:
                 logger &get_logger();
 
-                const std::string &get_test_name() const;
+                static std::string get_test_name();
 
             private:
                 std::shared_ptr<logger> logger_;
-                std::string test_name_;
             };
 
             class CountDownLatchWaiter {

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1586,19 +1586,18 @@ namespace hazelcast {
     namespace client {
         namespace test {
             ClientTestSupport::ClientTestSupport() {
-                const testing::TestInfo *testInfo = testing::UnitTest::GetInstance()->current_test_info();
-                std::ostringstream out;
-                out << testInfo->test_case_name() << "_" << testInfo->name();
-                test_name_ = out.str();
-                logger_ = std::make_shared<logger>("Test", test_name_, logger::level::info, logger::default_handler);
+                logger_ = std::make_shared<logger>("Test", get_test_name(), logger::level::info, logger::default_handler);
             }
 
             logger &ClientTestSupport::get_logger() {
                 return *logger_;
             }
 
-            const std::string &ClientTestSupport::get_test_name() const {
-                return test_name_;
+            std::string ClientTestSupport::get_test_name() {
+                const auto *info = testing::UnitTest::GetInstance()->current_test_info();
+                std::ostringstream out;
+                out << info->test_case_name() << "_" << info->name();
+                return out.str();
             }
 
             CountDownLatchWaiter &CountDownLatchWaiter::add(boost::latch &latch1) {


### PR DESCRIPTION
Some test cases under the **ClientStatisticsTests** suite have been failing on GA:
* https://github.com/hazelcast/hazelcast-cpp-client/runs/2157133452?check_suite_focus=true
* https://github.com/hazelcast/hazelcast-cpp-client/runs/2157133390?check_suite_focus=true
* https://github.com/hazelcast/hazelcast-cpp-client/runs/2143110874?check_suite_focus=true

The reason is that even though the client from the previous test case is shutdown and destroyed, it is still listed in the list that `getConnectedClients()` returns. And since we take the first element of that list (`...toArray()[0]`), the get_client_stats_from_server() sometimes returns the stats for the client from the previous test case. The member eventually realizes the client was destroyed and removes it from that list but it's sometimes too late for the ASSERT_..._EVENTUALLY statements.

To fix the issue, I did similarly to what was done in the Python client ([see](https://github.com/hazelcast/hazelcast-python-client/blob/ea1058ec914e6861ec8d09e4f632c64eb2d6b1e1/tests/integration/backward_compatible/statistics_test.py#L183)). Instead of always taking the first element, we search the client by name. I named the clients with the test name to be able to identify them.   

I am able to reproduce the tests failures on a linux VM (they fail once every ~5 runs). After doing this fix, I ran them many times and they always passed.