### PR TITLE
Fix Windows GHA builds

### DIFF
--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -51,7 +51,8 @@ jobs:
         run: |
           Invoke-WebRequest `
               "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz" `
-              -OutFile "boost_1_76_0.tar.gz"
+              -OutFile "boost_1_76_0.tar.gz" `
+              -UserAgent "''"
           tar xzf boost_1_76_0.tar.gz
           rm boost_1_76_0.tar.gz
           cd boost_1_76_0


### PR DESCRIPTION
The default user agent of `Invoke-WebRequest` in PowerShell is `Mozilla` and JFrog started serving HTML pages for download requests made with browser agents. Passing an empty user agent makes it work as it used be.

See [the run](https://github.com/yemreinci/hazelcast-cpp-client/actions/runs/1151372489) from my fork.