### PR TITLE
Fix ClientTxnMultiMapTest.testPutGetRemove

### DIFF
--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -2747,9 +2747,9 @@ namespace hazelcast {
 
                 std::array<boost::future<void>, n> futures;
                 for (int i = 0; i < n; i++) {
-                    futures[i] = boost::async(std::packaged_task<void()>([&]() {
-                        std::string key = std::to_string(hazelcast::util::get_current_thread_id());
-                        std::string key2 = key + "2";
+                    futures[i] = boost::async([&mm, this, i]() {
+                        std::string key = std::to_string(i);
+                        std::string key2 = key + "-2";
                         client_.get_multi_map("testPutGetRemove").get()->put(key, "value").get();
                         transaction_context context = client_.new_transaction_context();
                         context.begin_transaction().get();
@@ -2768,7 +2768,7 @@ namespace hazelcast {
                         context.commit_transaction().get();
 
                         ASSERT_EQ(3, (int) (mm->get<std::string, std::string>(key).get().size()));
-                    }));
+                    });
                 }
 
                 boost::wait_for_all(futures.begin(), futures.end());


### PR DESCRIPTION
`boost::async` does some kind of optimization and reuses threads even if the launch policy is `launch::async`. For example, running this:
```c++
#include <iostream>
#include <thread>

#define BOOST_THREAD_VERSION 5

#include <boost/thread/future.hpp>

int main()
{
    boost::future<void> futs[10];

    for (int i = 0; i < 10; i++) {
        futs[i] = boost::async(boost::launch::async, []{
            std::cout << std::this_thread::get_id() << std::endl;
        });
    }

    boost::wait_for_all(futs, futs+10);

    return 0;
}
```
printed:
```
140510230894144
140510214108736
140510222501440
140510205716032
140510123521600
140510222501440
140510205716032
140510123521600
140510230894144
140510222501440
```

Notice that printed thread ids are not unique. This causes `ClientTxnMultiMapTest.testPutGetRemove` to [sometimes fail ](https://github.com/yemreinci/hazelcast-cpp-client/runs/3419795509?check_suite_focus=true)because it depends on keys of each task to be different from each other.

PR uses the loop counter instead of the thread id to fix this. Also removes the use of `std::packaged_task` as it seemed unnecessary.
