### PR TITLE
Change use of std::atomic<time_point> with std::atomic<duration>

### DIFF
--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -51,7 +51,8 @@ jobs:
         run: |
           Invoke-WebRequest `
               "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz" `
-              -OutFile "boost_1_76_0.tar.gz"
+              -OutFile "boost_1_76_0.tar.gz" `
+              -UserAgent "''"
           tar xzf boost_1_76_0.tar.gz
           rm boost_1_76_0.tar.gz
           cd boost_1_76_0

--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -115,7 +115,7 @@ namespace hazelcast {
 
                 void deregister_invocation(int64_t call_id);
 
-                void last_write_time(std::chrono::steady_clock::time_point time_point);
+                void last_write_time(std::chrono::steady_clock::time_point tp);
 
                 std::chrono::steady_clock::time_point last_write_time() const;
 
@@ -143,7 +143,7 @@ namespace hazelcast {
                 logger &logger_;
                 std::atomic_bool alive_;
                 std::unique_ptr<boost::asio::steady_timer> backup_timer_;
-                std::atomic<std::chrono::steady_clock::time_point> last_write_time_;
+                std::atomic<std::chrono::steady_clock::duration> last_write_time_;
 
                 void schedule_periodic_backup_cleanup(std::chrono::milliseconds backup_timeout,
                                                       std::shared_ptr<Connection> this_connection);

--- a/hazelcast/include/hazelcast/client/connection/ReadHandler.h
+++ b/hazelcast/include/hazelcast/client/connection/ReadHandler.h
@@ -55,7 +55,7 @@ namespace hazelcast {
             private:
 
                 protocol::ClientMessageBuilder<Connection> builder_;
-                std::atomic<std::chrono::steady_clock::time_point> last_read_time_;
+                std::atomic<std::chrono::steady_clock::duration> last_read_time_;
             };
         }
     }

--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -40,7 +40,7 @@ namespace hazelcast {
                               connect_timeout_(connect_timeout_in_millis), resolver_(io_resolver),
                               socket_(io) {
                     }
-                    
+
 #ifdef HZ_BUILD_WITH_SSL
 
                     template<typename CONTEXT, typename = std::enable_if<std::is_same<T, boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>::value>>

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -754,7 +754,7 @@ namespace hazelcast {
 
             ReadHandler::ReadHandler(Connection &connection, size_t buffer_size)
                     : buffer(new char[buffer_size]), byte_buffer(buffer, buffer_size), builder_(connection),
-                      last_read_time_(std::chrono::steady_clock::now()) {
+                      last_read_time_(std::chrono::steady_clock::now().time_since_epoch()) {
             }
 
             ReadHandler::~ReadHandler() {
@@ -762,7 +762,7 @@ namespace hazelcast {
             }
 
             void ReadHandler::handle() {
-                last_read_time_ = std::chrono::steady_clock::now();
+                last_read_time_ = std::chrono::steady_clock::now().time_since_epoch();
 
                 if (byte_buffer.position() == 0)
                     return;
@@ -782,7 +782,7 @@ namespace hazelcast {
             }
 
             std::chrono::steady_clock::time_point ReadHandler::get_last_read_time() const {
-                return last_read_time_;
+                return std::chrono::steady_clock::time_point{ last_read_time_ };
             }
 
             bool AddressProvider::is_default_provider() {
@@ -800,7 +800,7 @@ namespace hazelcast {
                       invocation_service_(client_context.get_invocation_service()),
                       connection_id_(connection_id),
                       remote_uuid_(boost::uuids::nil_uuid()), logger_(client_context.get_logger()), alive_(true),
-                      last_write_time_(std::chrono::steady_clock::now()) {
+                      last_write_time_(std::chrono::steady_clock::now().time_since_epoch()) {
                 socket_ = socket_factory.create(address, connect_timeout_in_millis);
             }
 
@@ -1051,12 +1051,12 @@ namespace hazelcast {
                 remote_uuid_ = remote_uuid;
             }
 
-            void Connection::last_write_time(std::chrono::steady_clock::time_point time_point) {
-                last_write_time_ = time_point;
+            void Connection::last_write_time(std::chrono::steady_clock::time_point tp) {
+                last_write_time_ = tp.time_since_epoch();
             }
 
             std::chrono::steady_clock::time_point Connection::last_write_time() const {
-                return last_write_time_;
+                return std::chrono::steady_clock::time_point{ last_write_time_ };
             }
 
             HeartbeatManager::HeartbeatManager(spi::ClientContext &client,


### PR DESCRIPTION
Using `std::atomic<std::chrono::steady_clock::time_point>` on older Clang versions (8 and below) with `libstdc++` doesn't compile: https://godbolt.org/z/fbM6o4dEc.

