### PR TITLE
Fix the msecs part printing of the time strings in the logs [API-560]

### DIFF
--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -1015,10 +1015,10 @@ namespace hazelcast {
             }
 
             std::ostream &operator<<(std::ostream &os, const Connection &connection) {
-                os << "ClientConnection{"
+                os << "Connection{"
                    << "alive=" << connection.is_alive()
-                   << ", connectionId=" << connection.get_connection_id()
-                   << ", remoteEndpoint=";
+                   << ", connection id=" << connection.get_connection_id()
+                   << ", remote endpoint=";
                 if (connection.get_remote_address()) {
                     os << *connection.get_remote_address();
                 } else {

--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -434,13 +434,8 @@ namespace hazelcast {
                 return std::string("never");
             }
 
-            auto systemDuration = duration_cast<system_clock::duration>(t - steady_clock::now());
-            auto msecs = duration_cast<milliseconds>(systemDuration).count() % 1000;
-            auto system_time = system_clock::now() + systemDuration;
-            if (msecs < 0) {
-                msecs = 1000 + msecs;
-                system_time -= std::chrono::seconds(1);
-            }
+            auto system_time = system_clock::now() + duration_cast<system_clock::duration>(t - steady_clock::now());
+            auto msecs = duration_cast<milliseconds>(system_time.time_since_epoch()).count() % 1000;
 
             auto brokenTime = system_clock::to_time_t(system_time);
             struct tm localBrokenTime;
@@ -452,7 +447,7 @@ namespace hazelcast {
             char time_buffer[80];
             std::strftime(time_buffer, sizeof(time_buffer), "%Y-%m-%d %H:%M:%S", &localBrokenTime);
             oss << time_buffer;
-            oss << '.' << msecs;
+            oss << '.' << std::setfill('0') << std::setw(3) << msecs;
 
             return oss.str();
         }

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -191,6 +191,14 @@ namespace hazelcast {
                 int64_t actualDuration = end - start;
                 ASSERT_GE(actualDuration, parkDurationNanos);
             }
+
+            TEST_F (ClientUtilTest, print_older_stead_clock_time) {
+                auto now = std::chrono::steady_clock::now();
+                auto time_str = hazelcast::util::StringUtil::time_to_string(now);
+                ASSERT_EQ(std::string::npos, time_str.substr(time_str.find_last_of('.')).find('-'));
+                time_str = hazelcast::util::StringUtil::time_to_string(now - std::chrono::milliseconds(1720));
+                ASSERT_EQ(std::string::npos, time_str.substr(time_str.find_last_of('.')).find('-'));
+            }
         }
     }
 }

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -172,7 +172,7 @@ namespace hazelcast {
                 std::string timeString = hazelcast::util::StringUtil::time_to_string(
                         std::chrono::steady_clock::now());
                 //expected format is "%Y-%m-%d %H:%M:%S.%f" it will be something like 2018-03-20 15:36:07.280
-                ASSERT_LE((size_t) 21, timeString.length());
+                ASSERT_EQ(static_cast<std::size_t>(23), timeString.length());
                 ASSERT_EQ(timeString[0], '2');
                 ASSERT_EQ(timeString[1], '0');
                 ASSERT_EQ(timeString[4], '-');
@@ -2178,4 +2178,3 @@ namespace hazelcast {
 #if  defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif
-

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -172,7 +172,7 @@ namespace hazelcast {
                 std::string timeString = hazelcast::util::StringUtil::time_to_string(
                         std::chrono::steady_clock::now());
                 //expected format is "%Y-%m-%d %H:%M:%S.%f" it will be something like 2018-03-20 15:36:07.280
-                ASSERT_EQ((size_t) 23, timeString.length());
+                ASSERT_LE((size_t) 21, timeString.length());
                 ASSERT_EQ(timeString[0], '2');
                 ASSERT_EQ(timeString[1], '0');
                 ASSERT_EQ(timeString[4], '-');
@@ -192,7 +192,7 @@ namespace hazelcast {
                 ASSERT_GE(actualDuration, parkDurationNanos);
             }
 
-            TEST_F (ClientUtilTest, print_older_stead_clock_time) {
+            TEST_F (ClientUtilTest, print_older_steady_clock_time) {
                 auto now = std::chrono::steady_clock::now();
                 auto time_str = hazelcast::util::StringUtil::time_to_string(now);
                 ASSERT_EQ(std::string::npos, time_str.substr(time_str.find_last_of('.')).find('-'));


### PR DESCRIPTION
Fixed the time printing for `Connection` logs so that the msecs part is correctly written.

fixes #892