### PR TITLE
Break cyclic shared_ptr usages between ClientInvocation, Connection and cluster_view_listener::event_listener

### DIFF
--- a/hazelcast/include/hazelcast/client/iexecutor_service.h
+++ b/hazelcast/include/hazelcast/client/iexecutor_service.h
@@ -89,7 +89,7 @@ namespace hazelcast {
                 std::shared_ptr<spi::impl::ClientInvocation> invocation_;
 
                 bool invoke_cancel_request(bool may_interrupt_if_running) {
-                    invocation_->get_send_connection_or_wait();
+                    invocation_->wait_invoked();
 
                     if (partition_id_ > -1) {
                         auto request = protocol::codec::executorservice_cancelonpartition_encode(uuid_, may_interrupt_if_running);

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -121,7 +121,7 @@ namespace hazelcast {
 
                     std::shared_ptr<connection::Connection> get_send_connection() const;
 
-                    std::shared_ptr<connection::Connection> get_send_connection_or_wait() const;
+                    void wait_invoked() const;
 
                     void
                     set_send_connection(const std::shared_ptr<connection::Connection> &send_connection);
@@ -153,6 +153,7 @@ namespace hazelcast {
                     std::chrono::milliseconds retry_pause_;
                     std::string object_name_;
                     std::weak_ptr<connection::Connection> connection_;
+                    bool bound_to_single_connection_{false};
                     boost::atomic_shared_ptr<std::weak_ptr<connection::Connection>> send_connection_;
                     std::shared_ptr<EventHandler < protocol::ClientMessage>> event_handler_;
                     std::atomic<int64_t> invoke_count_;

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -152,8 +152,8 @@ namespace hazelcast {
                     std::chrono::steady_clock::time_point start_time_;
                     std::chrono::milliseconds retry_pause_;
                     std::string object_name_;
-                    std::shared_ptr<connection::Connection> connection_;
-                    boost::atomic_shared_ptr<std::shared_ptr<connection::Connection>> send_connection_;
+                    std::weak_ptr<connection::Connection> connection_;
+                    boost::atomic_shared_ptr<std::weak_ptr<connection::Connection>> send_connection_;
                     std::shared_ptr<EventHandler < protocol::ClientMessage>> event_handler_;
                     std::atomic<int64_t> invoke_count_;
                     boost::promise<protocol::ClientMessage> invocation_promise_;

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -154,6 +154,7 @@ namespace hazelcast {
                     std::string object_name_;
                     std::weak_ptr<connection::Connection> connection_;
                     bool bound_to_single_connection_{false};
+                    std::atomic_bool invoked_or_exception_set_{false};
                     boost::atomic_shared_ptr<std::weak_ptr<connection::Connection>> send_connection_;
                     std::shared_ptr<EventHandler < protocol::ClientMessage>> event_handler_;
                     std::atomic<int64_t> invoke_count_;

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
@@ -48,7 +48,7 @@ namespace hazelcast {
                     /**
                      * The partitions can be empty on the response, client will not apply the empty partition table,
                      */
-                    void handle_event(const std::shared_ptr<connection::Connection>& connection, int32_t version,
+                    void handle_event(int32_t connection_id, int32_t version,
                                       const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions);
 
                     boost::uuids::uuid get_partition_owner(int partition_id);
@@ -64,7 +64,10 @@ namespace hazelcast {
                     void reset();
                 private:
                     struct partition_table {
-                        std::shared_ptr<connection::Connection> connection;
+                        partition_table(int32_t connectionId = 0, int32_t version = -1,
+                                        const std::unordered_map<int32_t, boost::uuids::uuid> &partitions = {});
+
+                        int32_t connection_id{0};
                         int32_t version;
                         std::unordered_map<int32_t, boost::uuids::uuid> partitions;
                     };
@@ -84,12 +87,12 @@ namespace hazelcast {
                         ClientPartitionServiceImpl &partition_service_;
                     };
 
-                    bool should_be_applied(const std::shared_ptr<connection::Connection>& connection, int32_t version,
+                    bool should_be_applied(int32_t connection_id, int32_t version,
                                            const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions,
                                            const partition_table &current);
 
-                    void log_failure(const std::shared_ptr<connection::Connection> &connection, int32_t version,
-                                     const partition_table &current, const std::string &cause);
+                    void log_failure(int32_t connection_id, int32_t version, const partition_table &current,
+                                     const std::string &cause);
 
                     std::unordered_map<int32_t, boost::uuids::uuid>
                     convert_to_map(const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions);

--- a/hazelcast/include/hazelcast/client/spi/impl/listener/cluster_view_listener.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/listener/cluster_view_listener.h
@@ -53,7 +53,7 @@ namespace hazelcast {
                             virtual void handle_partitionsview(int32_t version,
                                                                const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions);
 
-                            std::shared_ptr<connection::Connection> connection;
+                            std::weak_ptr<connection::Connection> connection;
                             cluster_view_listener &view_listener;
                         };
 

--- a/hazelcast/include/hazelcast/client/spi/impl/listener/cluster_view_listener.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/listener/cluster_view_listener.h
@@ -40,8 +40,10 @@ namespace hazelcast {
 
                     private:
                         struct event_handler : public protocol::codec::client_addclusterviewlistener_handler {
-                            event_handler(const std::shared_ptr <connection::Connection> &connection,
-                                          cluster_view_listener &view_listener);
+                            int connection_id;
+                            cluster_view_listener &view_listener;
+
+                            event_handler(int connectionId, cluster_view_listener &viewListener);
 
                             virtual void before_listener_register();
 
@@ -52,9 +54,6 @@ namespace hazelcast {
 
                             virtual void handle_partitionsview(int32_t version,
                                                                const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions);
-
-                            std::weak_ptr<connection::Connection> connection;
-                            cluster_view_listener &view_listener;
                         };
 
                         void try_register(std::shared_ptr<connection::Connection> connection);

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -606,16 +606,16 @@ namespace hazelcast {
                     if (local_address) {
                         HZ_LOG(logger_, info,
                                boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
-                                                        "local address: %4%")
+                                                        "local address: %4%. %5%")
                                           % response.server_address % response.member_uuid
-                                          % response.server_version % *local_address)
+                                          % response.server_version % *local_address % *connection)
                         );
                     } else {
                         HZ_LOG(logger_, info,
                                boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
-                                                        "no local address: (connection disconnected ?)")
+                                                        "no local address: (connection disconnected ?). %5%")
                                           % response.server_address % response.member_uuid
-                                          % response.server_version)
+                                          % response.server_version % *connection)
                         );
                     }
 

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1260,7 +1260,7 @@ namespace hazelcast {
                     if (invocation.is_bind_to_single_connection()) {
                         auto conn = invocation.connection_.lock();
                         if (conn) {
-                            target << "connection " << conn;
+                            target << "connection " << *conn;
                         }
                     } else if (invocation.partition_id_ != -1) {
                         target << "partition " << invocation.partition_id_;
@@ -2392,6 +2392,5 @@ namespace std {
         return std::hash<std::string>()(k.get_service_name() + k.get_object_name());
     }
 }
-
 
 

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1611,10 +1611,10 @@ namespace hazelcast {
 
                 ClientPartitionServiceImpl::ClientPartitionServiceImpl(ClientContext &client)
                         : client_(client), logger_(client.get_logger()), partition_count_(0),
-                        partition_table_(boost::shared_ptr<partition_table>(new partition_table{nullptr, -1})) {
+                        partition_table_(boost::shared_ptr<partition_table>(new partition_table{0, -1})) {
                 }
 
-                void ClientPartitionServiceImpl::handle_event(const std::shared_ptr<connection::Connection>& connection, int32_t version,
+                void ClientPartitionServiceImpl::handle_event(int32_t connection_id, int32_t version,
                                                               const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions) {
                     HZ_LOG(logger_, finest,
                         boost::str(boost::format("Handling new partition table with partitionStateVersion: %1%") % version)
@@ -1622,11 +1622,11 @@ namespace hazelcast {
 
                     while (true) {
                         auto current = partition_table_.load();
-                        if (!should_be_applied(connection, version, partitions, *current)) {
+                        if (!should_be_applied(connection_id, version, partitions, *current)) {
                             return;
                         }
                         if (partition_table_.compare_exchange_strong(current, boost::shared_ptr<partition_table>(
-                                new partition_table{connection, version, convert_to_map(partitions)}))) {
+                                new partition_table{connection_id, version, convert_to_map(partitions)}))) {
                             HZ_LOG(logger_, finest,
                                 boost::str(boost::format("Applied partition table with partitionStateVersion : %1%") % version)
                             );
@@ -1671,30 +1671,29 @@ namespace hazelcast {
                 }
 
                 bool
-                ClientPartitionServiceImpl::should_be_applied(const std::shared_ptr<connection::Connection> &connection,
-                                                              int32_t version,
+                ClientPartitionServiceImpl::should_be_applied(int32_t connection_id, int32_t version,
                                                               const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions,
                                                               const partition_table &current) {
                     auto &lg = client_.get_logger();
                     if (partitions.empty()) {
                         if (logger_.enabled(logger::level::finest)) {
-                            log_failure(connection, version, current, "response is empty");
+                            log_failure(connection_id, version, current, "response is empty");
                         }
                         return false;
                     }
-                    if (!current.connection || *connection != *current.connection) {
+                    if (!current.connection_id || connection_id != current.connection_id) {
                         HZ_LOG(lg, finest, 
-                            ([&current, &connection](){
-                                auto frmt = boost::format("Event coming from a new connection. Old connection: %1%, "
+                            ([&current, connection_id](){
+                                auto frmt = boost::format("Event coming from a new connection. Old connection id: %1%, "
                                                           "new connection %2%");
 
-                                if (current.connection) {
-                                    frmt = frmt % *current.connection;
+                                if (current.connection_id) {
+                                    frmt = frmt % current.connection_id;
                                 } else {
-                                    frmt = frmt % "nullptr";
+                                    frmt = frmt % "none";
                                 }
 
-                                return boost::str(frmt % *connection);
+                                return boost::str(frmt % connection_id);
                             })()
                         );
                         
@@ -1702,28 +1701,28 @@ namespace hazelcast {
                     }
                     if (version <= current.version) {
                         if (lg.enabled(logger::level::finest)) {
-                            log_failure(connection, version, current, "response state version is old");
+                            log_failure(connection_id, version, current, "response state version is old");
                         }
                         return false;
                     }
                     return true;
                 }
 
-                void ClientPartitionServiceImpl::log_failure(const std::shared_ptr<connection::Connection> &connection,
-                                                             int32_t version,
+                void ClientPartitionServiceImpl::log_failure(int32_t connection_id, int32_t version,
                                                              const ClientPartitionServiceImpl::partition_table &current,
                                                              const std::string &cause) {
                     HZ_LOG(logger_, finest,
                         [&](){
                             auto frmt = boost::format(" We will not apply the response, since %1% ."
-                                                      " Response is from %2%. "
-                                                      "Current connection %3%, response state version:%4%. "
+                                                      " Response is from connection with id %2%. "
+                                                      "Current connection id is %3%, response state version:%4%. "
                                                       "Current state version: %5%");
-                            if (current.connection) {
-                                return boost::str(frmt % cause % *connection % *current.connection % version % current.version);
+                            if (current.connection_id) {
+                                return boost::str(frmt % cause % connection_id % current.connection_id % version %
+                                                  current.version);
                             }
                             else {
-                                return boost::str(frmt % cause % *connection % "nullptr" % version % current.version);
+                                return boost::str(frmt % cause % connection_id % "nullptr" % version % current.version);
                             }
                         }()
                     );
@@ -2184,7 +2183,7 @@ namespace hazelcast {
                                  std::make_shared<protocol::ClientMessage>(
                                  protocol::codec::client_addclusterviewlistener_encode()), "", connection);
 
-                        auto handler = std::shared_ptr<event_handler>(new event_handler(connection, *this));
+                        auto handler = std::make_shared<event_handler>(connection->get_connection_id(), *this);
                         invocation->set_event_handler(handler);
                         handler->before_listener_register();
 
@@ -2223,33 +2222,29 @@ namespace hazelcast {
                     void
                     cluster_view_listener::event_handler::handle_partitionsview(int32_t version,
                                                                                 const std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> &partitions) {
-                        auto conn = connection.lock();
-                        if (!conn) {
-                            // connection is already destroyed, just ignore the event
-                            return;
-                        }
-                        view_listener.client_context_.get_partition_service().handle_event(conn, version, partitions);
+                        view_listener.client_context_.get_partition_service().handle_event(connection_id, version, partitions);
                     }
 
                     void cluster_view_listener::event_handler::before_listener_register() {
                         view_listener.client_context_.get_client_cluster_service().clear_member_list_version();
                         auto &lg = view_listener.client_context_.get_logger();
                         HZ_LOG(lg, finest,
-                               boost::str(boost::format("Register attempt of cluster_view_listener::event_handler to %1%")
-                                          % *connection.lock()));
+                               boost::str(boost::format(
+                                       "Register attempt of cluster_view_listener::event_handler to connection with id %1%") %
+                                          connection_id));
                     }
 
                     void cluster_view_listener::event_handler::on_listener_register() {
                         auto &lg = view_listener.client_context_.get_logger();
                         HZ_LOG(lg, finest,
-                               boost::str(boost::format("Registered cluster_view_listener::event_handler to %1%")
-                                          % *connection.lock()));
+                               boost::str(boost::format(
+                                       "Registered cluster_view_listener::event_handler to connection with id %1%") %
+                                          connection_id));
                     }
 
-                    cluster_view_listener::event_handler::event_handler(
-                            const std::shared_ptr<connection::Connection> &connection,
-                            cluster_view_listener &view_listener) : connection(connection),
-                                                                   view_listener(view_listener) {}
+                    cluster_view_listener::event_handler::event_handler(int connectionId,
+                                                                        cluster_view_listener &viewListener)
+                            : connection_id(connectionId), view_listener(viewListener) {}
                 }
 
                 protocol::ClientMessage
@@ -2367,6 +2362,10 @@ namespace hazelcast {
                         return address(std::move(scoped_hostname), address_holder.get_port());
                     }
                 }
+
+                ClientPartitionServiceImpl::partition_table::partition_table(int32_t connectionId, int32_t version,
+                                                                             const std::unordered_map<int32_t, boost::uuids::uuid> &partitions)
+                        : connection_id(connectionId), version(version), partitions(partitions) {}
             }
         }
     }


### PR DESCRIPTION
Changed the strong shared_ptr usages to `weak_ptr` usages to avoid the cyclic usage and memory leaks as reported in issue #847

fixes #847