### PR TITLE
Fix the uninitialised memory usage warning during valgrind analysis

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -259,10 +259,9 @@ namespace hazelcast {
                     std::chrono::milliseconds connect_timeout_;
                     boost::asio::ip::tcp::resolver &resolver_;
                     T socket_;
-                    int32_t call_id_counter_;
+                    int32_t call_id_counter_{0};
                 };
             }
         }
     }
 }
-


### PR DESCRIPTION
Fixes the uninitialised memory usage warning during valgrind analysis. The valgrind reports errors similar to the following without this fix:

```
==16919== Use of uninitialised value of size 8
==16919==    at 0x5474319: std::_Hashtable<long, std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, std::allocator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> > >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_insert_bucket_begin(unsigned long, std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, false>*) (hashtable.h:1599)
==16919==    by 0x54730F7: std::_Hashtable<long, std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, std::allocator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> > >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_insert_unique_node(long const&, unsigned long, unsigned long, std::__detail::_Hash_node<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, false>*, unsigned long) (hashtable.h:1735)
==16919==    by 0x5472082: std::pair<std::__detail::_Node_iterator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, false, false>, bool> std::_Hashtable<long, std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, std::allocator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> > >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_emplace<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> > >(std::integral_constant<bool, true>, std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >&&) (hashtable.h:1682)
==16919==    by 0x5470BD5: std::pair<std::__detail::_Node_iterator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, false, false>, bool> std::__detail::_Insert<long, std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, std::allocator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> > >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>, false>::insert<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >, void>(std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >&&) (hashtable_policy.h:1021)
==16919==    by 0x546F6E7: std::unordered_map<long, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> > > >::insert(std::pair<long const, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation> >&&) (unordered_map.h:586)
==16919==    by 0x546D1D0: hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}::operator()() const (BaseSocket.h:113)
==16919==    by 0x547B885: void boost::asio::asio_handler_invoke<hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}>(hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}&, ...) (handler_invoke_hook.hpp:69)
==16919==    by 0x547A4AC: void boost_asio_handler_invoke_helpers::invoke<hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}, {lambda()#1}>(hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}&, {lambda()#1}&) (handler_invoke_helpers.hpp:37)
==16919==    by 0x5479242: void boost::asio::detail::handler_work<hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}, boost::asio::system_executor, hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}>::complete<{lambda()#1}>({lambda()#1}&, {lambda()#1}&) (handler_work.hpp:100)
==16919==    by 0x5477A15: boost::asio::detail::completion_handler<hazelcast::client::internal::socket::BaseSocket<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >::async_write(std::shared_ptr<hazelcast::client::connection::Connection>, std::shared_ptr<hazelcast::client::spi::impl::ClientInvocation>)::{lambda()#1}>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) (completion_handler.hpp:70)
==16919==    by 0x9BEFCB: boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) (scheduler_operation.hpp:40)
==16919==    by 0x5449B06: boost::asio::detail::strand_service::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) (strand_service.ipp:168)
==16919==  Uninitialised value was created by a heap allocation
==16919==    at 0x483BE7D: operator new(unsigned long) (vg_replace_malloc.c:342)
==16919==    by 0x543B702: hazelcast::client::internal::socket::SocketFactory::create(hazelcast::client::address const&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (network.cpp:1263)
==16919==    by 0x5438A01: hazelcast::client::connection::Connection::Connection(hazelcast::client::address const&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (network.cpp:819)
==16919==    by 0x546AB32: void __gnu_cxx::new_allocator<hazelcast::client::connection::Connection>::construct<hazelcast::client::connection::Connection, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(hazelcast::client::connection::Connection*, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (new_allocator.h:150)
==16919==    by 0x546963B: void std::allocator_traits<std::allocator<hazelcast::client::connection::Connection> >::construct<hazelcast::client::connection::Connection, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(std::allocator<hazelcast::client::connection::Connection>&, hazelcast::client::connection::Connection*, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (alloc_traits.h:512)
==16919==    by 0x5467485: std::_Sp_counted_ptr_inplace<hazelcast::client::connection::Connection, std::allocator<hazelcast::client::connection::Connection>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(std::allocator<hazelcast::client::connection::Connection>, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (shared_ptr_base.h:551)
==16919==    by 0x5464286: std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<hazelcast::client::connection::Connection, std::allocator<hazelcast::client::connection::Connection>, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(hazelcast::client::connection::Connection*&, std::_Sp_alloc_shared_tag<std::allocator<hazelcast::client::connection::Connection> >, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (shared_ptr_base.h:682)
==16919==    by 0x5460622: std::__shared_ptr<hazelcast::client::connection::Connection, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<hazelcast::client::connection::Connection>, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(std::_Sp_alloc_shared_tag<std::allocator<hazelcast::client::connection::Connection> >, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (shared_ptr_base.h:1371)
==16919==    by 0x545C469: std::shared_ptr<hazelcast::client::connection::Connection>::shared_ptr<std::allocator<hazelcast::client::connection::Connection>, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(std::_Sp_alloc_shared_tag<std::allocator<hazelcast::client::connection::Connection> >, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (shared_ptr.h:408)
==16919==    by 0x54569C6: std::shared_ptr<hazelcast::client::connection::Connection> std::allocate_shared<hazelcast::client::connection::Connection, std::allocator<hazelcast::client::connection::Connection>, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(std::allocator<hazelcast::client::connection::Connection> const&, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (shared_ptr.h:860)
==16919==    by 0x54507E2: std::shared_ptr<hazelcast::client::connection::Connection> std::make_shared<hazelcast::client::connection::Connection, hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&>(hazelcast::client::address&, hazelcast::client::spi::ClientContext&, int&&, hazelcast::client::internal::socket::SocketFactory&, hazelcast::client::connection::ClientConnectionManagerImpl&, std::chrono::duration<long, std::ratio<1l, 1000l> >&) (shared_ptr.h:876)
==16919==    by 0x543845E: hazelcast::client::connection::ClientConnectionManagerImpl::connect(hazelcast::client::address const&) (network.cpp:761)
==16919==
```