### PR TITLE
Revert boost version to 1.72 for fedora 22 docker

### DIFF
--- a/docker/hazelcast-fedora22-x86_64.dockerfile
+++ b/docker/hazelcast-fedora22-x86_64.dockerfile
@@ -4,7 +4,7 @@ RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ openssl-devel cmake tar wget bzip2 java-1.8.0-openjdk
 
 # install boost
-RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
+RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
 
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh && \
     chmod +x ./cmake-3.19.0-Linux-x86_64.sh && \


### PR DESCRIPTION
Revert boost version to 1.72 since higher versions require OpenSSL 10.2 and higher versions installed but fedora 22 has OpenSSL version 1.0.1k which causes the [builds](http://jenkins.hazelcast.com/job/cpp-fedora22-64-SHARED-Release) to fail.
