### PR TITLE
Remove redundant static/shared library logic in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,17 +93,9 @@ if (WITH_OPENSSL)
     find_package(OpenSSL REQUIRED)
 endif ()
 
-# add library
-if (BUILD_SHARED_LIBS)
-    set(LIB_TYPE SHARED)
-else()
-    set(LIB_TYPE STATIC)
-endif()
-
 # add the library target
 add_library(
         ${PROJECT_NAME}
-        ${LIB_TYPE}
         ${SOURCE_FILES} ${HEADER_FILES}
 )
 


### PR DESCRIPTION
[add_library](https://cmake.org/cmake/help/v3.10/command/add_library.html#command:add_library) determines the library type based on the `BUILD_SHARED_LIBS` variable if no type argument is passed.