### PR TITLE
Fix -Wunused-private-field

### DIFF
--- a/hazelcast/include/hazelcast/client/aws/aws_client.h
+++ b/hazelcast/include/hazelcast/client/aws/aws_client.h
@@ -43,11 +43,13 @@ namespace hazelcast {
                 std::unordered_map<address, address> get_addresses();
 
             private:
+#ifdef HZ_BUILD_WITH_SSL
                 std::chrono::steady_clock::duration timeout_;
                 config::client_aws_config &aws_config_;
                 std::string endpoint_;
                 logger &logger_;
                 int aws_member_port_;
+#endif // HZ_BUILD_WITH_SSL
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/spi/impl/discovery/cloud_discovery.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/discovery/cloud_discovery.h
@@ -46,9 +46,11 @@ namespace hazelcast {
                         static std::unordered_map<address, address> parse_json_response(std::istream &conn_stream);
 
                     private:
+#ifdef HZ_BUILD_WITH_SSL
                         config::cloud_config &cloud_config_;
                         std::string cloud_base_url_;
                         std::chrono::steady_clock::duration timeout_;
+#endif // HZ_BUILD_WITH_SSL
 
                         static address create_address(const std::string &hostname, int default_port);
                     };

--- a/hazelcast/src/hazelcast/client/discovery.cpp
+++ b/hazelcast/src/hazelcast/client/discovery.cpp
@@ -582,9 +582,8 @@ namespace hazelcast {
     namespace client {
         namespace aws {
                 aws_client::aws_client(std::chrono::steady_clock::duration timeout, config::client_aws_config &aws_config,
-                                   const client_properties &client_properties, logger &lg) : timeout_(timeout),
-                                   aws_config_(aws_config), logger_(lg) {
-                            util::Preconditions::check_ssl("aws_client::aws_client");
+                                       const client_properties &client_properties, logger &lg) {
+                    util::Preconditions::check_ssl("aws_client::aws_client");
                 }
 
                 std::unordered_map<address, address> aws_client::get_addresses() {

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -2294,9 +2294,14 @@ namespace hazelcast {
                         return boost::none;
                     }
 
+#ifdef HZ_BUILD_WITH_SSL
                     cloud_discovery::cloud_discovery(config::cloud_config &config, std::string cloud_base_url,
                                                      std::chrono::steady_clock::duration timeout)
                             : cloud_config_(config), cloud_base_url_(cloud_base_url), timeout_(timeout) {}
+#else
+                    cloud_discovery::cloud_discovery(config::cloud_config &config, std::string cloud_base_url,
+                                                     std::chrono::steady_clock::duration timeout) {}
+#endif // HZ_BUILD_WITH_SSL
 
                     std::unordered_map<address, address> cloud_discovery::get_addresses() {
 #ifdef HZ_BUILD_WITH_SSL


### PR DESCRIPTION
Clang gives warnings for unused fields in non-SSL builds: https://github.com/hazelcast/hazelcast-cpp-client/runs/2266445137?check_suite_focus=true.

This PR defines fields only when SSL is enabled.