### PR TITLE
Fix macOS builds

### DIFF
--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-          brew install boost openssl thrift
+          brew install boost openssl@1.1 thrift
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Homebrew started to install OpenSSL 3 by default. And the Mac builds fail because some functions the project is using was deprecated. ([see](https://github.com/hazelcast/hazelcast-cpp-client/runs/4810898840?check_suite_focus=true))

We should ideally replace deprecated methods, but this PR pins the version to 1.1 to make the builds green for now.
