### PR TITLE
Refactor dockerfiles

### DIFF
--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -1,16 +1,6 @@
 FROM fedora:33
 
-RUN dnf groups install -y "Development Tools"
-RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.i686 cmake valgrind rsync passwd openssh-server ninja-build java-1.8.0-openjdk
-
-#install 32-bit libraries
-RUN dnf -y install glibc-devel.i686 glibc-devel libstdc++.i686
-
-# needed for test
-RUN dnf install -y maven net-tools gcovr
-RUN dnf install -y fedora-repos-rawhide
-RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel.i686
-
-RUN dnf install -y wget bzip2
-RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
-
+RUN dnf groups install -y "Development Tools" && \
+    dnf install -y gcc-c++ gdb compat-openssl10-devel.i686 cmake valgrind rsync passwd openssh-server ninja-build \
+                   java-1.8.0-openjdk glibc-devel.i686 glibc-devel libstdc++.i686 maven net-tools gcovr \
+                   fedora-repos-rawhide boost-devel.i686 thrift-devel.i686

--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:33
 
 RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.i686 cmake valgrind rsync passwd openssh-server ninja-build java-1.8.0-openjdk

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -1,15 +1,8 @@
 FROM fedora:33
 
-RUN dnf groups install -y "Development Tools"
-RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.x86_64 cmake valgrind java-1.8.0-openjdk.x86_64 rsync passwd openssh-server ninja-build
-
-# needed for test
-RUN dnf install -y maven net-tools gcovr
-RUN dnf install -y fedora-repos-rawhide
-RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel
-
-# install boost
-RUN dnf install -y wget bzip2 && wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
+RUN dnf groups install -y "Development Tools" && \
+    dnf install -y gcc-c++ gdb compat-openssl10-devel.x86_64 cmake java-1.8.0-openjdk.x86_64 rsync passwd \
+                   openssh-server ninja-build maven net-tools gcovr fedora-repos-rawhide thrift-devel boost-devel
 
 RUN ssh-keygen -A
 

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:33
 
 RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.x86_64 cmake valgrind java-1.8.0-openjdk.x86_64 rsync passwd openssh-server ninja-build


### PR DESCRIPTION
Collects all `dnf install` commands into one `RUN` step, uses `boost-devel` instead of building from source.

32 bit build: http://jenkins.hazelcast.com/job/yinci-test-cpp-linux-32-SHARED-Debug-clone/1/