### PR TITLE
Fix dangling string reference

### DIFF
--- a/hazelcast/include/hazelcast/client/impl/EntryEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/EntryEventHandler.h
@@ -37,11 +37,12 @@ namespace hazelcast {
             template<typename BaseType>
             class EntryEventHandler : public BaseType {
             public:
-                EntryEventHandler(const std::string &instance_name, spi::impl::ClientClusterServiceImpl &cluster_service,
+                EntryEventHandler(std::string instance_name, spi::impl::ClientClusterServiceImpl &cluster_service,
                                   serialization::pimpl::SerializationService &serialization_service,
                                   entry_listener &&listener, bool include_value, logger &lg)
-                : instance_name_(instance_name), cluster_service_(cluster_service), serialization_service_(serialization_service)
-                , listener_(std::move(listener)), include_value_(include_value), logger_(lg) {}
+                        : instance_name_(std::move(instance_name)), cluster_service_(cluster_service),
+                          serialization_service_(serialization_service), listener_(std::move(listener)),
+                          include_value_(include_value), logger_(lg) {}
 
                 void handle_entry(const boost::optional<serialization::pimpl::data> &key,
                                   const boost::optional<serialization::pimpl::data> &value,
@@ -131,7 +132,7 @@ namespace hazelcast {
                     }
                 }
             private:
-                const std::string& instance_name_;
+                const std::string instance_name_;
                 spi::impl::ClientClusterServiceImpl &cluster_service_;
                 serialization::pimpl::SerializationService& serialization_service_;
                 entry_listener listener_;

--- a/hazelcast/include/hazelcast/client/impl/ItemEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/ItemEventHandler.h
@@ -28,11 +28,12 @@ namespace hazelcast {
             template<typename BaseType>
             class item_event_handler : public BaseType {
             public:
-                item_event_handler(const std::string &instance_name, spi::impl::ClientClusterServiceImpl &cluster_service,
+                item_event_handler(std::string instance_name, spi::impl::ClientClusterServiceImpl &cluster_service,
                                    serialization::pimpl::SerializationService &serialization_service,
                                    item_listener &&listener, bool include_value)
-                        : instance_name_(instance_name), cluster_service_(cluster_service),
-                          serialization_service_(serialization_service), listener_(std::move(listener)), include_value_(include_value) {};
+                        : instance_name_(std::move(instance_name)), cluster_service_(cluster_service),
+                          serialization_service_(serialization_service), listener_(std::move(listener)),
+                          include_value_(include_value) {};
 
                 void handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid,
                                         int32_t event_type) override {
@@ -51,7 +52,7 @@ namespace hazelcast {
                 }
 
             private:
-                const std::string &instance_name_;
+                const std::string instance_name_;
                 spi::impl::ClientClusterServiceImpl &cluster_service_;
                 serialization::pimpl::SerializationService &serialization_service_;
                 item_listener listener_;


### PR DESCRIPTION
`EntryEventHandler` and `ItemEventHandler` may outlive the `ClientProxy` object they are associated with. Therefore, the member `instance_name_` may become a dangling reference to an `std::string` that was already destroyed and cause a use-after-free error as was reported in [this comment](https://github.com/hazelcast/hazelcast-cpp-client/issues/900#issuecomment-893343382).

This PR solves the issue by storing a copy of the string instead of holding a reference.