### PR TITLE
Add a new section to redirect users to use Hazelcast Command Line tools

### DIFF
--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -18,8 +18,9 @@
       * [1.2. Starting Hazelcast IMDG Cluster](#12-starting-hazelcast-imdg-cluster)
          * [1.2.1. Starting Hazelcast Server](#121-starting-hazelcast-server)
             * [1.2.1.1. Starting Server Using Hazelcast Docker Images](#1211-starting-server-using-hazelcast-docker-images)
-            * [1.2.1.2. Starting Server Using Hazelcast Distribution](#1212-starting-server-using-hazelcast-distribution)
-            * [1.2.1.3. Adding User Java Library to Java CLASSPATH](#1213-adding-user-java-library-to-java-classpath)
+            * [1.2.1.2. Starting Server Using Hazelcast Command Line Tools](#1212-starting-server-using-hazelcast-command-line-tools)
+            * [1.2.1.3. Starting Server Using Hazelcast Distribution](#1213-starting-server-using-hazelcast-distribution)
+            * [1.2.1.4. Adding User Java Library to Java CLASSPATH](#1214-adding-user-java-library-to-java-classpath)
          * [1.3. Compiling Your Project](#13-compiling-your-project)
             * [1.3.1. CMake Users](#131-cmake-users)
             * [1.3.2. Linux and MacOS Users](#132-linux-and-macos-users)
@@ -139,7 +140,7 @@
    * [11. License](#11-license)
    * [12. Copyright](#12-copyright)
 
-<!-- Added by: ihsan, at: Wed Mar 17 13:59:21 +03 2021 -->
+<!-- Added by: ihsan, at: Wed Apr  7 13:25:05 +03 2021 -->
 
 <!--te-->
 
@@ -328,7 +329,11 @@ The quickest way to start a single member cluster for development purposes is to
 docker run -p 5701:5701 hazelcast/hazelcast:4.1.1
 ```
 
-#### 1.2.1.2. Starting Server Using Hazelcast Distribution
+#### 1.2.1.2. Starting Server Using Hazelcast Command Line Tools
+
+Hazelcast Command Line is a tool which allows users to install & run Hazelcast IMDG and Management Center on local environment. Please follow the [Command Line Tool Instructions](https://github.com/hazelcast/hazelcast-command-line) to start the Hazelcast cluster.  
+
+#### 1.2.1.3. Starting Server Using Hazelcast Distribution
 
 Follow the instructions below to create a Hazelcast IMDG cluster:
 
@@ -351,7 +356,7 @@ Nov 19, 2020 2:52:59 PM com.hazelcast.core.LifecycleService
 INFO: [192.168.1.112]:5701 [dev] [4.1] [192.168.1.112]:5701 is STARTED
 ```
 
-#### 1.2.1.3. Adding User Java Library to Java CLASSPATH
+#### 1.2.1.4. Adding User Java Library to Java CLASSPATH
 
 When you want to use features such as querying and language interoperability, you might need to add your own Java classes to the Hazelcast member in order to use them from your C++ client. This can be done by adding your own compiled code to the `CLASSPATH`. To do this, compile your code with the `CLASSPATH` and add the compiled files to the `user-lib` directory in the extracted `hazelcast-<version>.zip` (or `tar`). Then, you can start your Hazelcast member by using the start scripts in the `bin` directory. The start scripts will automatically add your compiled classes to the `CLASSPATH`.
 


### PR DESCRIPTION
Added a section to redirect users to use Hazelcast Command Line tools as an easy way to start Hazelcast IMDG server cluster.

fixes #726