### PR TITLE
Add google benchmark tests for the C++ client map

### DIFF
--- a/hazelcast/test/benchmark/CMakeLists.txt
+++ b/hazelcast/test/benchmark/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+cmake_minimum_required(VERSION 3.10)
+
+project(hazelcast-cpp-client-benchmark
+        VERSION 4.1.0
+        DESCRIPTION "Hazelcast C++ Client Benchmark Project"
+        LANGUAGES CXX)
+
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(benchmark REQUIRED)
+find_package(hazelcast-cpp-client REQUIRED)
+
+add_executable(hazelcast_benchmark hazelcast_benchmark.cpp)
+target_link_libraries(hazelcast_benchmark benchmark::benchmark benchmark::benchmark_main hazelcast-cpp-client::hazelcast-cpp-client)

--- a/hazelcast/test/benchmark/README.md
+++ b/hazelcast/test/benchmark/README.md
@@ -1,0 +1,24 @@
+#Dependencies:
+    - [google benchmark](https://github.com/google/benchmark): Mac OS: brew install google-benchmark
+    - hazelcast-cpp-client 
+    - Boost
+
+#Build Instructions:
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/path/to/boost/install/dir;/path/to/hazelcast-cpp-client/install/dir
+make
+
+#Running Instructions
+Run inside build directory as:
+```shell
+./hazelcast_benchmark
+```
+
+Print the options:
+```shell
+./hazelcast_benchmark --help
+```
+You can play with the number of repetitions, output format, aggregates, minimum bencmark time, etc.
+
+The test is using 32 threads by default, you can change it in the source code.

--- a/hazelcast/test/benchmark/README.md
+++ b/hazelcast/test/benchmark/README.md
@@ -6,7 +6,7 @@
 #Build Instructions:
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/path/to/boost/install/dir;/path/to/hazelcast-cpp-client/install/dir
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/path/to/boost/install/dir;/path/to/hazelcast-cpp-client/install/dir
 make
 
 #Running Instructions

--- a/hazelcast/test/benchmark/hazelcast_benchmark.cpp
+++ b/hazelcast/test/benchmark/hazelcast_benchmark.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <hazelcast/client/hazelcast_client.h>
+
+using namespace hazelcast::client;
+
+static auto client{hazelcast::new_client().get()};
+static auto bm_map = client.get_map("map_put").get();
+
+static void map_put(benchmark::State &state) {
+    int number_of_puts = 0;
+    for (auto _ : state) {
+        auto key = rand() % 10000;
+        bm_map->put(key, key).get();
+        state.counters["Put Rate"] = benchmark::Counter(++number_of_puts, benchmark::Counter::kIsRate);
+    }
+}
+
+static void map_get(benchmark::State &state) {
+    int number_of_puts = 0;
+    for (auto _ : state) {
+        auto key = rand() % 10000;
+        bm_map->get<int, int>(key).get();
+        state.counters["Get Rate"] = benchmark::Counter(++number_of_puts, benchmark::Counter::kIsRate);
+    }
+}
+
+static void map_remove(benchmark::State &state) {
+    int number_of_puts = 0;
+    for (auto _ : state) {
+        auto key = rand() % 10000;
+        bm_map->remove<int, int>(key).get();
+        state.counters["Remove Rate"] = benchmark::Counter(++number_of_puts, benchmark::Counter::kIsRate);
+    }
+}
+
+BENCHMARK(map_put)->Threads(32);
+BENCHMARK(map_get)->Threads(32);
+BENCHMARK(map_remove)->Threads(32);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Added the google benchmark tests for the C++ client map usages, for put, get and remove operations. It needs to be built separate from the main project. Instructions are in `README.md` file.

options that can be used with the executable:
```
hazelcast_benchmark --help 
benchmark [--benchmark_list_tests={true|false}]
          [--benchmark_filter=<regex>]
          [--benchmark_min_time=<min_time>]
          [--benchmark_repetitions=<num_repetitions>]
          [--benchmark_report_aggregates_only={true|false}]
          [--benchmark_display_aggregates_only={true|false}]
          [--benchmark_format=<console|json|csv>]
          [--benchmark_out=<filename>]
          [--benchmark_out_format=<json|console|csv>]
          [--benchmark_color={auto|true|false}]
          [--benchmark_counters_tabular={true|false}]
          [--v=<verbosity>]
```

A sample run result on my computer:
```
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
2021-05-06T16:30:51+03:00
Running /Users/ihsan/Desktop/work/src/hazelcast-cpp-client/hazelcast/test/benchmark/cmake-build-debug/hazelcast_benchmark
Run on (8 X 24.1254 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x8)
  L1 Instruction 128 KiB (x8)
  L2 Unified 4096 KiB (x8)
Load Average: 2.08, 2.03, 1.84
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
map_put/threads:32         22010 ns        15185 ns        45792 Put Rate=65.8536k/s
map_get/threads:32         20527 ns        13443 ns        52192 Get Rate=74.3891k/s
map_remove/threads:32      20296 ns        13332 ns        51680 Remove Rate=75.0093k/s
```
