### PR TITLE
Cleanup raliable_topic resources on client shutdown

### DIFF
--- a/hazelcast/include/hazelcast/client/reliable_topic.h
+++ b/hazelcast/include/hazelcast/client/reliable_topic.h
@@ -105,6 +105,8 @@ namespace hazelcast {
             */
             bool remove_message_listener(const std::string &registration_id);
         protected:
+            void on_shutdown() override;
+
             void on_destroy() override;
 
             void post_destroy() override;

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -76,6 +76,15 @@ namespace hazelcast {
             return true;
         }
 
+        void reliable_topic::on_shutdown() {
+            // cancel all runners
+            for (auto &entry : runners_map_.clear()) {
+                entry.second->cancel();
+            }
+            // destroy the underlying ringbuffer
+            ringbuffer_.get()->destroy().get();
+        }
+
         void reliable_topic::on_destroy() {
             // cancel all runners
             for (auto &entry : runners_map_.clear()) {

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -81,8 +81,6 @@ namespace hazelcast {
             for (auto &entry : runners_map_.clear()) {
                 entry.second->cancel();
             }
-            // destroy the underlying ringbuffer
-            ringbuffer_.get()->destroy().get();
         }
 
         void reliable_topic::on_destroy() {


### PR DESCRIPTION
When the client is shutting down the reliable_topic listeners should be cancelled and underlying ringbuffer should be destroyed. Failing to do this, causes the runner continue working and it is possible that the lambda function in `MessageRunner::next` method access memory freed after shutdown which is the user executor pool resource and cause the `AddressSanitizer: heap-use-after-free` error with address sanitizer. After this fix, I could the problem did not occur even after several runs.

related to #852 