### PR TITLE
[API-597] Implementation external public address usage support

### DIFF
--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -1206,7 +1206,7 @@ In order to use this feature, make sure your cluster members are accessible from
 
 ```c++
     hazelcast::client::client_config config;
-    constexpr const int32_t server_port = 5701;
+    constexpr int server_port = 5701;
     constexpr const char *server_public_address = "myserver.publicaddress.com";
     config.get_network_config().use_public_address(true).add_address(
             hazelcast::client::address{server_public_address, server_port});

--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -1198,11 +1198,20 @@ Please check the code sample at `examples/cloud-discovery/ssl-connect-cloud.cpp`
 
 > **NOTE: This feature requires Hazelcast IMDG 4.2 or higher version.**
 
-The client sends requests directly to cluster members in the smart client mode (default) in order to reduce hops to accomplish operations. Because of that, the client should know the addresses of members in the cluster.
+The client sends requests directly to cluster members in the smart client mode (default) in order to reduce hops to 
+accomplish operations. Because of that, the client should know the addresses of members in the cluster.
 
-In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and the public network. When the client is in the same network as the members, it uses their private network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue. The client needs to communicate with all cluster members via their public IP addresses in this case. Whenever Hazelcast cluster members are able to resolve their own public external IP addresses, they pass this information to the client. As a result, the client can use public addresses for communication.
+In cloud-like environments, or Kubernetes, there are usually two network interfaces: the private and public network 
+interfaces. When the client is in the same network as the members, it uses their private network addresses. Otherwise, 
+if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their 
+private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue. The client 
+needs to communicate with all cluster members via their public IP addresses in this case. Whenever Hazelcast cluster 
+members are able to resolve their own public external IP addresses, they pass this information to the client. 
+As a result, the client can use public addresses for communication.
 
-In order to use this feature, make sure your cluster members are accessible from the network the client resides in, then set config `client_network_config()::use_public_address(true)` to true. You should specify the public address of at least one member in the configuration:
+In order to use this feature, make sure your cluster members are accessible from the network the client resides in, 
+then set config `client_network_config()::use_public_address(true)` to true. You should specify the public address of 
+at least one member in the configuration:
 
 ```c++
     hazelcast::client::client_config config;
@@ -1212,7 +1221,8 @@ In order to use this feature, make sure your cluster members are accessible from
             hazelcast::client::address{server_public_address, server_port});
 ```
 
-This solution works everywhere without further configuration: Kubernetes, AWS, GCP, Azure, etc. as long as the corresponding plugin is enabled in Hazelcast server configuration.
+This solution works everywhere without further configuration (Kubernetes, AWS, GCP, Azure, etc.) as long as the 
+corresponding plugin is enabled in Hazelcast server configuration.
 
 ## 5.10. Authentication
 

--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -1196,9 +1196,11 @@ Please check the code sample at `examples/cloud-discovery/ssl-connect-cloud.cpp`
 
 ## 5.9. External Smart Client Discovery
 
+> **NOTE: This feature requires Hazelcast IMDG 4.2 or higher version.**
+
 The client sends requests directly to cluster members in the smart client mode (default) in order to reduce hops to accomplish operations. Because of that, the client should know the addresses of members in the cluster.
 
-In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and the public network. When the client is in the same network as the members, it uses their private network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue.
+In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and the public network. When the client is in the same network as the members, it uses their private network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue. The client needs to communicate with all cluster members via their public IP addresses in this case. Whenever Hazelcast cluster members are able to resolve their own public external IP addresses, they pass this information to the client. As a result, the client can use public addresses for communication.
 
 In order to use this feature, make sure your cluster members are accessible from the network the client resides in, then set config `client_network_config()::use_public_address(true)` to true. You should specify the public address of at least one member in the configuration:
 

--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -53,10 +53,11 @@
       * [5.7. Enabling Hazelcast AWS Discovery](#57-enabling-hazelcast-aws-discovery)
       * [5.8. Enabling Hazelcast Cloud Discovery](#58-enabling-hazelcast-cloud-discovery)
       * [5.8.1. Cloud Discovery With SSL Enabled](#581-cloud-discovery-with-ssl-enabled)
-      * [5.9. Authentication](#59-authentication)
-      * [5.9.1. Username Password Authentication](#591-username-password-authentication)
-      * [5.9.2. Token Authentication](#592-token-authentication)
-      * [5.10. Configuring Backup Acknowledgment](#510-configuring-backup-acknowledgment)
+      * [5.9. External Smart Client Discovery](#59-external-smart-client-discovery)
+      * [5.10. Authentication](#510-authentication)
+      * [5.10.1. Username Password Authentication](#5101-username-password-authentication)
+      * [5.10.2. Token Authentication](#5102-token-authentication)
+      * [5.11. Configuring Backup Acknowledgment](#511-configuring-backup-acknowledgment)
    * [6. Securing Client Connection](#6-securing-client-connection)
       * [6.1. TLS/SSL](#61-tlsssl)
          * [6.1.1. TLS/SSL for Hazelcast Members](#611-tlsssl-for-hazelcast-members)
@@ -140,7 +141,7 @@
    * [11. License](#11-license)
    * [12. Copyright](#12-copyright)
 
-<!-- Added by: ihsan, at: Wed Apr  7 13:25:05 +03 2021 -->
+<!-- Added by: ihsan, at: Wed Aug 11 10:30:27 +03 2021 -->
 
 <!--te-->
 
@@ -767,6 +768,9 @@ Hazelcast C++ client supports the following data structures and features:
 * custom_serializer Serialization
 * JSON Serialization
 * Global Serialization
+* Hazelcast AWS Discovery
+* Hazelcast Cloud Discovery
+* External Smart Client Discovery
 
 # 3. Configuration Overview
 
@@ -1190,7 +1194,25 @@ As you see in the code snippet, we provide a `boost::asio::ssl::context` in the 
 
 Please check the code sample at `examples/cloud-discovery/ssl-connect-cloud.cpp` for a full featured cloud discovery with SSL example.
 
-## 5.9. Authentication
+## 5.9. External Smart Client Discovery
+
+The client sends requests directly to cluster members in the smart client mode (default) in order to reduce hops to accomplish operations. Because of that, the client should know the addresses of members in the cluster.
+
+In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and the public network. When the client is in the same network as the members, it uses their private network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue.
+
+In order to use this feature, make sure your cluster members are accessible from the network the client resides in, then set config `client_network_config()::use_public_address(true)` to true. You should specify the public address of at least one member in the configuration:
+
+```c++
+    hazelcast::client::client_config config;
+    constexpr const int32_t server_port = 5701;
+    constexpr const char *server_public_address = "myserver.publicaddress.com";
+    config.get_network_config().use_public_address(true).add_address(
+            hazelcast::client::address{server_public_address, server_port});
+```
+
+This solution works everywhere without further configuration: Kubernetes, AWS, GCP, Azure, etc. as long as the corresponding plugin is enabled in Hazelcast server configuration.
+
+## 5.10. Authentication
 
 By default, the client does not use any authentication method and just uses the cluster "dev" to connect to. You can change which cluster to connect by using the configuration API `client_config::set_cluster_name`. This way, you can have multiple clusters in the network but the client will only be able to connect to the cluster with the correct cluster name (server should also be started with the cluster name configured to the same cluster name).
 
@@ -1199,7 +1221,7 @@ If you want to enable authentication, then the client can be configured in one o
 * Username password based authentication
 * Token based authentication
 
-## 5.9.1. Username Password Authentication
+## 5.10.1. Username Password Authentication
 
 The following is an example configuration where we set the username `test-user` and password `test-pass` to be used while trying to connect to the cluster:
 
@@ -1221,7 +1243,7 @@ Note that the server needs to be configured to use the same username and passwor
     </security>
 ```
 
-## 5.9.2. Token Authentication
+## 5.10.2. Token Authentication
 
 The following is an example configuration where we set the secret token bytes to be used while trying to connect to the cluster:
 
@@ -1245,7 +1267,7 @@ Note that the server needs to be configured to use the same token. An example se
     </security>
 ```
 
-## 5.10. Configuring Backup Acknowledgment
+## 5.11. Configuring Backup Acknowledgment
 
 When an operation with sync backup is sent by a client to the Hazelcast member(s), the acknowledgment of the operation's backup is sent to the client by the backup replica member(s). This improves the performance of the client operations.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(pipeline)
 add_subdirectory(authentication)
 add_subdirectory(cp)
 add_subdirectory(soak-test)
+add_subdirectory(external-smart-client-discovery)
 
 if (${WITH_OPENSSL})
     add_subdirectory(tls)

--- a/examples/external-smart-client-discovery/CMakeLists.txt
+++ b/examples/external-smart-client-discovery/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+add_executable(connect-external-client connect-external-client.cpp)

--- a/examples/external-smart-client-discovery/README.md
+++ b/examples/external-smart-client-discovery/README.md
@@ -1,0 +1,17 @@
+#External Smart Client Discovery
+
+The client sends requests directly to cluster members in the smart client mode (default) in order to reduce hops to accomplish operations. Because of that, the client should know the addresses of members in the cluster.
+
+In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and the public network. When the client is in the same network as the members, it uses their private network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue.
+
+In order to use this feature, make sure your cluster members are accessible from the network the client resides in, then set config `client_network_config()::use_public_address(true)` to true. You should specify the public address of at least one member in the configuration:
+
+```c++
+    hazelcast::client::client_config config;
+    constexpr const int32_t server_port = 5701;
+    constexpr const char *server_public_address = "myserver.publicaddress.com";
+    config.get_network_config().use_public_address(true).add_address(
+            hazelcast::client::address{server_public_address, server_port});
+```
+
+This solution works everywhere without further configuration: Kubernetes, AWS, GCP, Azure, etc. as long as the corresponding plugin is enabled in Hazelcast server configuration.

--- a/examples/external-smart-client-discovery/README.md
+++ b/examples/external-smart-client-discovery/README.md
@@ -16,7 +16,7 @@ should specify the public address of at least one member in the configuration:
 
 ```c++
     hazelcast::client::client_config config;
-    constexpr const int32_t server_port = 5701;
+    constexpr int server_port = 5701;
     constexpr const char *server_public_address = "myserver.publicaddress.com";
     config.get_network_config().use_public_address(true).add_address(
             hazelcast::client::address{server_public_address, server_port});

--- a/examples/external-smart-client-discovery/README.md
+++ b/examples/external-smart-client-discovery/README.md
@@ -1,10 +1,18 @@
-#External Smart Client Discovery
+# External Smart Client Discovery
 
-The client sends requests directly to cluster members in the smart client mode (default) in order to reduce hops to accomplish operations. Because of that, the client should know the addresses of members in the cluster.
+The client sends requests directly to cluster members in the smart client mode (default) in order to
+reduce hops to accomplish operations. Because of that, the client should know the addresses of
+members in the cluster.
 
-In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and the public network. When the client is in the same network as the members, it uses their private network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced External Smart Client Discovery to solve that issue.
+In cloud-like environments, or Kubernetes, there are usually two network interfaces, the private and
+the public network. When the client is in the same network as the members, it uses their private
+network addresses. Otherwise, if the client and the Hazelcast cluster are on different networks, the
+client cannot connect to members using their private network addresses. Hazelcast 4.2 introduced
+External Smart Client Discovery to solve that issue.
 
-In order to use this feature, make sure your cluster members are accessible from the network the client resides in, then set config `client_network_config()::use_public_address(true)` to true. You should specify the public address of at least one member in the configuration:
+In order to use this feature, make sure your cluster members are accessible from the network the
+client resides in, then set config `client_network_config()::use_public_address(true)` to true. You
+should specify the public address of at least one member in the configuration:
 
 ```c++
     hazelcast::client::client_config config;
@@ -14,4 +22,5 @@ In order to use this feature, make sure your cluster members are accessible from
             hazelcast::client::address{server_public_address, server_port});
 ```
 
-This solution works everywhere without further configuration: Kubernetes, AWS, GCP, Azure, etc. as long as the corresponding plugin is enabled in Hazelcast server configuration.
+This solution works everywhere without further configuration: Kubernetes, AWS, GCP, Azure, etc. as
+long as the corresponding plugin is enabled in Hazelcast server configuration.

--- a/examples/external-smart-client-discovery/connect-external-client.cpp
+++ b/examples/external-smart-client-discovery/connect-external-client.cpp
@@ -17,7 +17,7 @@
 
 int main(int argc, char **argv) {
     hazelcast::client::client_config config;
-    constexpr const int32_t server_port = 5701;
+    constexpr int server_port = 5701;
     constexpr const char *server_public_address = "myserver.publicaddress.com";
     config.get_network_config().use_public_address(true).add_address(
             hazelcast::client::address{server_public_address, server_port});

--- a/examples/external-smart-client-discovery/connect-external-client.cpp
+++ b/examples/external-smart-client-discovery/connect-external-client.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <hazelcast/client/hazelcast_client.h>
+
+int main(int argc, char **argv) {
+    hazelcast::client::client_config config;
+    constexpr const int32_t server_port = 5701;
+    constexpr const char *server_public_address = "myserver.publicaddress.com";
+    config.get_network_config().use_public_address(true).add_address(
+            hazelcast::client::address{server_public_address, server_port});
+    // The client will try to connect to the cluster initially using the provided server public address and
+    // it will connect to the other members of the cluster using their public interfaces if available.
+    auto hz = hazelcast::new_client(std::move(config)).get();
+
+    auto map = hz.get_map("MyMap").get();
+
+    map->put(1, 100).get();
+    map->put(2, 200).get();
+
+    auto value = map->get<int, int>(1).get();
+
+    if (value) {
+        std::cout << "Value for key 1 is " << value.value() << std::endl;
+    }
+
+    std::cout << "Finished" << std::endl;
+
+    return 0;
+}

--- a/hazelcast/include/hazelcast/client/config/client_network_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_network_config.h
@@ -152,6 +152,19 @@ namespace hazelcast {
 
                 socket_options &get_socket_options();
 
+                /**
+                 *
+                 * @return true if the public address of the server needs to be used when connecting to the cluster.
+                 */
+                bool use_public_address() const;
+
+                /**
+                 *
+                 * @param should_use_public_address `true` mean force usage of the public address of the server when
+                 * connecting to the server. Otherwise, set to `false` to use the private address. Default is `false`.
+                 */
+                void use_public_address(bool should_use_public_address);
+
             private:
                 config::ssl_config ssl_config_;
                 config::client_aws_config client_aws_config_;
@@ -163,6 +176,8 @@ namespace hazelcast {
                 std::vector<address> address_list_;
 
                 socket_options socket_options_;
+
+                bool use_public_address_{false};
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/config/client_network_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_network_config.h
@@ -162,7 +162,7 @@ namespace hazelcast {
                  *
                  * @param should_use_public_address `true` mean force usage of the public address of the server when
                  * connecting to the server. Otherwise, set to `false` to use the private address. Default is `false`.
-                * @return configured \client_network_config for chaining
+                 * @return configured \client_network_config for chaining
                  */
                 client_network_config &use_public_address(bool should_use_public_address);
 

--- a/hazelcast/include/hazelcast/client/config/client_network_config.h
+++ b/hazelcast/include/hazelcast/client/config/client_network_config.h
@@ -162,8 +162,9 @@ namespace hazelcast {
                  *
                  * @param should_use_public_address `true` mean force usage of the public address of the server when
                  * connecting to the server. Otherwise, set to `false` to use the private address. Default is `false`.
+                * @return configured \client_network_config for chaining
                  */
-                void use_public_address(bool should_use_public_address);
+                client_network_config &use_public_address(bool should_use_public_address);
 
             private:
                 config::ssl_config ssl_config_;

--- a/hazelcast/include/hazelcast/client/connection/AddressProvider.h
+++ b/hazelcast/include/hazelcast/client/connection/AddressProvider.h
@@ -43,6 +43,11 @@ namespace hazelcast {
                  */
                 virtual boost::optional<address> translate(const address &addr) = 0;
 
+                /**
+                 * @return true for the \DefaultAddressProvider , false otherwise.
+                 */
+                virtual bool is_default_provider();
+
                 virtual ~AddressProvider() = default;
             };
         }

--- a/hazelcast/include/hazelcast/client/member.h
+++ b/hazelcast/include/hazelcast/client/member.h
@@ -79,10 +79,7 @@ namespace hazelcast {
 
             member(boost::uuids::uuid uuid);
 
-            /**
-             * comparison operation
-             */
-            bool operator==(const member &) const;
+            friend bool operator==(const member &lhs, const member &rhs);
 
             /**
              *

--- a/hazelcast/include/hazelcast/client/member.h
+++ b/hazelcast/include/hazelcast/client/member.h
@@ -79,7 +79,7 @@ namespace hazelcast {
 
             member(boost::uuids::uuid uuid);
 
-            friend bool operator==(const member &lhs, const member &rhs);
+            friend bool HAZELCAST_API operator==(const member &lhs, const member &rhs);
 
             /**
              *

--- a/hazelcast/include/hazelcast/client/member.h
+++ b/hazelcast/include/hazelcast/client/member.h
@@ -27,9 +27,25 @@
 #pragma warning(disable: 4251) //for dll export	
 #endif
 
+namespace hazelcast { namespace client {
+    struct HAZELCAST_API endpoint_qualifier {
+        int32_t type;
+        std::string identifier;
+
+        friend bool HAZELCAST_API operator==(const endpoint_qualifier &lhs, const endpoint_qualifier &rhs);
+    };
+}}
+
+namespace std {
+    template<>
+    struct HAZELCAST_API hash<hazelcast::client::endpoint_qualifier> {
+        std::size_t operator()(const hazelcast::client::endpoint_qualifier &qualifier) const noexcept;
+    };
+}
+
+
 namespace hazelcast {
     namespace client {
-
         /**
          * hz_cluster member class. The default implementation
          *
@@ -47,9 +63,17 @@ namespace hazelcast {
                 REMOVE = 2
             };
 
+            struct version {
+                byte major;
+                byte minor;
+                byte patch;
+            };
+
             member();
 
-            member(address address, boost::uuids::uuid uuid, bool lite, std::unordered_map<std::string, std::string> attr);
+            member(address member_address, boost::uuids::uuid uuid, bool lite,
+                   std::unordered_map<std::string, std::string> attr,
+                   std::unordered_map<endpoint_qualifier, address> address_map);
 
             member(address member_address);
 
@@ -101,6 +125,8 @@ namespace hazelcast {
              */
             bool lookup_attribute(const std::string &key) const;
 
+            const std::unordered_map<endpoint_qualifier, address> &address_map() const;
+
             bool operator<(const member &rhs) const;
 
         private:
@@ -108,6 +134,7 @@ namespace hazelcast {
             boost::uuids::uuid uuid_;
             bool lite_member_;
             std::unordered_map<std::string, std::string> attributes_;
+            std::unordered_map<endpoint_qualifier, address> address_map_;
         };
 
         std::ostream HAZELCAST_API &operator<<(std::ostream &out, const member &member);

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
@@ -80,6 +80,8 @@ namespace hazelcast {
 
                 private:
                     static constexpr boost::chrono::milliseconds INITIAL_MEMBERS_TIMEOUT{boost::chrono::seconds(120)};
+                    static const endpoint_qualifier CLIENT;
+                    static const endpoint_qualifier MEMBER;
                     struct member_list_snapshot {
                         int32_t version;
                         std::unordered_map<boost::uuids::uuid, member, boost::hash<boost::uuids::uuid>> members;

--- a/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressProvider.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressProvider.h
@@ -39,6 +39,8 @@ namespace hazelcast {
 
                     boost::optional<address> translate(const address &addr) override;
 
+                    bool is_default_provider() override;
+
                 private:
                     config::client_network_config &network_config_;
                 };

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -846,7 +846,10 @@ namespace hazelcast {
 
 namespace std {
     std::size_t hash<hazelcast::client::address>::operator()(const hazelcast::client::address &address) const noexcept {
-        return std::hash<std::string>()(address.get_host()) + std::hash<int>()(address.get_port()) +
-               std::hash<unsigned long>()(address.type_);
+        std::size_t seed = 0;
+        boost::hash_combine(seed, address.get_host());
+        boost::hash_combine(seed, address.get_port());
+        boost::hash_combine(seed, address.type_);
+        return seed;
     }
 }

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -65,8 +65,11 @@ namespace hazelcast {
         member::member() : lite_member_(false) {
         }
 
-        member::member(address address, boost::uuids::uuid uuid, bool lite, std::unordered_map<std::string, std::string> attr) :
-                address_(address), uuid_(uuid), lite_member_(lite), attributes_(attr) {
+        member::member(address member_address, boost::uuids::uuid uuid, bool lite,
+                       std::unordered_map<std::string, std::string> attr,
+                       std::unordered_map<endpoint_qualifier, address> address_map) :
+                       address_(member_address), uuid_(uuid), lite_member_(lite), attributes_(attr),
+                       address_map_(address_map) {
         }
 
         member::member(address member_address) : address_(member_address), lite_member_(false) {
@@ -103,6 +106,9 @@ namespace hazelcast {
             out << ":";
             out << address.get_port();
             out << " - " << boost::uuids::to_string(member.get_uuid());
+            if (member.is_lite_member()) {
+                out << " lite";
+            }
             return out;
         }
 
@@ -121,6 +127,10 @@ namespace hazelcast {
 
         bool member::operator<(const member &rhs) const {
             return uuid_ < rhs.uuid_;
+        }
+
+        const std::unordered_map<endpoint_qualifier, address> &member::address_map() const {
+            return address_map_;
         }
 
         endpoint::endpoint(boost::uuids::uuid uuid, boost::optional<address> socket_address)
@@ -234,12 +244,28 @@ namespace hazelcast {
                 }
             }
         }
+
+        bool operator==(const endpoint_qualifier &lhs, const endpoint_qualifier &rhs) {
+            return lhs.type == rhs.type &&
+                   lhs.identifier == rhs.identifier;
+        }
     }
 }
 
 namespace std {
-    std::size_t hash<hazelcast::client::member>::operator()(const hazelcast::client::member &k) const noexcept {
-        return boost::hash<boost::uuids::uuid>()(k.get_uuid());
+    std::size_t hash<hazelcast::client::member>::operator()(const hazelcast::client::member &m) const noexcept {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, std::hash<hazelcast::client::address>()(m.get_address()));
+        boost::hash_combine(seed, m.get_uuid());
+        return seed;
+    }
+
+    std::size_t hash<hazelcast::client::endpoint_qualifier>::operator()(
+            const hazelcast::client::endpoint_qualifier &e) const noexcept {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, e.type);
+        boost::hash_combine(seed, e.identifier);
+        return seed;
     }
 }
 

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -65,11 +65,11 @@ namespace hazelcast {
         member::member() : lite_member_(false) {
         }
 
-        member::member(address member_address, boost::uuids::uuid uuid, bool lite,
+member::member(address member_address, boost::uuids::uuid uuid, bool lite,
                        std::unordered_map<std::string, std::string> attr,
                        std::unordered_map<endpoint_qualifier, address> address_map) :
-                       address_(member_address), uuid_(uuid), lite_member_(lite), attributes_(attr),
-                       address_map_(address_map) {
+                address_(std::move(member_address)), uuid_(uuid), lite_member_(lite),
+                attributes_(std::move(attr)), address_map_(std::move(address_map)) {
         }
 
         member::member(address member_address) : address_(member_address), lite_member_(false) {

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -78,10 +78,6 @@ member::member(address member_address, boost::uuids::uuid uuid, bool lite,
         member::member(boost::uuids::uuid uuid) : uuid_(uuid), lite_member_(false) {
         }
 
-        bool member::operator==(const member &rhs) const {
-            return uuid_ == rhs.uuid_;
-        }
-
         const address &member::get_address() const {
             return address_;
         }
@@ -131,6 +127,11 @@ member::member(address member_address, boost::uuids::uuid uuid, bool lite,
 
         const std::unordered_map<endpoint_qualifier, address> &member::address_map() const {
             return address_map_;
+        }
+
+        bool operator==(const member &lhs, const member &rhs) {
+            return lhs.address_ == rhs.address_ &&
+                   lhs.uuid_ == rhs.uuid_;
         }
 
         endpoint::endpoint(boost::uuids::uuid uuid, boost::optional<address> socket_address)

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -322,8 +322,9 @@ namespace hazelcast {
                 return use_public_address_;
             }
 
-            void client_network_config::use_public_address(bool should_use_public_address) {
+            client_network_config &client_network_config::use_public_address(bool should_use_public_address) {
                 use_public_address_ = should_use_public_address;
+                return *this;
             }
 
             client_connection_strategy_config::client_connection_strategy_config() : async_start_(false), reconnect_mode_(ON) {

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -318,6 +318,14 @@ namespace hazelcast {
                 return *this;
             }
 
+            bool client_network_config::use_public_address() const {
+                return use_public_address_;
+            }
+
+            void client_network_config::use_public_address(bool should_use_public_address) {
+                use_public_address_ = should_use_public_address;
+            }
+
             client_connection_strategy_config::client_connection_strategy_config() : async_start_(false), reconnect_mode_(ON) {
             }
 

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -85,9 +85,8 @@ namespace hazelcast {
                       wait_strategy_(client.get_client_config().get_connection_strategy_config().get_retry_config(),
                                      logger_), cluster_id_(boost::uuids::nil_uuid()),
                       connect_to_cluster_task_submitted_(false),
-                      use_public_address_(address_provider_->is_default_provider()
-                                          ? client.get_client_config().get_network_config().use_public_address()
-                                          : false) {
+                      use_public_address_(address_provider_->is_default_provider() &&
+                                          client.get_client_config().get_network_config().use_public_address()) {
                 config::client_network_config &networkConfig = client.get_client_config().get_network_config();
                 auto connTimeout = networkConfig.get_connection_timeout();
                 if (connTimeout.count() > 0) {

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -67,6 +67,7 @@ namespace hazelcast {
     namespace client {
         namespace connection {
             constexpr size_t ClientConnectionManagerImpl::EXECUTOR_CORE_POOL_SIZE;
+            const endpoint_qualifier ClientConnectionManagerImpl::PUBLIC_ENDPOINT_QUALIFIER{CLIENT, "public"};
 
             ClientConnectionManagerImpl::ClientConnectionManagerImpl(spi::ClientContext &client,
                                                                      std::unique_ptr<AddressProvider> address_provider)
@@ -83,7 +84,8 @@ namespace hazelcast {
                       load_balancer_(client.get_client_config().get_load_balancer()),
                       wait_strategy_(client.get_client_config().get_connection_strategy_config().get_retry_config(),
                                      logger_), cluster_id_(boost::uuids::nil_uuid()),
-                      connect_to_cluster_task_submitted_(false) {
+                      connect_to_cluster_task_submitted_(false),
+                      use_public_address_(client.get_client_config().get_network_config().use_public_address()){
 
                 config::client_network_config &networkConfig = client.get_client_config().get_network_config();
                 auto connTimeout = networkConfig.get_connection_timeout();
@@ -175,16 +177,6 @@ namespace hazelcast {
             }
 
             std::shared_ptr<Connection>
-            ClientConnectionManagerImpl::get_or_connect(const address &address) {
-                auto connection = get_connection(address);
-                if (connection) {
-                    return connection;
-                }
-
-                return connect(address);
-            }
-
-            std::shared_ptr<Connection>
             ClientConnectionManagerImpl::get_or_connect(const member &m) {
                 const auto &uuid = m.get_uuid();
                 auto connection = active_connections_.get(uuid);
@@ -192,22 +184,12 @@ namespace hazelcast {
                     return connection;
                 }
 
-                return connect(m.get_address());
+                address addr = translate(m);
+                return connect(addr);
             }
 
             std::vector<std::shared_ptr<Connection> > ClientConnectionManagerImpl::get_active_connections() {
                 return active_connections_.values();
-            }
-
-            std::shared_ptr<Connection>
-            ClientConnectionManagerImpl::get_connection(const address &address) {
-                for (const auto &connection : active_connections_.values()) {
-                    auto remote_address = connection->get_remote_address();
-                    if (remote_address && *remote_address == address) {
-                        return connection;
-                    }
-                }
-                return nullptr;
             }
 
             std::shared_ptr<Connection> ClientConnectionManagerImpl::get_connection(boost::uuids::uuid uuid) {
@@ -392,24 +374,22 @@ namespace hazelcast {
                     return;
                 }
 
-                for (const auto &member : client_.get_client_cluster_service().get_member_list()) {
-                    const auto& member_addr = member.get_address();
-
-                    if (client_.get_lifecycle_service().is_running() && !get_connection(member_addr)
-                        && connecting_addresses_.get_or_put_if_absent(member_addr, nullptr).second) {
+                for (const auto &m : client_.get_client_cluster_service().get_member_list()) {
+                    if (client_.get_lifecycle_service().is_running() && !get_connection(m.get_uuid())
+                        && connecting_members_.get_or_put_if_absent(m, nullptr).second) {
                         // submit a task for this address only if there is no other pending connection attempt for it
-                        address addr = member_addr;
-                        boost::asio::post(executor_->get_executor(), [=]() {
+                        member member_to_connect = m;
+                        boost::asio::post(executor_->get_executor(), [member_to_connect, this]() {
                             try {
                                 if (!client_.get_lifecycle_service().is_running()) {
                                     return;
                                 }
-                                if (!get_connection(member.get_uuid())) {
-                                    get_or_connect(addr);
+                                if (!get_connection(member_to_connect.get_uuid())) {
+                                    get_or_connect(member_to_connect);
                                 }
-                                connecting_addresses_.remove(addr);
+                                connecting_members_.remove(member_to_connect);
                             } catch (std::exception &) {
-                                connecting_addresses_.remove(addr);
+                                connecting_members_.remove(member_to_connect);
                             }
                         });
                     }
@@ -611,7 +591,7 @@ namespace hazelcast {
                     } else {
                         HZ_LOG(logger_, info,
                                boost::str(boost::format("Authenticated with server %1%:%2%, server version: %3%, "
-                                                        "no local address: (connection disconnected ?). %5%")
+                                                        "no local address: (connection disconnected ?). %4%")
                                           % response.server_address % response.member_uuid
                                           % response.server_version % *connection)
                         );
@@ -715,7 +695,7 @@ namespace hazelcast {
 
                 for (const auto &member : client_.get_client_cluster_service().get_member_list()) {
                     try {
-                        get_or_connect(member.get_address());
+                        get_or_connect(member);
                     } catch (std::exception &) {
                         // ignore
                     }
@@ -746,16 +726,9 @@ namespace hazelcast {
             }
 
             std::shared_ptr<Connection> ClientConnectionManagerImpl::connect(const address &addr) {
-                auto target = address_provider_->translate(addr);
-                if (!target) {
-                    BOOST_THROW_EXCEPTION(exception::null_pointer("ClientConnectionManagerImpl::connect",
-                                                                  (boost::format("Address Provider could not translate "
-                                                                                 "address %2%") % target).str()));
-                }
-                HZ_LOG(logger_, info, boost::str(
-                        boost::format("Trying to connect to %1%. Translated address:%2%.") % addr % target));
+                HZ_LOG(logger_, info, boost::str(boost::format("Trying to connect to %1%.") % addr));
 
-                auto connection = std::make_shared<Connection>(*target, client_, ++connection_id_gen_,
+                auto connection = std::make_shared<Connection>(addr, client_, ++connection_id_gen_,
                                                                *socket_factory_, *this, connection_timeout_millis_);
                 connection->connect();
 
@@ -765,6 +738,18 @@ namespace hazelcast {
                 auto result = authenticate_on_cluster(connection);
 
                 return on_authenticated(connection, result);
+            }
+
+            address ClientConnectionManagerImpl::translate(const member &m) {
+                if (use_public_address_) {
+                    auto public_addr_it = m.address_map().find(PUBLIC_ENDPOINT_QUALIFIER);
+                    if (public_addr_it != m.address_map().end()) {
+                        return public_addr_it->second;
+                    }
+                    return m.get_address();
+                }
+
+                return *address_provider_->translate(m.get_address());
             }
 
             ReadHandler::ReadHandler(Connection &connection, size_t buffer_size)
@@ -960,7 +945,7 @@ namespace hazelcast {
                             std::rethrow_exception(close_cause_);
                         } catch (exception::iexception &ie) {
                             HZ_LOG(logger_, warning, 
-                                boost::str(boost::format("%1%%2%") % message.str() % ie)
+                                boost::str(boost::format("%1% %2%") % message.str() % ie)
                             );
                         }
                     }

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -85,8 +85,9 @@ namespace hazelcast {
                       wait_strategy_(client.get_client_config().get_connection_strategy_config().get_retry_config(),
                                      logger_), cluster_id_(boost::uuids::nil_uuid()),
                       connect_to_cluster_task_submitted_(false),
-                      use_public_address_(client.get_client_config().get_network_config().use_public_address()){
-
+                      use_public_address_(address_provider_->is_default_provider()
+                                          ? client.get_client_config().get_network_config().use_public_address()
+                                          : false) {
                 config::client_network_config &networkConfig = client.get_client_config().get_network_config();
                 auto connTimeout = networkConfig.get_connection_timeout();
                 if (connTimeout.count() > 0) {
@@ -783,6 +784,10 @@ namespace hazelcast {
 
             std::chrono::steady_clock::time_point ReadHandler::get_last_read_time() const {
                 return last_read_time_;
+            }
+
+            bool AddressProvider::is_default_provider() {
+                return false;
             }
 
             Connection::Connection(const address &address, spi::ClientContext &client_context, int connection_id, // NOLINT(cppcoreguidelines-pro-type-member-init)

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -657,6 +657,10 @@ namespace hazelcast {
                     return addr;
                 }
 
+                bool DefaultAddressProvider::is_default_provider() {
+                    return true;
+                }
+
                 const boost::shared_ptr<ClientClusterServiceImpl::member_list_snapshot> ClientClusterServiceImpl::EMPTY_SNAPSHOT(
                         new ClientClusterServiceImpl::member_list_snapshot{-1});
 

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1843,13 +1843,7 @@ namespace hazelcast {
                 member m(public_address, ctx.get_hazelcast_client_implementation()->random_uuid(), false, {},
                          {{endpoint_qualifier{1, "public"}, address{"127.0.0.1", 5701}}});
 
-                try {
-                    ctx.get_connection_manager().get_or_connect(m);
-                } catch(boost::system::system_error &e) {
-                    ASSERT_EQ(boost::asio::error::network_unreachable, e.code());
-                } catch (...) {
-                    FAIL();
-                }
+                ASSERT_THROW(ctx.get_connection_manager().get_or_connect(m), boost::system::system_error);
             }
 
             TEST_F(connection_manager_translate, default_config_uses_private_addresses) {

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -36,6 +36,7 @@
 #include <hazelcast/client/client_properties.h>
 #include <hazelcast/client/connection/ClientConnectionManagerImpl.h>
 #include <hazelcast/client/connection/Connection.h>
+#include <hazelcast/client/connection/AddressProvider.h>
 #include <hazelcast/client/entry_event.h>
 #include <hazelcast/client/exception/protocol_exceptions.h>
 #include <hazelcast/client/hazelcast_client.h>
@@ -1762,6 +1763,99 @@ namespace hazelcast {
 
                 ASSERT_OPEN_EVENTUALLY(leave);
                 ASSERT_OPEN_EVENTUALLY(join);
+            }
+
+            class connection_manager_translate : public ClientTestSupport {
+            public:
+                static const address private_address;
+                static const address public_address;
+
+                class test_address_provider : public connection::AddressProvider {
+                    public:
+                        test_address_provider(bool shouldTranslate) : should_translate(shouldTranslate) {}
+
+                        boost::optional<address> translate(const address &addr) override {
+                                if (!should_translate) {
+                                    return addr;
+                                }
+
+                                if (addr == private_address) {
+                                    return public_address;
+                                }
+
+                                return boost::none;
+                        }
+
+                        std::vector<address> load_addresses() override {
+                            return std::vector<address>{{"localhost", 5701}};
+                        }
+                    private:
+                        bool should_translate;
+                };
+            protected:
+                static HazelcastServer *instance_;
+
+                static void SetUpTestCase() {
+                    instance_ = new HazelcastServer(*g_srvFactory);
+                }
+
+                static void TearDownTestCase() {
+                    delete instance_;
+                }
+            };
+
+            HazelcastServer *connection_manager_translate::instance_ = nullptr;
+            const address connection_manager_translate::private_address{"localhost", 5701};
+            const address connection_manager_translate::public_address{"192.168.0.1", 5701};
+
+            TEST_F(connection_manager_translate, test_translate_is_used) {
+                // given
+                client_config config;
+                config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(1));
+                auto client = new_client(std::move(config)).get();
+                spi::ClientContext ctx(client);
+                connection::ClientConnectionManagerImpl connection_manager(ctx,
+                                                                           std::unique_ptr<connection::AddressProvider>(
+                                                                                   new test_address_provider{true}));
+
+                // throws exception because it can't connect to the cluster using translated public unreachable address
+                ASSERT_THROW(connection_manager.start(), exception::illegal_state);
+            }
+
+            TEST_F(connection_manager_translate, test_translate_is_used_when_member_has_public_client_address) {
+                // given
+                client_config config;
+                config.get_network_config().use_public_address(true);
+                config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(1));
+                auto client = new_client(std::move(config)).get();
+                spi::ClientContext ctx(client);
+
+                member m(public_address, ctx.get_hazelcast_client_implementation()->random_uuid(), false, {},
+                         {{endpoint_qualifier{1, "public"}, address{"127.0.0.1", 5701}}});
+
+                auto conn = ctx.get_connection_manager().get_or_connect(m);
+                ASSERT_TRUE(conn);
+            }
+
+            TEST_F(connection_manager_translate, test_translate_is_not_used_when_public_ip_is_disabled) {
+                // given
+                client_config config;
+                config.get_network_config().use_public_address(false);
+                config.get_connection_strategy_config().get_retry_config().set_cluster_connect_timeout(
+                        std::chrono::seconds(1));
+                auto client = new_client(std::move(config)).get();
+                spi::ClientContext ctx(client);
+
+                member m(public_address, ctx.get_hazelcast_client_implementation()->random_uuid(), false, {},
+                         {{endpoint_qualifier{1, "public"}, address{"127.0.0.1", 5701}}});
+
+                ASSERT_THROW(ctx.get_connection_manager().get_or_connect(m), std::exception);
+            }
+
+            TEST_F(connection_manager_translate, default_config_uses_private_addresses) {
+                 ASSERT_FALSE(client_config().get_network_config().use_public_address());
             }
         }
     }


### PR DESCRIPTION
Initial implementation of external public address usage support for the C++ client. This feature is needed for external Kubernetes client to be able to connect to the Hazelcast cluster.

related to https://hazelcast.atlassian.net/browse/API-597

Verification:[ Sample kubernetes test run](https://github.com/alisengul53/GHActionTestRepo/runs/3289096937?check_suite_focus=true)

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/899