### PR TITLE
Update boost download urls

### DIFF
--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Boost
         run: |
-          ./scripts/install-boost.sh 1.75.0
+          ./scripts/install-boost.sh 1.76.0
 
       - name: Install Thrift
         run: |

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Boost
         run: |
-          sudo ./scripts/install-boost.sh 1.75.0
+          sudo ./scripts/install-boost.sh 1.76.0
 
       - name: Install Thrift
         run: |

--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -12,6 +12,6 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel.i686
 
 RUN dnf install -y wget bzip2
-RUN dnf install -y wget bzip2 && wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
 
 

--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -12,6 +12,5 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel.i686
 
 RUN dnf install -y wget bzip2
-RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
-
+RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
 

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel
 
 # install boost
-RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
 
 RUN ssh-keygen -A
 
@@ -24,4 +24,3 @@ RUN useradd -m user \
   && yes password | passwd user
 
 CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_test_clion"]
-

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y fedora-repos-rawhide
 RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel
 
 # install boost
-RUN dnf install -y wget bzip2 && wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
 
 RUN ssh-keygen -A
 

--- a/docker/hazelcast-fedora22-x86_64.dockerfile
+++ b/docker/hazelcast-fedora22-x86_64.dockerfile
@@ -4,7 +4,7 @@ RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ openssl-devel cmake tar wget bzip2 java-1.8.0-openjdk
 
 # install boost
-RUN wget --quiet https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
+RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
 
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh && \
     chmod +x ./cmake-3.19.0-Linux-x86_64.sh && \

--- a/docker/hazelcast-fedora22-x86_64.dockerfile
+++ b/docker/hazelcast-fedora22-x86_64.dockerfile
@@ -4,7 +4,7 @@ RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ openssl-devel cmake tar wget bzip2 java-1.8.0-openjdk
 
 # install boost
-RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
+RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
 
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh && \
     chmod +x ./cmake-3.19.0-Linux-x86_64.sh && \

--- a/scripts/install-boost.sh
+++ b/scripts/install-boost.sh
@@ -12,8 +12,9 @@ fi
 
 TARBALL_NAME=boost_$(echo "$1" | tr . _)
 
-curl --silent -Lo $TARBALL_NAME.tar.gz https://dl.bintray.com/boostorg/release/$1/source/$TARBALL_NAME.tar.gz
+curl --silent -Lo $TARBALL_NAME.tar.gz https://boostorg.jfrog.io/artifactory/main/release/$1/source/$TARBALL_NAME.tar.gz
 tar xzf $TARBALL_NAME.tar.gz
 cd $TARBALL_NAME
 ./bootstrap.sh
 ./b2 --with-thread --with-chrono install
+cd ..


### PR DESCRIPTION
Boost download urls have changed. Old links respond with "403 Forbidden".