### PR TITLE
Remove StartedThread

### DIFF
--- a/hazelcast/test/src/ClientTestSupportBase.h
+++ b/hazelcast/test/src/ClientTestSupportBase.h
@@ -64,46 +64,6 @@ namespace hazelcast {
             };
         }
     }
-
-    namespace util {
-        class ThreadArgs {
-        public:
-            const void *arg0;
-            const void *arg1;
-            const void *arg2;
-            const void *arg3;
-            void (*func)(ThreadArgs &);
-        };
-
-
-        class StartedThread {
-        public:
-            StartedThread(const std::string &name, void (*func)(ThreadArgs &),
-                          void *arg0 = nullptr, void *arg1 = nullptr, void *arg2 = nullptr, void *arg3 = nullptr);
-
-            StartedThread(void (func)(ThreadArgs &),
-                          void *arg0 = nullptr,
-                          void *arg1 = nullptr,
-                          void *arg2 = nullptr,
-                          void *arg3 = nullptr);
-
-            virtual ~StartedThread();
-
-            bool join();
-
-            virtual void run();
-
-            virtual const std::string get_name() const;
-
-        private:
-            ThreadArgs thread_args_;
-            std::string name_;
-            std::thread thread_;
-            std::shared_ptr<logger> logger_;
-
-            void init(void (func)(ThreadArgs &), void *arg0, void *arg1, void *arg2, void *arg3);
-        };
-    }
 }
 
 

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -795,55 +795,6 @@ namespace hazelcast {
             }
         }
     }
-
-    namespace util {
-        StartedThread::StartedThread(const std::string &name, void (*func)(ThreadArgs &),
-                                     void *arg0, void *arg1, void *arg2, void *arg3)
-                : name_(name)
-                , logger_(std::make_shared<logger>("StartedThread", "StartedThread", 
-                                                   logger::level::info, logger::default_handler)) {
-            init(func, arg0, arg1, arg2, arg3);
-        }
-
-        StartedThread::StartedThread(void (func)(ThreadArgs &),
-                                     void *arg0,
-                                     void *arg1,
-                                     void *arg2,
-                                     void *arg3)
-                : StartedThread("hz.unnamed", func, arg0, arg1, arg2, arg3) {
-        }
-
-        void StartedThread::init(void (func)(ThreadArgs &), void *arg0, void *arg1, void *arg2, void *arg3) {
-            thread_args_.arg0 = arg0;
-            thread_args_.arg1 = arg1;
-            thread_args_.arg2 = arg2;
-            thread_args_.arg3 = arg3;
-            thread_args_.func = func;
-
-            thread_ = std::thread([=]() { func(thread_args_); });
-        }
-
-        void StartedThread::run() {
-            thread_args_.func(thread_args_);
-        }
-
-        const std::string StartedThread::get_name() const {
-            return name_;
-        }
-
-        bool StartedThread::join() {
-            if (!thread_.joinable()) {
-                return false;
-            }
-            thread_.join();
-            return true;
-        }
-
-        StartedThread::~StartedThread() {
-            join();
-        }
-
-    }
 }
 
 namespace hazelcast {
@@ -2822,16 +2773,12 @@ namespace hazelcast {
                 ASSERT_EQ(0, client_.get_queue(name).get()->size().get());
             }
 
-            void test_transactional_offer_poll2_thread(hazelcast::util::ThreadArgs &args) {
-                boost::latch *latch1 = (boost::latch *) args.arg0;
-                hazelcast_client *client = (hazelcast_client *) args.arg1;
-                latch1->wait();
-                client->get_queue("defQueue0").get()->offer("item0").get();
-            }
-
             TEST_F(ClientTxnQueueTest, testTransactionalOfferPoll2) {
                 boost::latch latch1(1);
-                hazelcast::util::StartedThread t(test_transactional_offer_poll2_thread, &latch1, &client_);
+                std::thread t([this, &latch1]() {
+                    latch1.wait();
+                    client_.get_queue("defQueue0").get()->offer("item0").get();
+                });
                 transaction_context context = client_.new_transaction_context();
                 context.begin_transaction().get();
                 auto q0 = context.get_queue("defQueue0");
@@ -2846,6 +2793,8 @@ namespace hazelcast {
 
                 ASSERT_EQ(0, client_.get_queue("defQueue0").get()->size().get());
                 ASSERT_EQ("item0", client_.get_queue("defQueue1").get()->poll<std::string>().get().value());
+
+                t.join();
             }
         }
     }

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -579,12 +579,6 @@ namespace hazelcast {
                 ASSERT_NO_THROW(q->destroy().get());
             }
 
-            void test_offer_poll_thread2(hazelcast::util::ThreadArgs &args) {
-                auto *q = (iqueue *) args.arg0;
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                q->offer("item1");
-            }
-
             TEST_F(ClientQueueTest, testOfferPoll) {
                 for (int i = 0; i < 10; i++) {
                     ASSERT_TRUE(q->offer("item").get());
@@ -598,12 +592,16 @@ namespace hazelcast {
                 }
                 ASSERT_EQ(0, q->size().get());
 
-                hazelcast::util::StartedThread t2(test_offer_poll_thread2, q.get());
+                std::thread offer_in_background([]() {
+                    std::this_thread::sleep_for(std::chrono::seconds(2));
+                    q->offer("item1");
+                });
 
                 boost::optional<std::string> item = q->poll<std::string>(std::chrono::seconds(30)).get();
                 ASSERT_TRUE(item.has_value());
                 ASSERT_EQ("item1", item.value());
-                t2.join();
+
+                offer_in_background.join();
             }
 
             TEST_F(ClientQueueTest, testPeek) {
@@ -632,14 +630,17 @@ namespace hazelcast {
 
                 ASSERT_TRUE(q->is_empty().get());
 
-                // start a thread to insert an item
-                hazelcast::util::StartedThread t2(test_offer_poll_thread2, q.get());
+                // start a thread to offer an item
+                std::thread offer_in_background([]() {
+                    std::this_thread::sleep_for(std::chrono::seconds(2));
+                    q->offer("item1");
+                });
 
                 item = q->take<std::string>().get();  //  should block till it gets an item
                 ASSERT_TRUE(item.has_value());
                 ASSERT_EQ("item1", item.value());
 
-                t2.join();
+                offer_in_background.join();
             }
 
             TEST_F(ClientQueueTest, testRemainingCapacity) {
@@ -648,7 +649,6 @@ namespace hazelcast {
                 q->offer("item");
                 ASSERT_EQ(capacity - 1, q->remaining_capacity().get());
             }
-
 
             TEST_F(ClientQueueTest, testRemove) {
                 offer(3);


### PR DESCRIPTION
StartedThread was unsafe and looked very primitive, probably a leftover from when the library used c++98.