### PR TITLE
Fix dockerfiles

### DIFF
--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:33
 
 RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.i686 cmake valgrind rsync passwd openssh-server ninja-build java-1.8.0-openjdk

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:33
 
 RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.x86_64 cmake valgrind java-1.8.0-openjdk.x86_64 rsync passwd openssh-server ninja-build


### PR DESCRIPTION
Fedora 34 doesn't have the `compat-openssl10` package, and I can't use `openssl-devel` (which is version 1.1.x), because it won't compile as the pkg comes with FIPS and these lines only work with versions 1.0.x:

https://github.com/hazelcast/hazelcast-cpp-client/blob/a68c930885e63aac6b905271cb806ce92ab825a7/hazelcast/src/hazelcast/client/discovery.cpp#L255-L264

This is a bigger issue regarding the project's compatibility with FIPS-enabled OpenSSL and this PR is only a temporary workaround to fix the CI. 

Opened a separate issue to address the main problem later: https://github.com/hazelcast/hazelcast-cpp-client/issues/906
