### PR TITLE
io_context should process all posted works before shutting down

### DIFF
--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -165,12 +165,8 @@ namespace hazelcast {
 
                 spi::impl::ClientExecutionServiceImpl::shutdown_thread_pool(executor_.get());
 
+                // release the guard so that the io thread can stop gracefully
                 io_guard_.reset();
-/*
-                io_context_->stop();
-                boost::asio::use_service<boost::asio::detail::resolver_service<boost::asio::ip::tcp>>(
-                        *io_context_).shutdown();
-*/
                 io_thread_.join();
 
                 connection_listeners_.clear();

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -166,9 +166,11 @@ namespace hazelcast {
                 spi::impl::ClientExecutionServiceImpl::shutdown_thread_pool(executor_.get());
 
                 io_guard_.reset();
+/*
                 io_context_->stop();
                 boost::asio::use_service<boost::asio::detail::resolver_service<boost::asio::ip::tcp>>(
                         *io_context_).shutdown();
+*/
                 io_thread_.join();
 
                 connection_listeners_.clear();

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1438,6 +1438,35 @@ namespace hazelcast {
                 ASSERT_THROW((map->get<int, int>(1).get()), exception::hazelcast_client_not_active);
             }
 
+            TEST_F(IssueTest, invocation_should_not_block_indefinitely_during_client_shutdown) {
+                HazelcastServer server(*g_srvFactory);
+                auto hz = new_client().get();
+                auto map = hz.get_map("my_map").get();
+
+                ASSERT_NO_THROW(map->put(1, 5).get());
+
+                std::thread t([&] () {
+                   hz.shutdown();
+                });
+
+                try {
+                    int i = 0;
+                    while (true) {
+                        map->put(++i, 5).get();
+                    }
+                } catch (std::exception &) {
+                    // ignore
+                }
+
+                try {
+                    map->put(10, 5).get();
+                } catch (std::exception &) {
+                    // ignore
+                }
+
+                t.join();
+            }
+
             TEST_F(IssueTest, testIssue753) {
                 HazelcastServer server(*g_srvFactory);
 


### PR DESCRIPTION
Removed the stop statement while shutting down io_context so that it can indeed process all posted works before shutting down. Failing to do this may cause some posted requests, e.g., notifying any outstanding invocation requests to be not completed before shutdown, but they are expected to be completed with `target_disconnected` exception with close reason "Hazelcast client is shutting down".

Added a new test `invocation_should_not_block_indefinitely_during_client_shutdown` which can be run indefinitely and observe that it is not being blocked in any run. An example way to reproduce the problem without this PR fix is :
    ```
    for ((;;)) { /Users/ihsan/Desktop/work/src/hazelcast-cpp-client/cmake-build-arm-debug/hazelcast/test/src/client_test --gtest_filter=IssueTest.invocation_should_not_block_indefinitely_during_client_shutdown ; }
    ```
    
This run blocks after several runs in master branch but runs indefinite time with this PR fix with no problem.

I am hoping that this may fix the issues #852 and #857 .
