### PR TITLE
Fix multiple definitions error

### DIFF
--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -1001,7 +1001,7 @@ namespace hazelcast {
             /**
              * Default TTL value of a record.
              */
-            static constexpr std::chrono::milliseconds UNSET{-1};
+            static const std::chrono::milliseconds UNSET;
 
             monitor::impl::LocalMapStatsImpl local_map_stats_;
 

--- a/hazelcast/include/hazelcast/client/proxy/RingbufferImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/RingbufferImpl.h
@@ -72,7 +72,7 @@ namespace hazelcast {
                  * The maximum number of items that can be retrieved in 1 go using the {@link #readManyAsync(long, int, int, IFunction)}
                  * method.
                  */
-                static constexpr int32_t MAX_BATCH_SIZE = 1000;
+                static const int32_t MAX_BATCH_SIZE;
 
                 /**
                  * Returns the capacity of this Ringbuffer.

--- a/hazelcast/include/hazelcast/client/query/predicates.h
+++ b/hazelcast/include/hazelcast/client/query/predicates.h
@@ -28,8 +28,8 @@ namespace hazelcast {
 
         namespace query {
             struct HAZELCAST_API query_constants {
-                static constexpr const char *KEY_ATTRIBUTE_NAME = "__key";
-                static constexpr const char *THIS_ATTRIBUTE_NAME = "this";
+                static const char * const KEY_ATTRIBUTE_NAME;
+                static const char * const THIS_ATTRIBUTE_NAME;
             };
 
             /**

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -1632,7 +1632,7 @@ namespace hazelcast {
                                                                                           context),
                                                                                 target_partition_id_(-1) {}
 
-            constexpr int32_t RingbufferImpl::MAX_BATCH_SIZE;
+            const int32_t RingbufferImpl::MAX_BATCH_SIZE{ 1000 };
         }
 
         namespace map {

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -50,7 +50,7 @@
 
 namespace hazelcast {
     namespace client {
-        constexpr std::chrono::milliseconds imap::UNSET;
+        const std::chrono::milliseconds imap::UNSET{ -1 };
 
         reliable_topic::reliable_topic(const std::string &instance_name, spi::ClientContext *context)
                 : proxy::ProxyImpl(reliable_topic::SERVICE_NAME, instance_name, context),

--- a/hazelcast/src/hazelcast/client/query.cpp
+++ b/hazelcast/src/hazelcast/client/query.cpp
@@ -36,6 +36,8 @@
 namespace hazelcast {
     namespace client {
         namespace query {
+            const char * const query_constants::KEY_ATTRIBUTE_NAME = "__key";
+            const char * const query_constants::THIS_ATTRIBUTE_NAME = "this";
 
             base_predicate::base_predicate(hazelcast_client &client) : out_stream(spi::ClientContext(
                     client).get_serialization_service().new_output_stream()) {}

--- a/hazelcast/src/hazelcast/client/query.cpp
+++ b/hazelcast/src/hazelcast/client/query.cpp
@@ -36,8 +36,6 @@
 namespace hazelcast {
     namespace client {
         namespace query {
-            constexpr const char *query_constants::KEY_ATTRIBUTE_NAME;
-            constexpr const char *query_constants::THIS_ATTRIBUTE_NAME;
 
             base_predicate::base_predicate(hazelcast_client &client) : out_stream(spi::ClientContext(
                     client).get_serialization_service().new_output_stream()) {}


### PR DESCRIPTION
The reported issue is due to a bug in GCC or the linker. See the bug [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101957).

As a workaround, PR changes some `constexpr` usages with `const`. With this change, all examples compile in C++17 mode and link against a C++11-compiled client library without errors.

Fixes #895.