### PR TITLE
gcc 4.9 and 5 versions project compilation fixes

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
@@ -64,10 +64,7 @@ namespace hazelcast {
                     void reset();
                 private:
                     struct partition_table {
-                        partition_table(int32_t connectionId = 0, int32_t version = -1,
-                                        const std::unordered_map<int32_t, boost::uuids::uuid> &partitions = {});
-
-                        int32_t connection_id{0};
+                        int32_t connection_id;
                         int32_t version;
                         std::unordered_map<int32_t, boost::uuids::uuid> partitions;
                     };

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -856,7 +856,7 @@ namespace hazelcast {
                 return it->second;
             }
 
-            return reliable_topic_config_map_.emplace(name, name).first->second;
+            return reliable_topic_config_map_.emplace(name, config::reliable_topic_config{name}).first->second;
         }
 
         const config::reliable_topic_config *client_config::lookup_reliable_topic_config(const std::string &name) const {

--- a/hazelcast/src/hazelcast/client/discovery.cpp
+++ b/hazelcast/src/hazelcast/client/discovery.cpp
@@ -588,7 +588,7 @@ namespace hazelcast {
 
                 std::unordered_map<address, address> aws_client::get_addresses() {
                     util::Preconditions::check_ssl("aws_client::get_addresses");
-                    return {};
+                    return std::unordered_map<address, address>();
                 }
         }
     }

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -788,9 +788,10 @@ namespace hazelcast {
                     auto previous_list = member_list_snapshot_.load()->members;
 
                     member_list_snapshot_.store(
-                            boost::shared_ptr<member_list_snapshot>(new member_list_snapshot{0, {}}));
+                            boost::shared_ptr<member_list_snapshot>(new member_list_snapshot{0}));
 
-                    return detect_membership_events(previous_list, {});
+                    return detect_membership_events(previous_list,
+                                                    std::unordered_map<boost::uuids::uuid, member, boost::hash<boost::uuids::uuid>>());
                 }
 
                 void ClientClusterServiceImpl::clear_member_list() {
@@ -2357,7 +2358,7 @@ namespace hazelcast {
                         }
 #else
                         util::Preconditions::check_ssl("cloud_discovery::get_addresses");
-                        return {};
+                        return std::unordered_map<address, address>();
 #endif
                     }
 
@@ -2388,10 +2389,6 @@ namespace hazelcast {
                         return address(std::move(scoped_hostname), address_holder.get_port());
                     }
                 }
-
-                ClientPartitionServiceImpl::partition_table::partition_table(int32_t connectionId, int32_t version,
-                                                                             const std::unordered_map<int32_t, boost::uuids::uuid> &partitions)
-                        : connection_id(connectionId), version(version), partitions(partitions) {}
             }
         }
     }


### PR DESCRIPTION
gcc 4.9 and 5 versions failed compilation during the [conan update PR for 4.1.0 version](https://github.com/conan-io/conan-center-index/pull/5468) . These fixes make the project compile for older gcc versions 4.9 and 5 properly.