### PR TITLE
Fix missing .get() in test

### DIFF
--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1383,7 +1383,7 @@ namespace hazelcast {
 
                     auto  hazelcastClient = new_client(std::move(clientConfig)).get();
                     auto map = hazelcastClient.get_map("myMap").get();
-                    map->put(5, 20);
+                    map->put(5, 20).get();
                     auto val = map->get<int, int>(5).get();
                     ASSERT_TRUE(val);
                     ASSERT_EQ(20, *val);


### PR DESCRIPTION
I had [this](https://github.com/yemreinci/hazelcast-cpp-client/runs/3416772846?check_suite_focus=true) ASAN error report on a GHA run on my fork. (I have modified the workflow to use ASAN). 

Apparently, there can be future handlers still running even though the client object was destroyed and those handlers can access destroyed objects. 

This PR doesn't solve the heap-use-after-free but only fixes a trivial mistake in the test.