### PR TITLE
[API-403] Enable core dumps for GA linux builds

### DIFF
--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -29,7 +29,9 @@ jobs:
             name: 'SSL'
 
     runs-on: ubuntu-latest
-    container: i386/ubuntu
+    container:
+      image: i386/ubuntu
+      options: --privileged
 
     name: >-
       Ubuntu-i386
@@ -80,6 +82,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         run: |
+          ulimit -c unlimited
+          echo 'core' > /proc/sys/kernel/core_pattern
+          echo '1' > /proc/sys/kernel/core_uses_pid
+
           ./scripts/test-unix.sh
 
       - name: Verify Installation

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Necessary Packages
         run: |
           apt-get update
-          apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-11-jre-headless
+          apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-11-jre-headless gdb
 
       - name: Make sure the target architecture is 32 bit
         run: |

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -72,6 +72,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         run: |
+          ulimit -c unlimited
+          sudo sh -c "echo 'core' > /proc/sys/kernel/core_pattern"
+          sudo sh -c "echo '1' > /proc/sys/kernel/core_uses_pid"
+
           ./scripts/test-unix.sh
 
       - name: Verify Installation

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Necessary Packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y net-tools libssl-dev
+          sudo apt-get install -y net-tools libssl-dev gdb
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Enables core dumping for the test executable and sets the core pattern accordingly to be picked up by the `test-unix.sh`. 

Example runs from my fork: 
* Ubuntu-x86_64: https://github.com/yemreinci/hazelcast-cpp-client/runs/2525420064?check_suite_focus=true
* Ubuntu-i386: https://github.com/yemreinci/hazelcast-cpp-client/runs/2526632506?check_suite_focus=true
