### PR TITLE
Print the word "INFINITE" for the cluster connect timeout instead of max milliseconds number

### DIFF
--- a/hazelcast/include/hazelcast/client/connection/wait_strategy.h
+++ b/hazelcast/include/hazelcast/client/connection/wait_strategy.h
@@ -48,6 +48,7 @@ namespace hazelcast {
                 std::chrono::milliseconds cluster_connect_timeout_millis_{0};
                 std::chrono::steady_clock::time_point cluster_connect_attempt_begin_{
                         std::chrono::steady_clock::now()};
+                std::string cluster_connect_timeout_text_;
             };
         }
     }


### PR DESCRIPTION
Print the word "INFINITE" for the cluster connect timeout instead of the max milliseconds number possible for better user experience.

fixes #867 