### PR TITLE
Regenerate codecs

### DIFF
--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
@@ -24,14 +24,8 @@ namespace hazelcast {
     namespace client {
         namespace protocol {
             namespace codec {
-                ClientMessage client_authentication_encode(const std::string &cluster_name, const std::string *username,
-                                                           const std::string *password, boost::uuids::uuid uuid,
-                                                           const std::string &client_type, byte serialization_version,
-                                                           const std::string &client_hazelcast_version,
-                                                           const std::string &client_name,
-                                                           const std::vector<std::string> &labels) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage client_authentication_encode(const std::string &cluster_name, const std::string *username, const std::string *password, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("client.authentication");
@@ -58,16 +52,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_authenticationcustom_encode(const std::string &cluster_name,
-                                                                 const std::vector<byte> &credentials,
-                                                                 boost::uuids::uuid uuid,
-                                                                 const std::string &client_type,
-                                                                 byte serialization_version,
-                                                                 const std::string &client_hazelcast_version,
-                                                                 const std::string &client_name,
-                                                                 const std::vector<std::string> &labels) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage client_authenticationcustom_encode(const std::string &cluster_name, const std::vector<byte> &credentials, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("client.authenticationcustom");
@@ -111,14 +97,13 @@ namespace hazelcast {
                         auto version = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
-                        auto memberInfos = msg.get<std::vector<member>>();
+                        auto member_infos = msg.get<std::vector<member>>();
 
-                        handle_membersview(version, memberInfos);
+                        handle_membersview(version, member_infos);
                         return;
                     }
                     if (messageType == 771) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
                         auto version = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
@@ -132,7 +117,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_createproxy_encode(const std::string &name, const std::string &service_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.createproxy");
@@ -148,7 +133,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_destroyproxy_encode(const std::string &name, const std::string &service_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.destroyproxy");
@@ -175,9 +160,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage client_statistics_encode(int64_t timestamp, const std::string &client_attributes,
-                                                       const std::vector<byte> &metrics_blob) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage client_statistics_encode(int64_t timestamp, const std::string &client_attributes, const std::vector<byte> &metrics_blob) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.statistics");
@@ -208,12 +192,11 @@ namespace hazelcast {
                 void client_localbackuplistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 3842) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto sourceInvocationCorrelationId = msg.get<int64_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto source_invocation_correlation_id = msg.get<int64_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
-                        handle_backup(sourceInvocationCorrelationId);
+                        handle_backup(source_invocation_correlation_id);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -221,23 +204,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage client_removemigrationlistener_encode(boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
-                    ClientMessage msg(initial_frame_size, true);
-                    msg.set_retryable(true);
-                    msg.set_operation_name("client.removemigrationlistener");
-
-                    msg.set_message_type(static_cast<int32_t>(4608));
-                    msg.set_partition_id(-1);
-
-                    msg.set(registration_id);
-                    return msg;
-                }
-
-                ClientMessage map_put_encode(const std::string &name, const serialization::pimpl::data &key,
-                                             const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.put");
@@ -256,9 +224,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.get");
@@ -274,9 +241,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.remove");
@@ -292,9 +258,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_replace_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                 const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_replace_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.replace");
@@ -312,10 +277,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_replaceifsame_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                       const serialization::pimpl::data &test_value,
-                                                       const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_replaceifsame_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &test_value, const serialization::pimpl::data &value, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.replaceifsame");
@@ -335,9 +298,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_containskey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                     int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_containskey_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.containskey");
@@ -353,9 +315,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.containsvalue");
@@ -370,9 +331,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_removeifsame_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                      const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_removeifsame_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.removeifsame");
@@ -390,9 +350,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_delete_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_delete_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.delete");
@@ -408,7 +367,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_flush_encode(const std::string  & name) {
+                ClientMessage map_flush_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -422,11 +381,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_tryremove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                     int64_t timeout) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_tryremove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t timeout) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.tryremove");
@@ -443,11 +399,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_tryput_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                const serialization::pimpl::data &value, int64_t thread_id,
-                                                int64_t timeout) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_tryput_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t timeout) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.tryput");
@@ -466,11 +419,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_puttransient_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                      const serialization::pimpl::data &value, int64_t thread_id,
-                                                      int64_t ttl) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_puttransient_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.puttransient");
@@ -489,11 +439,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_putifabsent_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                     const serialization::pimpl::data &value, int64_t thread_id,
-                                                     int64_t ttl) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_putifabsent_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.putifabsent");
@@ -512,10 +459,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_set_encode(const std::string &name, const serialization::pimpl::data &key,
-                                             const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_set_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.set");
@@ -534,12 +479,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                int64_t ttl, int64_t reference_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
+                ClientMessage map_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t ttl, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.lock");
@@ -557,12 +498,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                   int64_t lease, int64_t timeout, int64_t reference_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.trylock");
@@ -582,7 +519,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_islocked_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.islocked");
@@ -597,11 +534,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                  int64_t reference_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage map_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.unlock");
@@ -618,9 +552,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_addinterceptor_encode(const std::string &name, const serialization::pimpl::data &interceptor) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_addinterceptor_encode(const std::string &name, const serialization::pimpl::data &interceptor) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addinterceptor");
@@ -635,7 +568,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_removeinterceptor_encode(const std::string  & name, const std::string  & id) {
+                ClientMessage map_removeinterceptor_encode(const std::string &name, const std::string &id) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -651,13 +584,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_addentrylistenerwithpredicate_encode(const std::string &name,
-                                                                       const serialization::pimpl::data &predicate,
-                                                                       bool include_value, int32_t listener_flags,
-                                                                       bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::UINT8_SIZE;
+                ClientMessage map_addentrylistenerwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate, bool include_value, int32_t listener_flags, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addentrylistenerwithpredicate");
@@ -678,18 +606,17 @@ namespace hazelcast {
                 void map_addentrylistenerwithpredicate_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 71426) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -697,12 +624,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                map_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                 bool include_value, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::UINT8_SIZE;
+                ClientMessage map_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool include_value, int32_t listener_flags, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addentrylistenertokey");
@@ -723,18 +646,17 @@ namespace hazelcast {
                 void map_addentrylistenertokey_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 71682) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -742,12 +664,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags,
-                                            bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::UINT8_SIZE;
+                ClientMessage map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addentrylistener");
@@ -766,18 +684,17 @@ namespace hazelcast {
                 void map_addentrylistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 71938) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -785,9 +702,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                ClientMessage map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.removeentrylistener");
@@ -801,9 +717,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_getentryview_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                      int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_getentryview_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.getentryview");
@@ -819,9 +734,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_evict_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_evict_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.evict");
@@ -837,7 +751,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_evictall_encode(const std::string  & name) {
+                ClientMessage map_evictall_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -851,7 +765,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_keyset_encode(const std::string  & name) {
+                ClientMessage map_keyset_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -865,9 +779,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_getall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_getall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.getall");
@@ -882,7 +795,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_values_encode(const std::string  & name) {
+                ClientMessage map_values_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -896,7 +809,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_entryset_encode(const std::string  & name) {
+                ClientMessage map_entryset_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -910,9 +823,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_keysetwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_keysetwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.keysetwithpredicate");
@@ -927,9 +839,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_valueswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_valueswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.valueswithpredicate");
@@ -944,9 +855,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_entrieswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_entrieswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.entrieswithpredicate");
@@ -962,7 +872,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addindex_encode(const std::string &name, const config::index_config &index_config) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addindex");
@@ -977,7 +887,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_size_encode(const std::string  & name) {
+                ClientMessage map_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -991,7 +901,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_isempty_encode(const std::string  & name) {
+                ClientMessage map_isempty_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1005,10 +915,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_putall_encode(const std::string &name,
-                                                const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries,
-                                                bool trigger_map_loader) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                ClientMessage map_putall_encode(const std::string &name, const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries, bool trigger_map_loader) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.putall");
@@ -1024,7 +932,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_clear_encode(const std::string  & name) {
+                ClientMessage map_clear_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1038,10 +946,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_executeonkey_encode(const std::string &name, const serialization::pimpl::data &entry_processor,
-                                        const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_executeonkey_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executeonkey");
@@ -1059,10 +965,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_submittokey_encode(const std::string &name, const serialization::pimpl::data &entry_processor,
-                                       const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_submittokey_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.submittokey");
@@ -1080,9 +984,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_executeonallkeys_encode(const std::string &name,
-                                                          const serialization::pimpl::data &entry_processor) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_executeonallkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executeonallkeys");
@@ -1097,10 +1000,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_executewithpredicate_encode(const std::string &name,
-                                                              const serialization::pimpl::data &entry_processor,
-                                                              const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_executewithpredicate_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executewithpredicate");
@@ -1117,10 +1018,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_executeonkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor,
-                                         const std::vector<serialization::pimpl::data> &keys) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_executeonkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const std::vector<serialization::pimpl::data> &keys) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executeonkeys");
@@ -1137,9 +1036,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                     int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.forceunlock");
@@ -1155,7 +1053,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_keysetwithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate) {
+                ClientMessage map_keysetwithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1171,7 +1069,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_valueswithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate) {
+                ClientMessage map_valueswithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1187,7 +1085,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage map_entrieswithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate) {
+                ClientMessage map_entrieswithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1203,9 +1101,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_removeall_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage map_removeall_encode(const std::string &name, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.removeall");
@@ -1220,11 +1117,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags,
-                                                            bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addnearcacheinvalidationlistener");
@@ -1243,13 +1137,13 @@ namespace hazelcast {
                     auto messageType = msg.get_message_type();
                     if (messageType == 81666) {
                         auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
-                        auto sourceUuid = msg.get<boost::uuids::uuid>();
-                        auto partitionUuid = msg.get<boost::uuids::uuid>();
+                        auto source_uuid = msg.get<boost::uuids::uuid>();
+                        auto partition_uuid = msg.get<boost::uuids::uuid>();
                         auto sequence = msg.get<int64_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
-                        handle_imapinvalidation(key, sourceUuid, partitionUuid, sequence);
+                        handle_imapinvalidation(key, source_uuid, partition_uuid, sequence);
                         return;
                     }
                     if (messageType == 81667) {
@@ -1257,10 +1151,10 @@ namespace hazelcast {
 
                         auto keys = msg.get<std::vector<serialization::pimpl::data>>();
 
-                        auto sourceUuids = msg.get<std::vector<boost::uuids::uuid>>();
-                        auto partitionUuids = msg.get<std::vector<boost::uuids::uuid>>();
+                        auto source_uuids = msg.get<std::vector<boost::uuids::uuid>>();
+                        auto partition_uuids = msg.get<std::vector<boost::uuids::uuid>>();
                         auto sequences = msg.get<std::vector<int64_t>>();
-                        handle_imapbatchinvalidation(keys, sourceUuids, partitionUuids, sequences);
+                        handle_imapbatchinvalidation(keys, source_uuids, partition_uuids, sequences);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -1268,9 +1162,24 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage multimap_put_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                  const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage map_replaceall_encode(const std::string &name, const serialization::pimpl::data &function) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    ClientMessage msg(initial_frame_size);
+                    msg.set_retryable(true);
+                    msg.set_operation_name("map.replaceall");
+
+                    msg.set_message_type(static_cast<int32_t>(83968));
+                    msg.set_partition_id(-1);
+
+                    msg.set(name);
+
+                    msg.set(function, true);
+
+                    return msg;
+                }
+
+                ClientMessage multimap_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.put");
@@ -1288,9 +1197,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.get");
@@ -1306,9 +1214,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_remove_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                     int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.remove");
@@ -1324,7 +1231,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_keyset_encode(const std::string  & name) {
+                ClientMessage multimap_keyset_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1338,7 +1245,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_values_encode(const std::string  & name) {
+                ClientMessage multimap_values_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1352,7 +1259,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_entryset_encode(const std::string  & name) {
+                ClientMessage multimap_entryset_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1366,10 +1273,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_containskey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                            int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_containskey_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.containskey");
@@ -1385,9 +1290,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage multimap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.containsvalue");
@@ -1402,10 +1306,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_containsentry_encode(const std::string &name, const serialization::pimpl::data &key,
-                                              const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_containsentry_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.containsentry");
@@ -1423,7 +1325,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_size_encode(const std::string  & name) {
+                ClientMessage multimap_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -1437,7 +1339,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_clear_encode(const std::string  & name) {
+                ClientMessage multimap_clear_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1451,9 +1353,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_valuecount_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                         int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_valuecount_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.valuecount");
@@ -1469,11 +1370,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                      bool include_value, bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage multimap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool include_value, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.addentrylistenertokey");
@@ -1493,18 +1391,17 @@ namespace hazelcast {
                 void multimap_addentrylistenertokey_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 134402) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -1512,10 +1409,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.addentrylistener");
@@ -1533,18 +1428,17 @@ namespace hazelcast {
                 void multimap_addentrylistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 134658) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -1552,9 +1446,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                ClientMessage multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.removeentrylistener");
@@ -1568,12 +1461,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                     int64_t ttl, int64_t reference_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
+                ClientMessage multimap_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t ttl, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.lock");
@@ -1591,12 +1480,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_trylock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                      int64_t thread_id, int64_t lease, int64_t timeout,
-                                                      int64_t reference_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.trylock");
@@ -1616,7 +1501,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_islocked_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.islocked");
@@ -1631,10 +1516,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage multimap_unlock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                     int64_t thread_id, int64_t reference_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.unlock");
@@ -1651,10 +1534,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                            int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t reference_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.forceunlock");
@@ -1670,10 +1551,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                multimap_removeentry_encode(const std::string &name, const serialization::pimpl::data &key,
-                                            const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage multimap_removeentry_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.removeentry");
@@ -1691,9 +1570,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_offer_encode(const std::string &name, const serialization::pimpl::data &value,
-                                                 int64_t timeout_millis) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage queue_offer_encode(const std::string &name, const serialization::pimpl::data &value, int64_t timeout_millis) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.offer");
@@ -1710,7 +1588,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_put_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.put");
@@ -1725,7 +1603,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_size_encode(const std::string  & name) {
+                ClientMessage queue_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1740,7 +1618,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_remove_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.remove");
@@ -1756,7 +1634,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_poll_encode(const std::string &name, int64_t timeout_millis) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.poll");
@@ -1770,7 +1648,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_take_encode(const std::string  & name) {
+                ClientMessage queue_take_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1784,7 +1662,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_peek_encode(const std::string  & name) {
+                ClientMessage queue_peek_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1798,7 +1676,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_iterator_encode(const std::string  & name) {
+                ClientMessage queue_iterator_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1812,7 +1690,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_drainto_encode(const std::string  & name) {
+                ClientMessage queue_drainto_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1827,7 +1705,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_draintomaxsize_encode(const std::string &name, int32_t max_size) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.draintomaxsize");
@@ -1842,7 +1720,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_contains_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.contains");
@@ -1857,9 +1735,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_containsall_encode(const std::string &name,
-                                                       const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage queue_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.containsall");
@@ -1874,9 +1751,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_compareandremoveall_encode(const std::string &name,
-                                                               const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage queue_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.compareandremoveall");
@@ -1891,9 +1767,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_compareandretainall_encode(const std::string &name,
-                                                               const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage queue_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.compareandretainall");
@@ -1908,7 +1783,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_clear_encode(const std::string  & name) {
+                ClientMessage queue_clear_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -1922,9 +1797,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                queue_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage queue_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.addall");
@@ -1940,8 +1814,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.addlistener");
@@ -1959,14 +1832,13 @@ namespace hazelcast {
                 void queue_addlistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 200962) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto eventType = msg.get<int32_t>();
+                        auto event_type = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto item = msg.get_nullable<serialization::pimpl::data>();
-                        handle_item(item, uuid, eventType);
+                        handle_item(item, uuid, event_type);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -1975,7 +1847,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("queue.removelistener");
@@ -1989,7 +1861,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_remainingcapacity_encode(const std::string  & name) {
+                ClientMessage queue_remainingcapacity_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2003,7 +1875,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage queue_isempty_encode(const std::string  & name) {
+                ClientMessage queue_isempty_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2018,7 +1890,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage topic_publish_encode(const std::string &name, const serialization::pimpl::data &message) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("topic.publish");
@@ -2034,7 +1906,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage topic_addmessagelistener_encode(const std::string &name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("topic.addmessagelistener");
@@ -2051,14 +1923,13 @@ namespace hazelcast {
                 void topic_addmessagelistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 262658) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto publishTime = msg.get<int64_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto publish_time = msg.get<int64_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto item = msg.get<serialization::pimpl::data>();
-                        handle_topic(item, publishTime, uuid);
+                        handle_topic(item, publish_time, uuid);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -2066,9 +1937,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                ClientMessage topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("topic.removemessagelistener");
@@ -2082,7 +1952,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_size_encode(const std::string  & name) {
+                ClientMessage list_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -2097,7 +1967,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_contains_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.contains");
@@ -2112,9 +1982,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_containsall_encode(const std::string &name,
-                                                      const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage list_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.containsall");
@@ -2130,7 +1999,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_add_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.add");
@@ -2146,7 +2015,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_remove_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.remove");
@@ -2161,9 +2030,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                list_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage list_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addall");
@@ -2178,9 +2046,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_compareandremoveall_encode(const std::string &name,
-                                                              const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage list_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.compareandremoveall");
@@ -2195,9 +2062,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_compareandretainall_encode(const std::string &name,
-                                                              const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage list_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.compareandretainall");
@@ -2212,7 +2078,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_clear_encode(const std::string  & name) {
+                ClientMessage list_clear_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2226,7 +2092,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_getall_encode(const std::string  & name) {
+                ClientMessage list_getall_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -2241,8 +2107,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addlistener");
@@ -2260,14 +2125,13 @@ namespace hazelcast {
                 void list_addlistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 330498) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto eventType = msg.get<int32_t>();
+                        auto event_type = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto item = msg.get_nullable<serialization::pimpl::data>();
-                        handle_item(item, uuid, eventType);
+                        handle_item(item, uuid, event_type);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -2276,7 +2140,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.removelistener");
@@ -2290,7 +2154,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_isempty_encode(const std::string  & name) {
+                ClientMessage list_isempty_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -2304,9 +2168,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_addallwithindex_encode(const std::string &name, int32_t index,
-                                                          const std::vector<serialization::pimpl::data> &value_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage list_addallwithindex_encode(const std::string &name, int32_t index, const std::vector<serialization::pimpl::data> &value_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addallwithindex");
@@ -2322,7 +2185,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_get_encode(const std::string  & name, int32_t index) {
+                ClientMessage list_get_encode(const std::string &name, int32_t index) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -2337,9 +2200,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                list_set_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage list_set_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.set");
@@ -2355,9 +2217,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_addwithindex_encode(const std::string &name, int32_t index,
-                                                       const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage list_addwithindex_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addwithindex");
@@ -2373,7 +2234,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_removewithindex_encode(const std::string  & name, int32_t index) {
+                ClientMessage list_removewithindex_encode(const std::string &name, int32_t index) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2388,9 +2249,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                list_lastindexof_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage list_lastindexof_encode(const std::string &name, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.lastindexof");
@@ -2406,7 +2266,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_indexof_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.indexof");
@@ -2421,7 +2281,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage list_sub_encode(const std::string  & name, int32_t from, int32_t to) {
+                ClientMessage list_sub_encode(const std::string &name, int32_t from, int32_t to) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -2437,7 +2297,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_size_encode(const std::string  & name) {
+                ClientMessage set_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2452,7 +2312,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_contains_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.contains");
@@ -2467,9 +2327,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                set_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &items) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage set_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &items) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.containsall");
@@ -2485,7 +2344,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_add_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.add");
@@ -2501,7 +2360,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_remove_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.remove");
@@ -2516,9 +2375,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                set_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage set_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.addall");
@@ -2533,9 +2391,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_compareandremoveall_encode(const std::string &name,
-                                                             const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage set_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.compareandremoveall");
@@ -2550,9 +2407,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_compareandretainall_encode(const std::string &name,
-                                                             const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage set_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.compareandretainall");
@@ -2567,7 +2423,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_clear_encode(const std::string  & name) {
+                ClientMessage set_clear_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2581,7 +2437,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_getall_encode(const std::string  & name) {
+                ClientMessage set_getall_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2596,8 +2452,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.addlistener");
@@ -2615,14 +2470,13 @@ namespace hazelcast {
                 void set_addlistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 396034) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto eventType = msg.get<int32_t>();
+                        auto event_type = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto item = msg.get_nullable<serialization::pimpl::data>();
-                        handle_item(item, uuid, eventType);
+                        handle_item(item, uuid, event_type);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -2631,7 +2485,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("set.removelistener");
@@ -2645,7 +2499,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage set_isempty_encode(const std::string  & name) {
+                ClientMessage set_isempty_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2659,12 +2513,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                fencedlock_lock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                       int64_t thread_id, boost::uuids::uuid invocation_uid) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE;
+                ClientMessage fencedlock_lock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.lock");
@@ -2682,12 +2532,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage fencedlock_trylock_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                        int64_t session_id, int64_t thread_id,
-                                                        boost::uuids::uuid invocation_uid, int64_t timeout_ms) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage fencedlock_trylock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int64_t timeout_ms) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.trylock");
@@ -2706,12 +2552,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                fencedlock_unlock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                         int64_t thread_id, boost::uuids::uuid invocation_uid) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE;
+                ClientMessage fencedlock_unlock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.unlock");
@@ -2729,9 +2571,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                fencedlock_getlockownership_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage fencedlock_getlockownership_encode(const cp::raft_group_id &group_id, const std::string &name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.getlockownership");
@@ -2746,7 +2587,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage executorservice_shutdown_encode(const std::string  & name) {
+                ClientMessage executorservice_shutdown_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2760,7 +2601,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage executorservice_isshutdown_encode(const std::string  & name) {
+                ClientMessage executorservice_isshutdown_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -2788,12 +2629,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid,
-                                                      bool interrupt) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE +
-                            ClientMessage::UINT8_SIZE;
+                ClientMessage executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_u_u_i_d, bool interrupt) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.cancelonmember");
@@ -2802,14 +2639,13 @@ namespace hazelcast {
                     msg.set_partition_id(-1);
 
                     msg.set(uuid);
-                    msg.set(member_uuid);
+                    msg.set(member_u_u_i_d);
                     msg.set(interrupt);
                     return msg;
                 }
 
-                ClientMessage executorservice_submittopartition_encode(const std::string &name, boost::uuids::uuid uuid,
-                                                                       const serialization::pimpl::data &callable) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                ClientMessage executorservice_submittopartition_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.submittopartition");
@@ -2825,11 +2661,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid,
-                                                                    const serialization::pimpl::data &callable,
-                                                                    boost::uuids::uuid member_uuid) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE;
+                ClientMessage executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable, boost::uuids::uuid member_u_u_i_d) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.submittomember");
@@ -2838,7 +2671,7 @@ namespace hazelcast {
                     msg.set_partition_id(-1);
 
                     msg.set(uuid);
-                    msg.set(member_uuid);
+                    msg.set(member_u_u_i_d);
                     msg.set(name);
 
                     msg.set(callable, true);
@@ -2846,9 +2679,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomiclong_apply_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                      const serialization::pimpl::data &function) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage atomiclong_apply_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.apply");
@@ -2865,10 +2697,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomiclong_alter_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                      const serialization::pimpl::data &function,
-                                                      int32_t return_value_type) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage atomiclong_alter_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function, int32_t return_value_type) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.alter");
@@ -2886,9 +2716,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                atomiclong_addandget_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage atomiclong_addandget_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.addandget");
@@ -2904,11 +2733,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                atomiclong_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                int64_t expected, int64_t updated) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage atomiclong_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t expected, int64_t updated) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.compareandset");
@@ -2926,7 +2752,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_get_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("atomiclong.get");
@@ -2941,9 +2767,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                atomiclong_getandadd_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage atomiclong_getandadd_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.getandadd");
@@ -2959,9 +2784,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomiclong_getandset_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                          int64_t new_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage atomiclong_getandset_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t new_value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.getandset");
@@ -2977,11 +2801,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomicref_apply_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                     const serialization::pimpl::data &function,
-                                                     int32_t return_value_type, bool alter) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage atomicref_apply_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function, int32_t return_value_type, bool alter) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomicref.apply");
@@ -3000,10 +2821,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomicref_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                             const serialization::pimpl::data *old_value,
-                                                             const serialization::pimpl::data *new_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage atomicref_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *old_value, const serialization::pimpl::data *new_value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomicref.compareandset");
@@ -3022,9 +2841,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomicref_contains_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                        const serialization::pimpl::data *value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage atomicref_contains_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("atomicref.contains");
@@ -3042,7 +2860,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomicref_get_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("atomicref.get");
@@ -3057,9 +2875,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage atomicref_set_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                   const serialization::pimpl::data *new_value, bool return_old_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                ClientMessage atomicref_set_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *new_value, bool return_old_value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomicref.set");
@@ -3077,10 +2894,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                countdownlatch_trysetcount_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                  int32_t count) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage countdownlatch_trysetcount_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t count) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.trysetcount");
@@ -3096,10 +2911,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage countdownlatch_await_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                          boost::uuids::uuid invocation_uid, int64_t timeout_ms) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage countdownlatch_await_encode(const cp::raft_group_id &group_id, const std::string &name, boost::uuids::uuid invocation_uid, int64_t timeout_ms) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.await");
@@ -3116,11 +2929,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                countdownlatch_countdown_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                boost::uuids::uuid invocation_uid, int32_t expected_round) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
+                ClientMessage countdownlatch_countdown_encode(const cp::raft_group_id &group_id, const std::string &name, boost::uuids::uuid invocation_uid, int32_t expected_round) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.countdown");
@@ -3137,9 +2947,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                countdownlatch_getcount_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage countdownlatch_getcount_encode(const cp::raft_group_id &group_id, const std::string &name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.getcount");
@@ -3154,9 +2963,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                countdownlatch_getround_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage countdownlatch_getround_encode(const cp::raft_group_id &group_id, const std::string &name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.getround");
@@ -3171,9 +2979,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                semaphore_init_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t permits) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage semaphore_init_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t permits) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.init");
@@ -3189,13 +2996,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                semaphore_acquire_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                         int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits,
-                                         int64_t timeout_ms) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage semaphore_acquire_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits, int64_t timeout_ms) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.acquire");
@@ -3215,12 +3017,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                semaphore_release_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                         int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
+                ClientMessage semaphore_release_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.release");
@@ -3239,12 +3037,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                semaphore_drain_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                       int64_t thread_id, boost::uuids::uuid invocation_uid) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE;
+                ClientMessage semaphore_drain_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.drain");
@@ -3262,12 +3056,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                semaphore_change_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                        int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
+                ClientMessage semaphore_change_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.change");
@@ -3286,9 +3076,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                semaphore_availablepermits_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage semaphore_availablepermits_encode(const cp::raft_group_id &group_id, const std::string &name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.availablepermits");
@@ -3304,7 +3093,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_getsemaphoretype_encode(const std::string &proxy_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.getsemaphoretype");
@@ -3317,9 +3106,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_put_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                       const serialization::pimpl::data &value, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                ClientMessage replicatedmap_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t ttl) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.put");
@@ -3337,7 +3125,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_size_encode(const std::string  & name) {
+                ClientMessage replicatedmap_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -3351,7 +3139,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_isempty_encode(const std::string  & name) {
+                ClientMessage replicatedmap_isempty_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -3365,9 +3153,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                replicatedmap_containskey_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage replicatedmap_containskey_encode(const std::string &name, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.containskey");
@@ -3382,9 +3169,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                replicatedmap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage replicatedmap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.containsvalue");
@@ -3400,7 +3186,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_get_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.get");
@@ -3415,9 +3201,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                replicatedmap_remove_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage replicatedmap_remove_encode(const std::string &name, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.remove");
@@ -3432,9 +3217,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_putall_encode(const std::string &name,
-                                                          const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage replicatedmap_putall_encode(const std::string &name, const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.putall");
@@ -3449,7 +3233,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_clear_encode(const std::string  & name) {
+                ClientMessage replicatedmap_clear_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
@@ -3463,11 +3247,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_addentrylistenertokeywithpredicate_encode(const std::string &name,
-                                                                                      const serialization::pimpl::data &key,
-                                                                                      const serialization::pimpl::data &predicate,
-                                                                                      bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                ClientMessage replicatedmap_addentrylistenertokeywithpredicate_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &predicate, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistenertokeywithpredicate");
@@ -3488,18 +3269,17 @@ namespace hazelcast {
                 void replicatedmap_addentrylistenertokeywithpredicate_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 854530) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -3507,10 +3287,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage replicatedmap_addentrylistenerwithpredicate_encode(const std::string &name,
-                                                                                 const serialization::pimpl::data &predicate,
-                                                                                 bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                ClientMessage replicatedmap_addentrylistenerwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistenerwithpredicate");
@@ -3529,18 +3307,17 @@ namespace hazelcast {
                 void replicatedmap_addentrylistenerwithpredicate_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 854786) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -3548,10 +3325,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage replicatedmap_addentrylistenertokey_encode(const std::string &name,
-                                                                         const serialization::pimpl::data &key,
-                                                                         bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                ClientMessage replicatedmap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistenertokey");
@@ -3570,18 +3345,17 @@ namespace hazelcast {
                 void replicatedmap_addentrylistenertokey_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 855042) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -3590,7 +3364,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_addentrylistener_encode(const std::string &name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistener");
@@ -3607,18 +3381,17 @@ namespace hazelcast {
                 void replicatedmap_addentrylistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 855298) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -3626,9 +3399,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage
-                replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                ClientMessage replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.removeentrylistener");
@@ -3642,7 +3414,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_keyset_encode(const std::string  & name) {
+                ClientMessage replicatedmap_keyset_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -3656,7 +3428,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_values_encode(const std::string  & name) {
+                ClientMessage replicatedmap_values_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -3670,7 +3442,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage replicatedmap_entryset_encode(const std::string  & name) {
+                ClientMessage replicatedmap_entryset_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -3684,11 +3456,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value,
-                                                               bool local_only) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value, bool local_only) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addnearcacheentrylistener");
@@ -3706,18 +3475,17 @@ namespace hazelcast {
                 void replicatedmap_addnearcacheentrylistener_handler::handle(ClientMessage &msg) {
                     auto messageType = msg.get_message_type();
                     if (messageType == 856578) {
-                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(
-                                ClientMessage::EVENT_HEADER_LEN));
-                        auto eventType = msg.get<int32_t>();
+                        auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>(msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN));
+                        auto event_type = msg.get<int32_t>();
                         auto uuid = msg.get<boost::uuids::uuid>();
-                        auto numberOfAffectedEntries = msg.get<int32_t>();
+                        auto number_of_affected_entries = msg.get<int32_t>();
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
 
                         auto key = msg.get_nullable<serialization::pimpl::data>();
                         auto value = msg.get_nullable<serialization::pimpl::data>();
-                        auto oldValue = msg.get_nullable<serialization::pimpl::data>();
-                        auto mergingValue = msg.get_nullable<serialization::pimpl::data>();
-                        handle_entry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
+                        auto old_value = msg.get_nullable<serialization::pimpl::data>();
+                        auto merging_value = msg.get_nullable<serialization::pimpl::data>();
+                        handle_entry(key, value, old_value, merging_value, event_type, uuid, number_of_affected_entries);
                         return;
                     }
                     HZ_LOG(*get_logger(), warning, (boost::format(
@@ -3725,11 +3493,8 @@ namespace hazelcast {
                                                     messageType).str());
                 }
 
-                ClientMessage transactionalmap_containskey_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                  int64_t thread_id,
-                                                                  const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_containskey_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.containskey");
@@ -3746,11 +3511,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.get");
@@ -3767,10 +3529,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.size");
@@ -3785,10 +3545,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.isempty");
@@ -3803,13 +3561,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &key,
-                                            const serialization::pimpl::data &value, int64_t ttl) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t ttl) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.put");
@@ -3829,12 +3582,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_set_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &key,
-                                            const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_set_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.set");
@@ -3853,12 +3602,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_putifabsent_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                  int64_t thread_id,
-                                                                  const serialization::pimpl::data &key,
-                                                                  const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_putifabsent_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.putifabsent");
@@ -3877,12 +3622,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_replace_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                const serialization::pimpl::data &key,
-                                                const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_replace_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.replace");
@@ -3901,13 +3642,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_replaceifsame_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                    int64_t thread_id,
-                                                                    const serialization::pimpl::data &key,
-                                                                    const serialization::pimpl::data &old_value,
-                                                                    const serialization::pimpl::data &new_value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_replaceifsame_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &old_value, const serialization::pimpl::data &new_value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.replaceifsame");
@@ -3928,11 +3664,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.remove");
@@ -3949,11 +3682,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_delete_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_delete_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.delete");
@@ -3970,12 +3700,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmap_removeifsame_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                   int64_t thread_id,
-                                                                   const serialization::pimpl::data &key,
-                                                                   const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_removeifsame_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.removeifsame");
@@ -3994,10 +3720,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.keyset");
@@ -4012,12 +3736,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_keysetwithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                            int64_t thread_id,
-                                                            const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_keysetwithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.keysetwithpredicate");
@@ -4034,10 +3754,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.values");
@@ -4052,12 +3770,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmap_valueswithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                            int64_t thread_id,
-                                                            const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmap_valueswithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &predicate) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.valueswithpredicate");
@@ -4074,12 +3788,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmultimap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                 const serialization::pimpl::data &key,
-                                                 const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.put");
@@ -4098,11 +3808,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmultimap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                 const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.get");
@@ -4119,11 +3826,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmultimap_remove_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                  int64_t thread_id,
-                                                                  const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.remove");
@@ -4140,12 +3844,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmultimap_removeentry_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                         int64_t thread_id, const serialization::pimpl::data &key,
-                                                         const serialization::pimpl::data &value) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_removeentry_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.removeentry");
@@ -4164,11 +3864,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalmultimap_valuecount_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                        int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_valuecount_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.valuecount");
@@ -4185,10 +3882,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                                int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.size");
@@ -4203,11 +3898,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalset_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &item) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalset_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalset.add");
@@ -4224,11 +3916,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalset_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               const serialization::pimpl::data &item) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalset_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalset.remove");
@@ -4245,10 +3934,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalset.size");
@@ -4263,11 +3950,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionallist_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                             const serialization::pimpl::data &item) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionallist_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionallist.add");
@@ -4284,11 +3968,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionallist_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                const serialization::pimpl::data &item) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionallist_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionallist.remove");
@@ -4305,10 +3986,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionallist.size");
@@ -4323,12 +4002,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalqueue_offer_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                const serialization::pimpl::data &item, int64_t timeout) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
+                ClientMessage transactionalqueue_offer_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item, int64_t timeout) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalqueue.offer");
@@ -4346,12 +4021,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               int64_t timeout) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE +
-                            ClientMessage::INT64_SIZE;
+                ClientMessage transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalqueue.poll");
@@ -4367,10 +4038,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalqueue.size");
@@ -4386,8 +4055,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("transaction.commit");
@@ -4400,11 +4068,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type,
-                                                        int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
+                ClientMessage transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type, int64_t thread_id) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("transaction.create");
@@ -4420,8 +4085,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("transaction.rollback");
@@ -4434,7 +4098,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_size_encode(const std::string  & name) {
+                ClientMessage ringbuffer_size_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4448,7 +4112,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_tailsequence_encode(const std::string  & name) {
+                ClientMessage ringbuffer_tailsequence_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4462,7 +4126,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_headsequence_encode(const std::string  & name) {
+                ClientMessage ringbuffer_headsequence_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4476,7 +4140,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_capacity_encode(const std::string  & name) {
+                ClientMessage ringbuffer_capacity_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4490,7 +4154,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_remainingcapacity_encode(const std::string  & name) {
+                ClientMessage ringbuffer_remainingcapacity_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4504,9 +4168,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_add_encode(const std::string &name, int32_t overflow_policy,
-                                                    const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage ringbuffer_add_encode(const std::string &name, int32_t overflow_policy, const serialization::pimpl::data &value) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("ringbuffer.add");
@@ -4522,7 +4185,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_readone_encode(const std::string  & name, int64_t sequence) {
+                ClientMessage ringbuffer_readone_encode(const std::string &name, int64_t sequence) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4537,10 +4200,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage ringbuffer_addall_encode(const std::string &name,
-                                                       const std::vector<serialization::pimpl::data> &value_list,
-                                                       int32_t overflow_policy) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                ClientMessage ringbuffer_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list, int32_t overflow_policy) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("ringbuffer.addall");
@@ -4556,12 +4217,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                ringbuffer_readmany_encode(const std::string &name, int64_t start_sequence, int32_t min_count,
-                                           int32_t max_count, const serialization::pimpl::data *filter) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE +
-                            ClientMessage::INT32_SIZE;
+                ClientMessage ringbuffer_readmany_encode(const std::string &name, int64_t start_sequence, int32_t min_count, int32_t max_count, const serialization::pimpl::data *filter) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.readmany");
@@ -4580,7 +4237,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage flakeidgenerator_newidbatch_encode(const std::string &name, int32_t batch_size) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("flakeidgenerator.newidbatch");
@@ -4594,10 +4251,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_get_encode(const std::string &name,
-                                                   const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
-                                                   boost::uuids::uuid target_replica_uuid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
+                ClientMessage pncounter_get_encode(const std::string &name, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("pncounter.get");
@@ -4605,7 +4260,7 @@ namespace hazelcast {
                     msg.set_message_type(static_cast<int32_t>(1900800));
                     msg.set_partition_id(-1);
 
-                    msg.set(target_replica_uuid);
+                    msg.set(target_replica_u_u_i_d);
                     msg.set(name);
 
                     msg.set(replica_timestamps, true);
@@ -4613,12 +4268,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update,
-                                                   const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
-                                                   boost::uuids::uuid target_replica_uuid) {
-                    size_t initial_frame_size =
-                            ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::UINT8_SIZE +
-                            ClientMessage::UUID_SIZE;
+                ClientMessage pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::UINT8_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("pncounter.add");
@@ -4628,7 +4279,7 @@ namespace hazelcast {
 
                     msg.set(delta);
                     msg.set(get_before_update);
-                    msg.set(target_replica_uuid);
+                    msg.set(target_replica_u_u_i_d);
                     msg.set(name);
 
                     msg.set(replica_timestamps, true);
@@ -4636,7 +4287,7 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_getconfiguredreplicacount_encode(const std::string  & name) {
+                ClientMessage pncounter_getconfiguredreplicacount_encode(const std::string &name) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
@@ -4651,7 +4302,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpgroup_createcpgroup_encode(const std::string &proxy_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpgroup.createcpgroup");
@@ -4664,10 +4315,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                cpgroup_destroycpobject_encode(const cp::raft_group_id &group_id, const std::string &service_name,
-                                               const std::string &object_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage cpgroup_destroycpobject_encode(const cp::raft_group_id &group_id, const std::string &service_name, const std::string &object_name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpgroup.destroycpobject");
@@ -4684,9 +4333,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage
-                cpsession_createsession_encode(const cp::raft_group_id &group_id, const std::string &endpoint_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                ClientMessage cpsession_createsession_encode(const cp::raft_group_id &group_id, const std::string &endpoint_name) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.createsession");
@@ -4702,7 +4350,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_closesession_encode(const cp::raft_group_id &group_id, int64_t session_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.closesession");
@@ -4717,7 +4365,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_heartbeatsession_encode(const cp::raft_group_id &group_id, int64_t session_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.heartbeatsession");
@@ -4732,7 +4380,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_generatethreadid_encode(const cp::raft_group_id &group_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.generatethreadid");

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
@@ -25,7 +25,7 @@ namespace hazelcast {
         namespace protocol {
             namespace codec {
                 ClientMessage client_authentication_encode(const std::string &cluster_name, const std::string *username, const std::string *password, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("client.authentication");
@@ -53,7 +53,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_authenticationcustom_encode(const std::string &cluster_name, const std::vector<byte> &credentials, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("client.authenticationcustom");
@@ -79,7 +79,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_addclusterviewlistener_encode() {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.addclusterviewlistener");
@@ -117,7 +117,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_createproxy_encode(const std::string &name, const std::string &service_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.createproxy");
@@ -133,7 +133,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_destroyproxy_encode(const std::string &name, const std::string &service_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.destroyproxy");
@@ -149,7 +149,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_ping_encode() {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(true);
                     msg.set_operation_name("client.ping");
@@ -161,7 +161,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_statistics_encode(int64_t timestamp, const std::string &client_attributes, const std::vector<byte> &metrics_blob) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.statistics");
@@ -178,7 +178,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage client_localbackuplistener_encode() {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("client.localbackuplistener");
@@ -205,7 +205,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.put");
@@ -225,7 +225,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.get");
@@ -242,7 +242,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.remove");
@@ -259,7 +259,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_replace_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.replace");
@@ -278,7 +278,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_replaceifsame_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &test_value, const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.replaceifsame");
@@ -299,7 +299,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_containskey_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.containskey");
@@ -316,7 +316,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.containsvalue");
@@ -332,7 +332,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_removeifsame_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.removeifsame");
@@ -351,7 +351,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_delete_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.delete");
@@ -368,7 +368,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_flush_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.flush");
@@ -382,7 +382,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_tryremove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t timeout) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.tryremove");
@@ -400,7 +400,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_tryput_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t timeout) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.tryput");
@@ -420,7 +420,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_puttransient_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.puttransient");
@@ -440,7 +440,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_putifabsent_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.putifabsent");
@@ -460,7 +460,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_set_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.set");
@@ -480,7 +480,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t ttl, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.lock");
@@ -499,7 +499,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.trylock");
@@ -519,7 +519,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_islocked_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.islocked");
@@ -535,7 +535,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.unlock");
@@ -553,7 +553,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addinterceptor_encode(const std::string &name, const serialization::pimpl::data &interceptor) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addinterceptor");
@@ -569,7 +569,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_removeinterceptor_encode(const std::string &name, const std::string &id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.removeinterceptor");
@@ -585,7 +585,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addentrylistenerwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate, bool include_value, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addentrylistenerwithpredicate");
@@ -625,7 +625,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool include_value, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addentrylistenertokey");
@@ -665,7 +665,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addentrylistener");
@@ -703,7 +703,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.removeentrylistener");
@@ -718,7 +718,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_getentryview_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.getentryview");
@@ -735,7 +735,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_evict_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.evict");
@@ -752,7 +752,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_evictall_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.evictall");
@@ -766,7 +766,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_keyset_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.keyset");
@@ -780,7 +780,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_getall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.getall");
@@ -796,7 +796,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_values_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.values");
@@ -810,7 +810,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_entryset_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.entryset");
@@ -824,7 +824,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_keysetwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.keysetwithpredicate");
@@ -840,7 +840,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_valueswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.valueswithpredicate");
@@ -856,7 +856,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_entrieswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.entrieswithpredicate");
@@ -872,7 +872,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addindex_encode(const std::string &name, const config::index_config &index_config) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addindex");
@@ -888,7 +888,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.size");
@@ -902,7 +902,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_isempty_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.isempty");
@@ -916,7 +916,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_putall_encode(const std::string &name, const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries, bool trigger_map_loader) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.putall");
@@ -933,7 +933,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_clear_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.clear");
@@ -947,7 +947,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_executeonkey_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executeonkey");
@@ -966,7 +966,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_submittokey_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.submittokey");
@@ -985,7 +985,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_executeonallkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executeonallkeys");
@@ -1001,7 +1001,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_executewithpredicate_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executewithpredicate");
@@ -1019,7 +1019,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_executeonkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const std::vector<serialization::pimpl::data> &keys) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.executeonkeys");
@@ -1037,7 +1037,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.forceunlock");
@@ -1054,7 +1054,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_keysetwithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.keysetwithpagingpredicate");
@@ -1070,7 +1070,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_valueswithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.valueswithpagingpredicate");
@@ -1086,7 +1086,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_entrieswithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.entrieswithpagingpredicate");
@@ -1102,7 +1102,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_removeall_encode(const std::string &name, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.removeall");
@@ -1118,7 +1118,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("map.addnearcacheinvalidationlistener");
@@ -1163,7 +1163,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage map_replaceall_encode(const std::string &name, const serialization::pimpl::data &function) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("map.replaceall");
@@ -1179,7 +1179,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.put");
@@ -1198,7 +1198,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.get");
@@ -1215,7 +1215,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.remove");
@@ -1232,7 +1232,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_keyset_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.keyset");
@@ -1246,7 +1246,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_values_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.values");
@@ -1260,7 +1260,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_entryset_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.entryset");
@@ -1274,7 +1274,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_containskey_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.containskey");
@@ -1291,7 +1291,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.containsvalue");
@@ -1307,7 +1307,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_containsentry_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.containsentry");
@@ -1326,7 +1326,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.size");
@@ -1340,7 +1340,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_clear_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.clear");
@@ -1354,7 +1354,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_valuecount_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.valuecount");
@@ -1371,7 +1371,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.addentrylistenertokey");
@@ -1410,7 +1410,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.addentrylistener");
@@ -1447,7 +1447,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.removeentrylistener");
@@ -1462,7 +1462,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t ttl, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.lock");
@@ -1481,7 +1481,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.trylock");
@@ -1501,7 +1501,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_islocked_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.islocked");
@@ -1517,7 +1517,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.unlock");
@@ -1535,7 +1535,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t reference_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("multimap.forceunlock");
@@ -1552,7 +1552,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage multimap_removeentry_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("multimap.removeentry");
@@ -1571,7 +1571,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_offer_encode(const std::string &name, const serialization::pimpl::data &value, int64_t timeout_millis) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.offer");
@@ -1588,7 +1588,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_put_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.put");
@@ -1604,7 +1604,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.size");
@@ -1618,7 +1618,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_remove_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.remove");
@@ -1634,7 +1634,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_poll_encode(const std::string &name, int64_t timeout_millis) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.poll");
@@ -1649,7 +1649,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_take_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.take");
@@ -1663,7 +1663,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_peek_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.peek");
@@ -1677,7 +1677,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_iterator_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.iterator");
@@ -1691,7 +1691,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_drainto_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.drainto");
@@ -1705,7 +1705,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_draintomaxsize_encode(const std::string &name, int32_t max_size) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.draintomaxsize");
@@ -1720,7 +1720,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_contains_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.contains");
@@ -1736,7 +1736,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.containsall");
@@ -1752,7 +1752,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.compareandremoveall");
@@ -1768,7 +1768,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.compareandretainall");
@@ -1784,7 +1784,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_clear_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.clear");
@@ -1798,7 +1798,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.addall");
@@ -1814,7 +1814,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.addlistener");
@@ -1847,7 +1847,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("queue.removelistener");
@@ -1862,7 +1862,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_remainingcapacity_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.remainingcapacity");
@@ -1876,7 +1876,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage queue_isempty_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("queue.isempty");
@@ -1890,7 +1890,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage topic_publish_encode(const std::string &name, const serialization::pimpl::data &message) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("topic.publish");
@@ -1906,7 +1906,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage topic_addmessagelistener_encode(const std::string &name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("topic.addmessagelistener");
@@ -1938,7 +1938,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("topic.removemessagelistener");
@@ -1953,7 +1953,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.size");
@@ -1967,7 +1967,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_contains_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.contains");
@@ -1983,7 +1983,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.containsall");
@@ -1999,7 +1999,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_add_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.add");
@@ -2015,7 +2015,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_remove_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.remove");
@@ -2031,7 +2031,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addall");
@@ -2047,7 +2047,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.compareandremoveall");
@@ -2063,7 +2063,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.compareandretainall");
@@ -2079,7 +2079,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_clear_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.clear");
@@ -2093,7 +2093,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_getall_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.getall");
@@ -2107,7 +2107,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addlistener");
@@ -2140,7 +2140,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.removelistener");
@@ -2155,7 +2155,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_isempty_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.isempty");
@@ -2169,7 +2169,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_addallwithindex_encode(const std::string &name, int32_t index, const std::vector<serialization::pimpl::data> &value_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addallwithindex");
@@ -2186,7 +2186,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_get_encode(const std::string &name, int32_t index) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.get");
@@ -2201,7 +2201,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_set_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.set");
@@ -2218,7 +2218,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_addwithindex_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.addwithindex");
@@ -2235,7 +2235,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_removewithindex_encode(const std::string &name, int32_t index) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("list.removewithindex");
@@ -2250,7 +2250,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_lastindexof_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.lastindexof");
@@ -2266,7 +2266,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_indexof_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.indexof");
@@ -2282,7 +2282,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage list_sub_encode(const std::string &name, int32_t from, int32_t to) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("list.sub");
@@ -2298,7 +2298,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.size");
@@ -2312,7 +2312,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_contains_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.contains");
@@ -2328,7 +2328,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &items) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.containsall");
@@ -2344,7 +2344,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_add_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.add");
@@ -2360,7 +2360,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_remove_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.remove");
@@ -2376,7 +2376,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.addall");
@@ -2392,7 +2392,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.compareandremoveall");
@@ -2408,7 +2408,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.compareandretainall");
@@ -2424,7 +2424,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_clear_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.clear");
@@ -2438,7 +2438,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_getall_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.getall");
@@ -2452,7 +2452,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_addlistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.addlistener");
@@ -2485,7 +2485,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("set.removelistener");
@@ -2500,7 +2500,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage set_isempty_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("set.isempty");
@@ -2514,7 +2514,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage fencedlock_lock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.lock");
@@ -2533,7 +2533,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage fencedlock_trylock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int64_t timeout_ms) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.trylock");
@@ -2553,7 +2553,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage fencedlock_unlock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.unlock");
@@ -2572,7 +2572,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage fencedlock_getlockownership_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("fencedlock.getlockownership");
@@ -2588,7 +2588,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage executorservice_shutdown_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.shutdown");
@@ -2602,7 +2602,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage executorservice_isshutdown_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.isshutdown");
@@ -2616,7 +2616,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage executorservice_cancelonpartition_encode(boost::uuids::uuid uuid, bool interrupt) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.cancelonpartition");
@@ -2629,8 +2629,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_u_u_i_d, bool interrupt) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
+                ClientMessage executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid, bool interrupt) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.cancelonmember");
@@ -2639,13 +2639,13 @@ namespace hazelcast {
                     msg.set_partition_id(-1);
 
                     msg.set(uuid);
-                    msg.set(member_u_u_i_d);
+                    msg.set(member_uuid);
                     msg.set(interrupt);
                     return msg;
                 }
 
                 ClientMessage executorservice_submittopartition_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.submittopartition");
@@ -2661,8 +2661,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable, boost::uuids::uuid member_u_u_i_d) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE;
+                ClientMessage executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable, boost::uuids::uuid member_uuid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("executorservice.submittomember");
@@ -2671,7 +2671,7 @@ namespace hazelcast {
                     msg.set_partition_id(-1);
 
                     msg.set(uuid);
-                    msg.set(member_u_u_i_d);
+                    msg.set(member_uuid);
                     msg.set(name);
 
                     msg.set(callable, true);
@@ -2680,7 +2680,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_apply_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.apply");
@@ -2698,7 +2698,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_alter_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function, int32_t return_value_type) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.alter");
@@ -2717,7 +2717,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_addandget_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.addandget");
@@ -2734,7 +2734,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t expected, int64_t updated) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.compareandset");
@@ -2752,7 +2752,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_get_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("atomiclong.get");
@@ -2768,7 +2768,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_getandadd_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.getandadd");
@@ -2785,7 +2785,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomiclong_getandset_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t new_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomiclong.getandset");
@@ -2802,7 +2802,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomicref_apply_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function, int32_t return_value_type, bool alter) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomicref.apply");
@@ -2822,7 +2822,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomicref_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *old_value, const serialization::pimpl::data *new_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomicref.compareandset");
@@ -2842,7 +2842,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomicref_contains_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("atomicref.contains");
@@ -2860,7 +2860,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomicref_get_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("atomicref.get");
@@ -2876,7 +2876,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage atomicref_set_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *new_value, bool return_old_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("atomicref.set");
@@ -2895,7 +2895,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage countdownlatch_trysetcount_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t count) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.trysetcount");
@@ -2912,7 +2912,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage countdownlatch_await_encode(const cp::raft_group_id &group_id, const std::string &name, boost::uuids::uuid invocation_uid, int64_t timeout_ms) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.await");
@@ -2930,7 +2930,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage countdownlatch_countdown_encode(const cp::raft_group_id &group_id, const std::string &name, boost::uuids::uuid invocation_uid, int32_t expected_round) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.countdown");
@@ -2948,7 +2948,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage countdownlatch_getcount_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.getcount");
@@ -2964,7 +2964,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage countdownlatch_getround_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("countdownlatch.getround");
@@ -2980,7 +2980,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_init_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t permits) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.init");
@@ -2997,7 +2997,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_acquire_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits, int64_t timeout_ms) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.acquire");
@@ -3018,7 +3018,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_release_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.release");
@@ -3038,7 +3038,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_drain_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.drain");
@@ -3057,7 +3057,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_change_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE + ClientMessage::UUID_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.change");
@@ -3077,7 +3077,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_availablepermits_encode(const cp::raft_group_id &group_id, const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.availablepermits");
@@ -3093,7 +3093,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage semaphore_getsemaphoretype_encode(const std::string &proxy_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("semaphore.getsemaphoretype");
@@ -3107,7 +3107,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.put");
@@ -3126,7 +3126,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.size");
@@ -3140,7 +3140,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_isempty_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.isempty");
@@ -3154,7 +3154,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_containskey_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.containskey");
@@ -3170,7 +3170,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.containsvalue");
@@ -3186,7 +3186,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_get_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.get");
@@ -3202,7 +3202,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_remove_encode(const std::string &name, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.remove");
@@ -3218,7 +3218,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_putall_encode(const std::string &name, const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.putall");
@@ -3234,7 +3234,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_clear_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.clear");
@@ -3248,7 +3248,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_addentrylistenertokeywithpredicate_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &predicate, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistenertokeywithpredicate");
@@ -3288,7 +3288,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_addentrylistenerwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistenerwithpredicate");
@@ -3326,7 +3326,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistenertokey");
@@ -3364,7 +3364,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_addentrylistener_encode(const std::string &name, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addentrylistener");
@@ -3400,7 +3400,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.removeentrylistener");
@@ -3415,7 +3415,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_keyset_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.keyset");
@@ -3429,7 +3429,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_values_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.values");
@@ -3443,7 +3443,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_entryset_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("replicatedmap.entryset");
@@ -3457,7 +3457,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value, bool local_only) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UINT8_SIZE + ClientMessage::UINT8_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("replicatedmap.addnearcacheentrylistener");
@@ -3494,7 +3494,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_containskey_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.containskey");
@@ -3512,7 +3512,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.get");
@@ -3530,7 +3530,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.size");
@@ -3546,7 +3546,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.isempty");
@@ -3562,7 +3562,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t ttl) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.put");
@@ -3583,7 +3583,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_set_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.set");
@@ -3603,7 +3603,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_putifabsent_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.putifabsent");
@@ -3623,7 +3623,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_replace_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.replace");
@@ -3643,7 +3643,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_replaceifsame_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &old_value, const serialization::pimpl::data &new_value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.replaceifsame");
@@ -3665,7 +3665,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.remove");
@@ -3683,7 +3683,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_delete_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.delete");
@@ -3701,7 +3701,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_removeifsame_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.removeifsame");
@@ -3721,7 +3721,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.keyset");
@@ -3737,7 +3737,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_keysetwithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.keysetwithpredicate");
@@ -3755,7 +3755,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.values");
@@ -3771,7 +3771,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmap_valueswithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &predicate) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmap.valueswithpredicate");
@@ -3789,7 +3789,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmultimap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.put");
@@ -3809,7 +3809,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmultimap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.get");
@@ -3827,7 +3827,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmultimap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.remove");
@@ -3845,7 +3845,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmultimap_removeentry_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.removeentry");
@@ -3865,7 +3865,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmultimap_valuecount_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.valuecount");
@@ -3883,7 +3883,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalmultimap.size");
@@ -3899,7 +3899,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalset_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalset.add");
@@ -3917,7 +3917,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalset_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalset.remove");
@@ -3935,7 +3935,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalset.size");
@@ -3951,7 +3951,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionallist_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionallist.add");
@@ -3969,7 +3969,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionallist_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionallist.remove");
@@ -3987,7 +3987,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionallist.size");
@@ -4003,7 +4003,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalqueue_offer_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item, int64_t timeout) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalqueue.offer");
@@ -4022,7 +4022,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalqueue.poll");
@@ -4039,7 +4039,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("transactionalqueue.size");
@@ -4055,7 +4055,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("transaction.commit");
@@ -4069,7 +4069,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("transaction.create");
@@ -4085,7 +4085,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size, true);
                     msg.set_retryable(false);
                     msg.set_operation_name("transaction.rollback");
@@ -4099,7 +4099,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_size_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.size");
@@ -4113,7 +4113,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_tailsequence_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.tailsequence");
@@ -4127,7 +4127,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_headsequence_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.headsequence");
@@ -4141,7 +4141,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_capacity_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.capacity");
@@ -4155,7 +4155,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_remainingcapacity_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.remainingcapacity");
@@ -4169,7 +4169,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_add_encode(const std::string &name, int32_t overflow_policy, const serialization::pimpl::data &value) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("ringbuffer.add");
@@ -4186,7 +4186,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_readone_encode(const std::string &name, int64_t sequence) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.readone");
@@ -4201,7 +4201,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list, int32_t overflow_policy) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("ringbuffer.addall");
@@ -4218,7 +4218,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage ringbuffer_readmany_encode(const std::string &name, int64_t start_sequence, int32_t min_count, int32_t max_count, const serialization::pimpl::data *filter) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::INT32_SIZE + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("ringbuffer.readmany");
@@ -4237,7 +4237,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage flakeidgenerator_newidbatch_encode(const std::string &name, int32_t batch_size) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT32_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("flakeidgenerator.newidbatch");
@@ -4251,8 +4251,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_get_encode(const std::string &name, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::UUID_SIZE;
+                ClientMessage pncounter_get_encode(const std::string &name, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_uuid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("pncounter.get");
@@ -4260,7 +4260,7 @@ namespace hazelcast {
                     msg.set_message_type(static_cast<int32_t>(1900800));
                     msg.set_partition_id(-1);
 
-                    msg.set(target_replica_u_u_i_d);
+                    msg.set(target_replica_uuid);
                     msg.set(name);
 
                     msg.set(replica_timestamps, true);
@@ -4268,8 +4268,8 @@ namespace hazelcast {
                     return msg;
                 }
 
-                ClientMessage pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE + ClientMessage::UINT8_SIZE + ClientMessage::UUID_SIZE;
+                ClientMessage pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_uuid) {
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE + ClientMessage::UINT8_SIZE + ClientMessage::UUID_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(false);
                     msg.set_operation_name("pncounter.add");
@@ -4279,7 +4279,7 @@ namespace hazelcast {
 
                     msg.set(delta);
                     msg.set(get_before_update);
-                    msg.set(target_replica_u_u_i_d);
+                    msg.set(target_replica_uuid);
                     msg.set(name);
 
                     msg.set(replica_timestamps, true);
@@ -4288,7 +4288,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage pncounter_getconfiguredreplicacount_encode(const std::string &name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("pncounter.getconfiguredreplicacount");
@@ -4302,7 +4302,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpgroup_createcpgroup_encode(const std::string &proxy_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpgroup.createcpgroup");
@@ -4316,7 +4316,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpgroup_destroycpobject_encode(const cp::raft_group_id &group_id, const std::string &service_name, const std::string &object_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpgroup.destroycpobject");
@@ -4334,7 +4334,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_createsession_encode(const cp::raft_group_id &group_id, const std::string &endpoint_name) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.createsession");
@@ -4350,7 +4350,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_closesession_encode(const cp::raft_group_id &group_id, int64_t session_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.closesession");
@@ -4365,7 +4365,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_heartbeatsession_encode(const cp::raft_group_id &group_id, int64_t session_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN  + ClientMessage::INT64_SIZE;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.heartbeatsession");
@@ -4380,7 +4380,7 @@ namespace hazelcast {
                 }
 
                 ClientMessage cpsession_generatethreadid_encode(const cp::raft_group_id &group_id) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN ;
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
                     ClientMessage msg(initial_frame_size);
                     msg.set_retryable(true);
                     msg.set_operation_name("cpsession.generatethreadid");

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
@@ -29,24 +29,12 @@ namespace hazelcast {
                 /**
                  * Makes an authentication request to the cluster.
                  */
-                ClientMessage HAZELCAST_API
-                client_authentication_encode(const std::string &cluster_name, const std::string *username,
-                                             const std::string *password, boost::uuids::uuid uuid,
-                                             const std::string &client_type, byte serialization_version,
-                                             const std::string &client_hazelcast_version,
-                                             const std::string &client_name, const std::vector<std::string> &labels);
+                ClientMessage HAZELCAST_API client_authentication_encode(const std::string &cluster_name, const std::string *username, const std::string *password, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels);
 
                 /**
                  * Makes an authentication request to the cluster using custom credentials.
                  */
-                ClientMessage HAZELCAST_API client_authenticationcustom_encode(const std::string &cluster_name,
-                                                                               const std::vector<byte> &credentials,
-                                                                               boost::uuids::uuid uuid,
-                                                                               const std::string &client_type,
-                                                                               byte serialization_version,
-                                                                               const std::string &client_hazelcast_version,
-                                                                               const std::string &client_name,
-                                                                               const std::vector<std::string> &labels);
+                ClientMessage HAZELCAST_API client_authenticationcustom_encode(const std::string &cluster_name, const std::vector<byte> &credentials, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels);
 
                 /**
                  * Adds a cluster view listener to a connection.
@@ -55,13 +43,12 @@ namespace hazelcast {
 
                 struct HAZELCAST_API client_addclusterviewlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param version Incremental member list version
-                     * @param memberInfos List of member infos  at the cluster associated with the given version
-                     *                    params:
+                     * @param member_infos List of member infos  at the cluster associated with the given version
+                     *                     params:
                     */
-                    virtual void handle_membersview(int32_t version, std::vector<member> const &member_infos) = 0;
+                    virtual void handle_membersview(int32_t version, std::vector<member> const & member_infos) = 0;
 
                     /**
                      * @param version Incremental state version of the partition table
@@ -74,14 +61,12 @@ namespace hazelcast {
                 /**
                  * Creates a cluster-wide proxy with the given name and service.
                  */
-                ClientMessage HAZELCAST_API
-                client_createproxy_encode(const std::string &name, const std::string &service_name);
+                ClientMessage HAZELCAST_API client_createproxy_encode(const std::string &name, const std::string &service_name);
 
                 /**
                  * Destroys the proxy given by its name cluster-wide. Also, clears and releases all resources of this proxy.
                  */
-                ClientMessage HAZELCAST_API
-                client_destroyproxy_encode(const std::string &name, const std::string &service_name);
+                ClientMessage HAZELCAST_API client_destroyproxy_encode(const std::string &name, const std::string &service_name);
 
                 /**
                  * Sends a ping to the given connection.
@@ -96,7 +81,7 @@ namespace hazelcast {
                  * The second parameter, the clientAttribute is a String that is composed of key=value pairs separated by ','. The
                  * following characters ('=' '.' ',' '\') should be escaped.
                  * 
-                 * Please note that if any client implementation can not provide the value for a statistics, the corresponding key, value
+                 * Please note that if any client implementation can not provide the value for statistics, the corresponding key, value
                  * pair will not be presented in the statistics string. Only the ones, that the client can provide will be added.
                  * 
                  * The third parameter, metrics is a compressed byte array containing all metrics recorded by the client.
@@ -121,6 +106,8 @@ namespace hazelcast {
                  * | Size of dictionary blob         |   4 bytes (int)    |
                  * +---------------------------------+--------------------+
                  * | ZLIB compressed dictionary blob |   variable size    |
+                 * +---------------------------------+--------------------+
+                 * | Number of metrics in the blob   |   4 bytes (int)    |
                  * +---------------------------------+--------------------+
                  * | ZLIB compressed metrics blob    |   variable size    |
                  * +---------------------------------+--------------------+
@@ -186,11 +173,12 @@ namespace hazelcast {
                  * THE METRIC BLOB
                  * ===============
                  * 
-                 * The compressed dictionary blob is followed by the compressed metrics blob
-                 * with the following layout:
+                 * The compressed dictionary blob is followed by the number of metrics
+                 * (int) present in the metrics blob.
                  * 
-                 * +------------------------------------------------+--------------------+
-                 * | Number of metrics                              |   4 bytes (int)    |
+                 * The number of metrics is followed by the compressed metrics blob with
+                 * the following layout:
+                 * 
                  * +------------------------------------------------+--------------------+
                  * | Metrics mask                                   |   1 byte           |
                  * +------------------------------------------------+--------------------+
@@ -247,9 +235,7 @@ namespace hazelcast {
                  * 
                  * The metrics blob constructed this way is then gets ZLIB compressed.
                  */
-                ClientMessage HAZELCAST_API
-                client_statistics_encode(int64_t timestamp, const std::string &client_attributes,
-                                         const std::vector<byte> &metrics_blob);
+                ClientMessage HAZELCAST_API client_statistics_encode(int64_t timestamp, const std::string &client_attributes, const std::vector<byte> &metrics_blob);
 
                 /**
                  * Adds listener for backup acks
@@ -259,16 +245,11 @@ namespace hazelcast {
                 struct HAZELCAST_API client_localbackuplistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
                     /**
-                     * @param sourceInvocationCorrelationId correlation id of the invocation that backup acks belong to
+                     * @param source_invocation_correlation_id correlation id of the invocation that backup acks belong to
                     */
                     virtual void handle_backup(int64_t source_invocation_correlation_id) = 0;
 
                 };
-
-                /**
-                 * Removes the specified migration listener.
-                 */
-                ClientMessage HAZELCAST_API client_removemigrationlistener_encode(boost::uuids::uuid registration_id);
 
                 /**
                  * Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
@@ -276,16 +257,13 @@ namespace hazelcast {
                  * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
                  * rounded to the next closest second value.
                  */
-                ClientMessage HAZELCAST_API
-                map_put_encode(const std::string &name, const serialization::pimpl::data &key,
-                               const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
+                ClientMessage HAZELCAST_API map_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
 
                 /**
                  * This method returns a clone of the original value, so modifying the returned value does not change the actual
                  * value in the map. You should put the modified value back to make changes visible to all nodes.
                  */
-                ClientMessage HAZELCAST_API
-                map_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Removes the mapping for a key from this map if it is present (optional operation).
@@ -294,44 +272,33 @@ namespace hazelcast {
                  * possible that the map explicitly mapped the key to null. The map will not contain a mapping for the specified key once the
                  * call returns.
                  */
-                ClientMessage HAZELCAST_API
-                map_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Replaces the entry for a key only if currently mapped to a given value.
                  */
-                ClientMessage HAZELCAST_API
-                map_replace_encode(const std::string &name, const serialization::pimpl::data &key,
-                                   const serialization::pimpl::data &value, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_replace_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
                  * Replaces the the entry for a key only if existing values equal to the testValue
                  */
-                ClientMessage HAZELCAST_API
-                map_replaceifsame_encode(const std::string &name, const serialization::pimpl::data &key,
-                                         const serialization::pimpl::data &test_value,
-                                         const serialization::pimpl::data &value, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_replaceifsame_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &test_value, const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
                  * Returns true if this map contains a mapping for the specified key.
                  */
-                ClientMessage HAZELCAST_API
-                map_containskey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                       int64_t thread_id);
+                ClientMessage HAZELCAST_API map_containskey_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Returns true if this map maps one or more keys to the specified value.This operation will probably require time
                  * linear in the map size for most implementations of the Map interface.
                  */
-                ClientMessage HAZELCAST_API
-                map_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API map_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Removes the mapping for a key from this map if existing value equal to the this value
                  */
-                ClientMessage HAZELCAST_API
-                map_removeifsame_encode(const std::string &name, const serialization::pimpl::data &key,
-                                        const serialization::pimpl::data &value, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_removeifsame_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
                  * Removes the mapping for a key from this map if it is present.Unlike remove(Object), this operation does not return
@@ -341,57 +308,46 @@ namespace hazelcast {
                  * This method breaks the contract of EntryListener. When an entry is removed by delete(), it fires an EntryEvent
                  * with a null oldValue. Also, a listener with predicates will have null values, so only keys can be queried via predicates
                  */
-                ClientMessage HAZELCAST_API
-                map_delete_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_delete_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * If this map has a MapStore, this method flushes all the local dirty entries by calling MapStore.storeAll()
                  * and/or MapStore.deleteAll().
                  */
-                ClientMessage HAZELCAST_API map_flush_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_flush_encode(const std::string &name);
 
                 /**
                  * Tries to remove the entry with the given key from this map within the specified timeout value.
                  * If the key is already locked by another thread and/or member, then this operation will wait the timeout
                  * amount for acquiring the lock.
                  */
-                ClientMessage HAZELCAST_API
-                map_tryremove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                     int64_t timeout);
+                ClientMessage HAZELCAST_API map_tryremove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t timeout);
 
                 /**
                  * Tries to put the given key and value into this map within a specified timeout value. If this method returns false,
                  * it means that the caller thread could not acquire the lock for the key within the timeout duration,
                  * thus the put operation is not successful.
                  */
-                ClientMessage HAZELCAST_API
-                map_tryput_encode(const std::string &name, const serialization::pimpl::data &key,
-                                  const serialization::pimpl::data &value, int64_t thread_id, int64_t timeout);
+                ClientMessage HAZELCAST_API map_tryput_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t timeout);
 
                 /**
                  * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
                  * If ttl is 0, then the entry lives forever.
                  */
-                ClientMessage HAZELCAST_API
-                map_puttransient_encode(const std::string &name, const serialization::pimpl::data &key,
-                                        const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
+                ClientMessage HAZELCAST_API map_puttransient_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
 
                 /**
                  * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
                  * with a value. Entry will expire and get evicted after the ttl.
                  */
-                ClientMessage HAZELCAST_API
-                map_putifabsent_encode(const std::string &name, const serialization::pimpl::data &key,
-                                       const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
+                ClientMessage HAZELCAST_API map_putifabsent_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
 
                 /**
                  * Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
                  * If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
                  * return the old value, which is more efficient.
                  */
-                ClientMessage HAZELCAST_API
-                map_set_encode(const std::string &name, const serialization::pimpl::data &key,
-                               const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
+                ClientMessage HAZELCAST_API map_set_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id, int64_t ttl);
 
                 /**
                  * Acquires the lock for the specified lease time.After lease time, lock will be released.If the lock is not
@@ -400,9 +356,7 @@ namespace hazelcast {
                  * Scope of the lock is this map only. Acquired lock is only for the key in this map. Locks are re-entrant,
                  * so if the key is locked N times then it should be unlocked N times before another thread can acquire it.
                  */
-                ClientMessage HAZELCAST_API
-                map_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                int64_t ttl, int64_t reference_id);
+                ClientMessage HAZELCAST_API map_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t ttl, int64_t reference_id);
 
                 /**
                  * Tries to acquire the lock for the specified key for the specified lease time.After lease time, the lock will be
@@ -410,15 +364,12 @@ namespace hazelcast {
                  * purposes and lies dormant until one of two things happens the lock is acquired by the current thread, or
                  * the specified waiting time elapses.
                  */
-                ClientMessage HAZELCAST_API
-                map_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                   int64_t lease, int64_t timeout, int64_t reference_id);
+                ClientMessage HAZELCAST_API map_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id);
 
                 /**
                  * Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
                  */
-                ClientMessage HAZELCAST_API
-                map_islocked_encode(const std::string &name, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API map_islocked_encode(const std::string &name, const serialization::pimpl::data &key);
 
                 /**
                  * Releases the lock for the specified key. It never blocks and returns immediately.
@@ -426,60 +377,47 @@ namespace hazelcast {
                  * then the lock is released.  If the current thread is not the holder of this lock,
                  * then ILLEGAL_MONITOR_STATE is thrown.
                  */
-                ClientMessage HAZELCAST_API
-                map_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                  int64_t reference_id);
+                ClientMessage HAZELCAST_API map_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t reference_id);
 
                 /**
                  * Adds an interceptor for this map. Added interceptor will intercept operations
                  * and execute user defined methods and will cancel operations if user defined method throw exception.
                  */
-                ClientMessage HAZELCAST_API
-                map_addinterceptor_encode(const std::string &name, const serialization::pimpl::data &interceptor);
+                ClientMessage HAZELCAST_API map_addinterceptor_encode(const std::string &name, const serialization::pimpl::data &interceptor);
 
                 /**
                  * Removes the given interceptor for this map so it will not intercept operations anymore.
                  */
-                ClientMessage HAZELCAST_API map_removeinterceptor_encode(const std::string  & name, const std::string  & id);
+                ClientMessage HAZELCAST_API map_removeinterceptor_encode(const std::string &name, const std::string &id);
 
                 /**
                  * Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
                  * filtered by the given predicate.
                  */
-                ClientMessage HAZELCAST_API map_addentrylistenerwithpredicate_encode(const std::string &name,
-                                                                                     const serialization::pimpl::data &predicate,
-                                                                                     bool include_value,
-                                                                                     int32_t listener_flags,
-                                                                                     bool local_only);
+                ClientMessage HAZELCAST_API map_addentrylistenerwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate, bool include_value, int32_t listener_flags, bool local_only);
 
                 struct HAZELCAST_API map_addentrylistenerwithpredicate_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -487,38 +425,30 @@ namespace hazelcast {
                  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
                  * sub-interface for that event.
                  */
-                ClientMessage HAZELCAST_API
-                map_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                 bool include_value, int32_t listener_flags, bool local_only);
+                ClientMessage HAZELCAST_API map_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool include_value, int32_t listener_flags, bool local_only);
 
                 struct HAZELCAST_API map_addentrylistenertokey_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -526,38 +456,30 @@ namespace hazelcast {
                  * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
                  * sub-interface for that event.
                  */
-                ClientMessage HAZELCAST_API
-                map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags,
-                                            bool local_only);
+                ClientMessage HAZELCAST_API map_addentrylistener_encode(const std::string &name, bool include_value, int32_t listener_flags, bool local_only);
 
                 struct HAZELCAST_API map_addentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -565,38 +487,34 @@ namespace hazelcast {
                  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API
-                map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API map_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns the EntryView for the specified key.
                  * This method returns a clone of original mapping, modifying the returned value does not change the actual value
                  * in the map. One should put modified value back to make changes visible to all nodes.
                  */
-                ClientMessage HAZELCAST_API
-                map_getentryview_encode(const std::string &name, const serialization::pimpl::data &key,
-                                        int64_t thread_id);
+                ClientMessage HAZELCAST_API map_getentryview_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
                  * from the underlying MapStore, evict only removes the entry from the memory.
                  */
-                ClientMessage HAZELCAST_API
-                map_evict_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_evict_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Evicts all keys from this map except the locked ones. If a MapStore is defined for this map, deleteAll is not
                  * called by this method. If you do want to deleteAll to be called use the clear method. The EVICT_ALL event is
                  * fired for any registered listeners.
                  */
-                ClientMessage HAZELCAST_API map_evictall_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_evictall_encode(const std::string &name);
 
                 /**
                  * Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
                  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
-                 * throw a query_result_size_exceeded if query result size limit is configured.
+                 * throw a QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API map_keyset_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_keyset_encode(const std::string &name);
 
                 /**
                  * Returns the entries for the given keys. If any keys are not present in the Map, it will call loadAll The returned
@@ -605,68 +523,63 @@ namespace hazelcast {
                  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
                  * of these request messages for filling a request for a key set if the keys belong to different partitions.
                  */
-                ClientMessage HAZELCAST_API
-                map_getall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys);
+                ClientMessage HAZELCAST_API map_getall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &keys);
 
                 /**
                  * Returns a collection clone of the values contained in this map.
                  * The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
-                 * This method is always executed by a distributed query, so it may throw a query_result_size_exceeded
+                 * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
                  * if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API map_values_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_values_encode(const std::string &name);
 
                 /**
                  * Returns a Set clone of the mappings contained in this map.
                  * The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
-                 * This method is always executed by a distributed query, so it may throw a query_result_size_exceeded
+                 * This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
                  * if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API map_entryset_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_entryset_encode(const std::string &name);
 
                 /**
                  * Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
                  * runs on all members in parallel.The set is NOT backed by the map, so changes to the map are NOT reflected in the
                  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                map_keysetwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API map_keysetwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate);
 
                 /**
                  * Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
                  * runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
                  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                map_valueswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API map_valueswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate);
 
                 /**
                  * Queries the map based on the specified predicate and returns the matching entries.Specified predicate
                  * runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
                  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                map_entrieswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API map_entrieswithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate);
 
                 /**
                  * Adds an index to this map with specified configuration.
                  */
-                ClientMessage HAZELCAST_API
-                map_addindex_encode(const std::string &name, const config::index_config &index_config);
+                ClientMessage HAZELCAST_API map_addindex_encode(const std::string &name, const config::index_config &index_config);
 
                 /**
                  * Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
                  * returns Integer.MAX_VALUE
                  */
-                ClientMessage HAZELCAST_API map_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_size_encode(const std::string &name);
 
                 /**
                  * Returns true if this map contains no key-value mappings.
                  */
-                ClientMessage HAZELCAST_API map_isempty_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_isempty_encode(const std::string &name);
 
                 /**
                  * Copies all of the mappings from the specified map to this map (optional operation).The effect of this call is
@@ -677,276 +590,234 @@ namespace hazelcast {
                  * matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
                  * of these request messages for filling a request for a key set if the keys belong to different partitions.
                  */
-                ClientMessage HAZELCAST_API map_putall_encode(const std::string &name,
-                                                              const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries,
-                                                              bool trigger_map_loader);
+                ClientMessage HAZELCAST_API map_putall_encode(const std::string &name, const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries, bool trigger_map_loader);
 
                 /**
                  * This method clears the map and invokes MapStore#deleteAll deleteAll on MapStore which, if connected to a database,
                  * will delete the records from that database. The MAP_CLEARED event is fired for any registered listeners.
                  * To clear a map without calling MapStore#deleteAll, use #evictAll.
                  */
-                ClientMessage HAZELCAST_API map_clear_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API map_clear_encode(const std::string &name);
 
                 /**
                  * Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
                  * the process() method of EntryProcessor.
                  */
-                ClientMessage HAZELCAST_API
-                map_executeonkey_encode(const std::string &name, const serialization::pimpl::data &entry_processor,
-                                        const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_executeonkey_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Applies the user defined EntryProcessor to the entry mapped by the key. Returns immediately with a Future
                  * representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
                  * operation of EntryProcessor.
                  */
-                ClientMessage HAZELCAST_API
-                map_submittokey_encode(const std::string &name, const serialization::pimpl::data &entry_processor,
-                                       const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API map_submittokey_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
                  */
-                ClientMessage HAZELCAST_API
-                map_executeonallkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor);
+                ClientMessage HAZELCAST_API map_executeonallkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor);
 
                 /**
                  * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
                  * Returns the results mapped by each key in the map.
                  */
-                ClientMessage HAZELCAST_API map_executewithpredicate_encode(const std::string &name,
-                                                                            const serialization::pimpl::data &entry_processor,
-                                                                            const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API map_executewithpredicate_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const serialization::pimpl::data &predicate);
 
                 /**
                  * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
                  * each key in the collection.
                  */
-                ClientMessage HAZELCAST_API
-                map_executeonkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor,
-                                         const std::vector<serialization::pimpl::data> &keys);
+                ClientMessage HAZELCAST_API map_executeonkeys_encode(const std::string &name, const serialization::pimpl::data &entry_processor, const std::vector<serialization::pimpl::data> &keys);
 
                 /**
                  * Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,
                  * never blocks,and returns immediately.
                  */
-                ClientMessage HAZELCAST_API
-                map_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                       int64_t reference_id);
+                ClientMessage HAZELCAST_API map_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t reference_id);
 
                 /**
                  * Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
                  * runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
                  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API map_keysetwithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate);
+                ClientMessage HAZELCAST_API map_keysetwithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate);
 
                 /**
                  * Queries the map based on the specified predicate and returns the values of matching entries. Specified predicate
                  * runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
                  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API map_valueswithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate);
+                ClientMessage HAZELCAST_API map_valueswithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate);
 
                 /**
                  * Queries the map based on the specified predicate and returns the matching entries. Specified predicate
                  * runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
                  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API map_entrieswithpagingpredicate_encode(const std::string  & name, const codec::holder::paging_predicate_holder  & predicate);
+                ClientMessage HAZELCAST_API map_entrieswithpagingpredicate_encode(const std::string &name, const codec::holder::paging_predicate_holder &predicate);
 
                 /**
                  * Removes all entries which match with the supplied predicate
                  */
-                ClientMessage HAZELCAST_API
-                map_removeall_encode(const std::string &name, const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API map_removeall_encode(const std::string &name, const serialization::pimpl::data &predicate);
 
                 /**
                  * Adds listener to map. This listener will be used to listen near cache invalidation events.
                  */
-                ClientMessage HAZELCAST_API
-                map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags,
-                                                            bool local_only);
+                ClientMessage HAZELCAST_API map_addnearcacheinvalidationlistener_encode(const std::string &name, int32_t listener_flags, bool local_only);
 
                 struct HAZELCAST_API map_addnearcacheinvalidationlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key The key of the invalidated entry.
-                     * @param sourceUuid UUID of the member who fired this event.
-                     * @param partitionUuid UUID of the source partition that invalidated entry belongs to.
+                     * @param source_uuid UUID of the member who fired this event.
+                     * @param partition_uuid UUID of the source partition that invalidated entry belongs to.
                      * @param sequence Sequence number of the invalidation event.
                     */
-                    virtual void handle_imapinvalidation(const boost::optional<serialization::pimpl::data> &key,
-                                                         boost::uuids::uuid source_uuid,
-                                                         boost::uuids::uuid partition_uuid, int64_t sequence) = 0;
+                    virtual void handle_imapinvalidation( const boost::optional<serialization::pimpl::data> & key, boost::uuids::uuid source_uuid, boost::uuids::uuid partition_uuid, int64_t sequence) = 0;
 
                     /**
                      * @param keys List of the keys of the invalidated entries.
-                     * @param sourceUuids List of UUIDs of the members who fired these events.
-                     * @param partitionUuids List of UUIDs of the source partitions that invalidated entries belong to.
+                     * @param source_uuids List of UUIDs of the members who fired these events.
+                     * @param partition_uuids List of UUIDs of the source partitions that invalidated entries belong to.
                      * @param sequences List of sequence numbers of the invalidation events.
                     */
-                    virtual void handle_imapbatchinvalidation(std::vector<serialization::pimpl::data> const &keys,
-                                                              std::vector<boost::uuids::uuid> const &source_uuids,
-                                                              std::vector<boost::uuids::uuid> const &partition_uuids,
-                                                              std::vector<int64_t> const &sequences) = 0;
+                    virtual void handle_imapbatchinvalidation(std::vector<serialization::pimpl::data> const & keys, std::vector<boost::uuids::uuid> const & source_uuids, std::vector<boost::uuids::uuid> const & partition_uuids, std::vector<int64_t> const & sequences) = 0;
 
                 };
 
                 /**
+                 * Replaces each entry's value with the result of invoking the given
+                 * function on that entry until all entries have been processed in the targetted partition
+                 * or the function throws an exception.
+                 */
+                ClientMessage HAZELCAST_API map_replaceall_encode(const std::string &name, const serialization::pimpl::data &function);
+
+                /**
                  * Stores a key-value pair in the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_put_encode(const std::string &name, const serialization::pimpl::data &key,
-                                    const serialization::pimpl::data &value, int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
                  * Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
                  * the map are NOT reflected in the collection, and vice-versa.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_get_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Removes the given key value pair from the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_remove_encode(const std::string &name, const serialization::pimpl::data &key,
-                                       int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_remove_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Returns the set of keys in the multimap.The collection is NOT backed by the map, so changes to the map are NOT
                  * reflected in the collection, and vice-versa.
                  */
-                ClientMessage HAZELCAST_API multimap_keyset_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API multimap_keyset_encode(const std::string &name);
 
                 /**
                  * Returns the collection of values in the multimap.The collection is NOT backed by the map, so changes to the map
                  * are NOT reflected in the collection, and vice-versa.
                  */
-                ClientMessage HAZELCAST_API multimap_values_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API multimap_values_encode(const std::string &name);
 
                 /**
                  * Returns the set of key-value pairs in the multimap.The collection is NOT backed by the map, so changes to the map
                  * are NOT reflected in the collection, and vice-versa
                  */
-                ClientMessage HAZELCAST_API multimap_entryset_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API multimap_entryset_encode(const std::string &name);
 
                 /**
                  * Returns whether the multimap contains an entry with the key.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_containskey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                            int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_containskey_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Returns whether the multimap contains an entry with the value.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API multimap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns whether the multimap contains the given key-value pair.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_containsentry_encode(const std::string &name, const serialization::pimpl::data &key,
-                                              const serialization::pimpl::data &value, int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_containsentry_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
                  * Returns the number of key-value pairs in the multimap.
                  */
-                ClientMessage HAZELCAST_API multimap_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API multimap_size_encode(const std::string &name);
 
                 /**
                  * Clears the multimap. Removes all key-value pairs.
                  */
-                ClientMessage HAZELCAST_API multimap_clear_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API multimap_clear_encode(const std::string &name);
 
                 /**
                  * Returns the number of values that match the given key in the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_valuecount_encode(const std::string &name, const serialization::pimpl::data &key,
-                                           int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_valuecount_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id);
 
                 /**
                  * Adds the specified entry listener for the specified key.The listener will be notified for all
                  * add/remove/update/evict events for the specified key only.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key,
-                                                      bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API multimap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool include_value, bool local_only);
 
                 struct HAZELCAST_API multimap_addentrylistenertokey_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
                 /**
                  * Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API multimap_addentrylistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API multimap_addentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -954,8 +825,7 @@ namespace hazelcast {
                  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API multimap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Acquires the lock for the specified key for the specified lease time. After the lease time, the lock will be
@@ -964,9 +834,7 @@ namespace hazelcast {
                  * lock is only for the key in this map.Locks are re-entrant, so if the key is locked N times, then it should be
                  * unlocked N times before another thread can acquire it.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id,
-                                     int64_t ttl, int64_t reference_id);
+                ClientMessage HAZELCAST_API multimap_lock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t ttl, int64_t reference_id);
 
                 /**
                  * Tries to acquire the lock for the specified key for the specified lease time. After lease time, the lock will be
@@ -974,66 +842,53 @@ namespace hazelcast {
                  * and lies dormant until one of two things happens:the lock is acquired by the current thread, or the specified
                  * waiting time elapses.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_trylock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                        int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id);
+                ClientMessage HAZELCAST_API multimap_trylock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t lease, int64_t timeout, int64_t reference_id);
 
                 /**
                  * Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_islocked_encode(const std::string &name, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API multimap_islocked_encode(const std::string &name, const serialization::pimpl::data &key);
 
                 /**
                  * Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
                  * never blocks and returns immediately.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_unlock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                       int64_t thread_id, int64_t reference_id);
+                ClientMessage HAZELCAST_API multimap_unlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t thread_id, int64_t reference_id);
 
                 /**
                  * Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
                  * never blocks and returns immediately.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key,
-                                            int64_t reference_id);
+                ClientMessage HAZELCAST_API multimap_forceunlock_encode(const std::string &name, const serialization::pimpl::data &key, int64_t reference_id);
 
                 /**
                  * Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
                  * NOT reflected in the collection, and vice-versa.
                  */
-                ClientMessage HAZELCAST_API
-                multimap_removeentry_encode(const std::string &name, const serialization::pimpl::data &key,
-                                            const serialization::pimpl::data &value, int64_t thread_id);
+                ClientMessage HAZELCAST_API multimap_removeentry_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t thread_id);
 
                 /**
                  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
                  * become available.
                  */
-                ClientMessage HAZELCAST_API
-                queue_offer_encode(const std::string &name, const serialization::pimpl::data &value,
-                                   int64_t timeout_millis);
+                ClientMessage HAZELCAST_API queue_offer_encode(const std::string &name, const serialization::pimpl::data &value, int64_t timeout_millis);
 
                 /**
                  * Inserts the specified element into this queue, waiting if necessary for space to become available.
                  */
-                ClientMessage HAZELCAST_API
-                queue_put_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API queue_put_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns the number of elements in this collection.  If this collection contains more than Integer.MAX_VALUE
                  * elements, returns Integer.MAX_VALUE
                  */
-                ClientMessage HAZELCAST_API queue_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_size_encode(const std::string &name);
 
                 /**
                  * Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
                  * if this queue is empty.
                  */
-                ClientMessage HAZELCAST_API
-                queue_remove_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API queue_remove_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
@@ -1044,18 +899,18 @@ namespace hazelcast {
                 /**
                  * Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
                  */
-                ClientMessage HAZELCAST_API queue_take_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_take_encode(const std::string &name);
 
                 /**
                  * Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
                  */
-                ClientMessage HAZELCAST_API queue_peek_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_peek_encode(const std::string &name);
 
                 /**
                  * Returns an iterator over the elements in this collection.  There are no guarantees concerning the order in which
                  * the elements are returned (unless this collection is an instance of some class that provides a guarantee).
                  */
-                ClientMessage HAZELCAST_API queue_iterator_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_iterator_encode(const std::string &name);
 
                 /**
                  * Removes all available elements from this queue and adds them to the given collection.  This operation may be more
@@ -1064,7 +919,7 @@ namespace hazelcast {
                  * thrown. Attempts to drain a queue to itself result in ILLEGAL_ARGUMENT. Further, the behavior of
                  * this operation is undefined if the specified collection is modified while the operation is in progress.
                  */
-                ClientMessage HAZELCAST_API queue_drainto_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_drainto_encode(const std::string &name);
 
                 /**
                  * Removes at most the given number of available elements from this queue and adds them to the given collection.
@@ -1079,34 +934,30 @@ namespace hazelcast {
                  * Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
                  * contains at least one element e such that value.equals(e)
                  */
-                ClientMessage HAZELCAST_API
-                queue_contains_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API queue_contains_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Return true if this collection contains all of the elements in the specified collection.
                  */
-                ClientMessage HAZELCAST_API queue_containsall_encode(const std::string &name,
-                                                                     const std::vector<serialization::pimpl::data> &data_list);
+                ClientMessage HAZELCAST_API queue_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list);
 
                 /**
                  * Removes all of this collection's elements that are also contained in the specified collection (optional operation).
                  * After this call returns, this collection will contain no elements in common with the specified collection.
                  */
-                ClientMessage HAZELCAST_API queue_compareandremoveall_encode(const std::string &name,
-                                                                             const std::vector<serialization::pimpl::data> &data_list);
+                ClientMessage HAZELCAST_API queue_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list);
 
                 /**
                  * Retains only the elements in this collection that are contained in the specified collection (optional operation).
                  * In other words, removes from this collection all of its elements that are not contained in the specified collection.
                  */
-                ClientMessage HAZELCAST_API queue_compareandretainall_encode(const std::string &name,
-                                                                             const std::vector<serialization::pimpl::data> &data_list);
+                ClientMessage HAZELCAST_API queue_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list);
 
                 /**
                  * Removes all of the elements from this collection (optional operation). The collection will be empty after this
                  * method returns.
                  */
-                ClientMessage HAZELCAST_API queue_clear_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_clear_encode(const std::string &name);
 
                 /**
                  * Adds all of the elements in the specified collection to this collection (optional operation).The behavior of this
@@ -1114,26 +965,21 @@ namespace hazelcast {
                  * (This implies that the behavior of this call is undefined if the specified collection is this collection,
                  * and this collection is nonempty.)
                  */
-                ClientMessage HAZELCAST_API
-                queue_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list);
+                ClientMessage HAZELCAST_API queue_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &data_list);
 
                 /**
                  * Adds an listener for this collection. Listener will be notified or all collection add/remove events.
                  */
-                ClientMessage HAZELCAST_API
-                queue_addlistener_encode(const std::string &name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API queue_addlistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API queue_addlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param item Item that the event is fired for.
                      * @param uuid UUID of the member that dispatches this event.
-                     * @param eventType Type of the event. It is either ADDED(1) or REMOVED(2).
+                     * @param event_type Type of the event. It is either ADDED(1) or REMOVED(2).
                     */
-                    virtual void
-                    handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid,
-                                int32_t event_type) = 0;
+                    virtual void handle_item( const boost::optional<serialization::pimpl::data> & item, boost::uuids::uuid uuid, int32_t event_type) = 0;
 
                 };
 
@@ -1141,8 +987,7 @@ namespace hazelcast {
                  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API
-                queue_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API queue_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns the number of additional elements that this queue can ideally (in the absence of memory or resource
@@ -1150,18 +995,17 @@ namespace hazelcast {
                  * always tell if an attempt to insert an element will succeed by inspecting remainingCapacity because it may be
                  * the case that another thread is about to insert or remove an element.
                  */
-                ClientMessage HAZELCAST_API queue_remainingcapacity_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_remainingcapacity_encode(const std::string &name);
 
                 /**
                  * Returns true if this collection contains no elements.
                  */
-                ClientMessage HAZELCAST_API queue_isempty_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API queue_isempty_encode(const std::string &name);
 
                 /**
                  * Publishes the message to all subscribers of this topic
                  */
-                ClientMessage HAZELCAST_API
-                topic_publish_encode(const std::string &name, const serialization::pimpl::data &message);
+                ClientMessage HAZELCAST_API topic_publish_encode(const std::string &name, const serialization::pimpl::data &message);
 
                 /**
                  * Subscribes to this topic. When someone publishes a message on this topic. onMessage() function of the given
@@ -1171,40 +1015,35 @@ namespace hazelcast {
 
                 struct HAZELCAST_API topic_addmessagelistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param item Item that the event is fired for.
-                     * @param publishTime Time that the item is published to the topic.
+                     * @param publish_time Time that the item is published to the topic.
                      * @param uuid UUID of the member that dispatches this event.
                     */
-                    virtual void handle_topic(serialization::pimpl::data const &item, int64_t publish_time,
-                                              boost::uuids::uuid uuid) = 0;
+                    virtual void handle_topic(serialization::pimpl::data const & item, int64_t publish_time, boost::uuids::uuid uuid) = 0;
 
                 };
 
                 /**
                  * Stops receiving messages for the given message listener.If the given listener already removed, this method does nothing.
                  */
-                ClientMessage HAZELCAST_API
-                topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API topic_removemessagelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
                  * Integer.MAX_VALUE.
                  */
-                ClientMessage HAZELCAST_API list_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API list_size_encode(const std::string &name);
 
                 /**
                  * Returns true if this list contains the specified element.
                  */
-                ClientMessage HAZELCAST_API
-                list_contains_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_contains_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns true if this list contains all of the elements of the specified collection.
                  */
-                ClientMessage HAZELCAST_API
-                list_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values);
+                ClientMessage HAZELCAST_API list_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values);
 
                 /**
                  * Appends the specified element to the end of this list (optional operation). Lists that support this operation may
@@ -1212,16 +1051,14 @@ namespace hazelcast {
                  * elements, and others will impose restrictions on the type of elements that may be added. List classes should
                  * clearly specify in their documentation any restrictions on what elements may be added.
                  */
-                ClientMessage HAZELCAST_API
-                list_add_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_add_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Removes the first occurrence of the specified element from this list, if it is present (optional operation).
                  * If this list does not contain the element, it is unchanged.
                  * Returns true if this list contained the specified element (or equivalently, if this list changed as a result of the call).
                  */
-                ClientMessage HAZELCAST_API
-                list_remove_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_remove_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Appends all of the elements in the specified collection to the end of this list, in the order that they are
@@ -1229,49 +1066,42 @@ namespace hazelcast {
                  * The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
                  * (Note that this will occur if the specified collection is this list, and it's nonempty.)
                  */
-                ClientMessage HAZELCAST_API
-                list_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list);
+                ClientMessage HAZELCAST_API list_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list);
 
                 /**
                  * Removes from this list all of its elements that are contained in the specified collection (optional operation).
                  */
-                ClientMessage HAZELCAST_API list_compareandremoveall_encode(const std::string &name,
-                                                                            const std::vector<serialization::pimpl::data> &values);
+                ClientMessage HAZELCAST_API list_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values);
 
                 /**
                  * Retains only the elements in this list that are contained in the specified collection (optional operation).
                  * In other words, removes from this list all of its elements that are not contained in the specified collection.
                  */
-                ClientMessage HAZELCAST_API list_compareandretainall_encode(const std::string &name,
-                                                                            const std::vector<serialization::pimpl::data> &values);
+                ClientMessage HAZELCAST_API list_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values);
 
                 /**
                  * Removes all of the elements from this list (optional operation). The list will be empty after this call returns.
                  */
-                ClientMessage HAZELCAST_API list_clear_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API list_clear_encode(const std::string &name);
 
                 /**
                  * Return the all elements of this collection
                  */
-                ClientMessage HAZELCAST_API list_getall_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API list_getall_encode(const std::string &name);
 
                 /**
                  * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
                  */
-                ClientMessage HAZELCAST_API
-                list_addlistener_encode(const std::string &name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API list_addlistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API list_addlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param item Item that the event is fired for.
                      * @param uuid UUID of the member that dispatches this event.
-                     * @param eventType Type of the event. It is either ADDED(1) or REMOVED(2).
+                     * @param event_type Type of the event. It is either ADDED(1) or REMOVED(2).
                     */
-                    virtual void
-                    handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid,
-                                int32_t event_type) = 0;
+                    virtual void handle_item( const boost::optional<serialization::pimpl::data> & item, boost::uuids::uuid uuid, int32_t event_type) = 0;
 
                 };
 
@@ -1279,13 +1109,12 @@ namespace hazelcast {
                  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API
-                list_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API list_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns true if this list contains no elements
                  */
-                ClientMessage HAZELCAST_API list_isempty_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API list_isempty_encode(const std::string &name);
 
                 /**
                  * Inserts all of the elements in the specified collection into this list at the specified position (optional operation).
@@ -1294,46 +1123,41 @@ namespace hazelcast {
                  * The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
                  * (Note that this will occur if the specified collection is this list, and it's nonempty.)
                  */
-                ClientMessage HAZELCAST_API list_addallwithindex_encode(const std::string &name, int32_t index,
-                                                                        const std::vector<serialization::pimpl::data> &value_list);
+                ClientMessage HAZELCAST_API list_addallwithindex_encode(const std::string &name, int32_t index, const std::vector<serialization::pimpl::data> &value_list);
 
                 /**
                  * Returns the element at the specified position in this list
                  */
-                ClientMessage HAZELCAST_API list_get_encode(const std::string  & name, int32_t index);
+                ClientMessage HAZELCAST_API list_get_encode(const std::string &name, int32_t index);
 
                 /**
                  * The element previously at the specified position
                  */
-                ClientMessage HAZELCAST_API
-                list_set_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_set_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value);
 
                 /**
                  * Inserts the specified element at the specified position in this list (optional operation). Shifts the element
                  * currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
                  */
-                ClientMessage HAZELCAST_API list_addwithindex_encode(const std::string &name, int32_t index,
-                                                                     const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_addwithindex_encode(const std::string &name, int32_t index, const serialization::pimpl::data &value);
 
                 /**
                  * Removes the element at the specified position in this list (optional operation). Shifts any subsequent elements
                  * to the left (subtracts one from their indices). Returns the element that was removed from the list.
                  */
-                ClientMessage HAZELCAST_API list_removewithindex_encode(const std::string  & name, int32_t index);
+                ClientMessage HAZELCAST_API list_removewithindex_encode(const std::string &name, int32_t index);
 
                 /**
                  * Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
                  * contain the element.
                  */
-                ClientMessage HAZELCAST_API
-                list_lastindexof_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_lastindexof_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
                  * contain the element.
                  */
-                ClientMessage HAZELCAST_API
-                list_indexof_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API list_indexof_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns a view of the portion of this list between the specified from, inclusive, and to, exclusive.(If from and
@@ -1348,26 +1172,24 @@ namespace hazelcast {
                  * structurally modified in any way other than via the returned list.(Structural modifications are those that change
                  * the size of this list, or otherwise perturb it in such a fashion that iterations in progress may yield incorrect results.)
                  */
-                ClientMessage HAZELCAST_API list_sub_encode(const std::string  & name, int32_t from, int32_t to);
+                ClientMessage HAZELCAST_API list_sub_encode(const std::string &name, int32_t from, int32_t to);
 
                 /**
                  * Returns the number of elements in this set (its cardinality). If this set contains more than Integer.MAX_VALUE
                  * elements, returns Integer.MAX_VALUE.
                  */
-                ClientMessage HAZELCAST_API set_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API set_size_encode(const std::string &name);
 
                 /**
                  * Returns true if this set contains the specified element.
                  */
-                ClientMessage HAZELCAST_API
-                set_contains_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API set_contains_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns true if this set contains all of the elements of the specified collection. If the specified collection is
                  * also a set, this method returns true if it is a subset of this set.
                  */
-                ClientMessage HAZELCAST_API
-                set_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &items);
+                ClientMessage HAZELCAST_API set_containsall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &items);
 
                 /**
                  * Adds the specified element to this set if it is not already present (optional operation).
@@ -1377,16 +1199,14 @@ namespace hazelcast {
                  * element, including null, and throw an exception, as described in the specification for Collection
                  * Individual set implementations should clearly document any restrictions on the elements that they may contain.
                  */
-                ClientMessage HAZELCAST_API
-                set_add_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API set_add_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Removes the specified element from this set if it is present (optional operation).
                  * Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
                  * (This set will not contain the element once the call returns.)
                  */
-                ClientMessage HAZELCAST_API
-                set_remove_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API set_remove_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Adds all of the elements in the specified collection to this set if they're not already present
@@ -1394,16 +1214,14 @@ namespace hazelcast {
                  * set so that its value is the union of the two sets. The behavior of this operation is undefined if the specified
                  * collection is modified while the operation is in progress.
                  */
-                ClientMessage HAZELCAST_API
-                set_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list);
+                ClientMessage HAZELCAST_API set_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list);
 
                 /**
                  * Removes from this set all of its elements that are contained in the specified collection (optional operation).
                  * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
                  * asymmetric set difference of the two sets.
                  */
-                ClientMessage HAZELCAST_API set_compareandremoveall_encode(const std::string &name,
-                                                                           const std::vector<serialization::pimpl::data> &values);
+                ClientMessage HAZELCAST_API set_compareandremoveall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values);
 
                 /**
                  * Retains only the elements in this set that are contained in the specified collection (optional operation).
@@ -1411,36 +1229,31 @@ namespace hazelcast {
                  * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
                  * intersection of the two sets.
                  */
-                ClientMessage HAZELCAST_API set_compareandretainall_encode(const std::string &name,
-                                                                           const std::vector<serialization::pimpl::data> &values);
+                ClientMessage HAZELCAST_API set_compareandretainall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &values);
 
                 /**
                  * Removes all of the elements from this set (optional operation). The set will be empty after this call returns.
                  */
-                ClientMessage HAZELCAST_API set_clear_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API set_clear_encode(const std::string &name);
 
                 /**
                  * Return the all elements of this collection
                  */
-                ClientMessage HAZELCAST_API set_getall_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API set_getall_encode(const std::string &name);
 
                 /**
                  * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
                  */
-                ClientMessage HAZELCAST_API
-                set_addlistener_encode(const std::string &name, bool include_value, bool local_only);
+                ClientMessage HAZELCAST_API set_addlistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API set_addlistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param item Item that the event is fired for.
                      * @param uuid UUID of the member that dispatches this event.
-                     * @param eventType Type of the event. It is either ADDED(1) or REMOVED(2).
+                     * @param event_type Type of the event. It is either ADDED(1) or REMOVED(2).
                     */
-                    virtual void
-                    handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid,
-                                int32_t event_type) = 0;
+                    virtual void handle_item( const boost::optional<serialization::pimpl::data> & item, boost::uuids::uuid uuid, int32_t event_type) = 0;
 
                 };
 
@@ -1448,13 +1261,12 @@ namespace hazelcast {
                  * Removes the specified item listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API
-                set_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API set_removelistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns true if this set contains no elements.
                  */
-                ClientMessage HAZELCAST_API set_isempty_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API set_isempty_encode(const std::string &name);
 
                 /**
                  * Acquires the given FencedLock on the given CP group. If the lock is
@@ -1465,9 +1277,7 @@ namespace hazelcast {
                  * is closed between reentrant acquires, the call fails with
                  * {@code LockOwnershipLostException}.
                  */
-                ClientMessage HAZELCAST_API
-                fencedlock_lock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                       int64_t thread_id, boost::uuids::uuid invocation_uid);
+                ClientMessage HAZELCAST_API fencedlock_lock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid);
 
                 /**
                  * Attempts to acquire the given FencedLock on the given CP group.
@@ -1479,10 +1289,7 @@ namespace hazelcast {
                  * duration passes. If the session is closed between reentrant acquires,
                  * the call fails with {@code LockOwnershipLostException}.
                  */
-                ClientMessage HAZELCAST_API
-                fencedlock_trylock_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                          int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid,
-                                          int64_t timeout_ms);
+                ClientMessage HAZELCAST_API fencedlock_trylock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int64_t timeout_ms);
 
                 /**
                  * Unlocks the given FencedLock on the given CP group. If the lock is
@@ -1491,26 +1298,23 @@ namespace hazelcast {
                  * {@code LockOwnershipLostException}. Returns true if the lock is still
                  * held by the caller after a successful unlock() call, false otherwise.
                  */
-                ClientMessage HAZELCAST_API
-                fencedlock_unlock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                         int64_t thread_id, boost::uuids::uuid invocation_uid);
+                ClientMessage HAZELCAST_API fencedlock_unlock_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid);
 
                 /**
                  * Returns current lock ownership status of the given FencedLock instance.
                  */
-                ClientMessage HAZELCAST_API
-                fencedlock_getlockownership_encode(const cp::raft_group_id &group_id, const std::string &name);
+                ClientMessage HAZELCAST_API fencedlock_getlockownership_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
                  * Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
                  * Invocation has no additional effect if already shut down.
                  */
-                ClientMessage HAZELCAST_API executorservice_shutdown_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API executorservice_shutdown_encode(const std::string &name);
 
                 /**
                  * Returns true if this executor has been shut down.
                  */
-                ClientMessage HAZELCAST_API executorservice_isshutdown_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API executorservice_isshutdown_encode(const std::string &name);
 
                 /**
                  * Cancels the task running on the member that owns the partition with the given id.
@@ -1520,116 +1324,85 @@ namespace hazelcast {
                 /**
                  * Cancels the task running on the member with the given address.
                  */
-                ClientMessage HAZELCAST_API
-                executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid,
-                                                      bool interrupt);
+                ClientMessage HAZELCAST_API executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_u_u_i_d, bool interrupt);
 
                 /**
                  * Submits the task to the member that owns the partition with the given id.
                  */
-                ClientMessage HAZELCAST_API
-                executorservice_submittopartition_encode(const std::string &name, boost::uuids::uuid uuid,
-                                                         const serialization::pimpl::data &callable);
+                ClientMessage HAZELCAST_API executorservice_submittopartition_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable);
 
                 /**
                  * Submits the task to member specified by the address.
                  */
-                ClientMessage HAZELCAST_API
-                executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid,
-                                                      const serialization::pimpl::data &callable,
-                                                      boost::uuids::uuid member_uuid);
+                ClientMessage HAZELCAST_API executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable, boost::uuids::uuid member_u_u_i_d);
 
                 /**
                  * Applies a function on the value, the actual stored value will not change
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_apply_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                        const serialization::pimpl::data &function);
+                ClientMessage HAZELCAST_API atomiclong_apply_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function);
 
                 /**
                  * Alters the currently stored value by applying a function on it.
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_alter_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                        const serialization::pimpl::data &function, int32_t return_value_type);
+                ClientMessage HAZELCAST_API atomiclong_alter_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function, int32_t return_value_type);
 
                 /**
                  * Atomically adds the given value to the current value.
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_addandget_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta);
+                ClientMessage HAZELCAST_API atomiclong_addandget_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta);
 
                 /**
                  * Atomically sets the value to the given updated value only if the current
                  * value the expected value.
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                int64_t expected, int64_t updated);
+                ClientMessage HAZELCAST_API atomiclong_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t expected, int64_t updated);
 
                 /**
                  * Gets the current value.
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_get_encode(const cp::raft_group_id &group_id, const std::string &name);
+                ClientMessage HAZELCAST_API atomiclong_get_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
                  * Atomically adds the given value to the current value.
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_getandadd_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta);
+                ClientMessage HAZELCAST_API atomiclong_getandadd_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t delta);
 
                 /**
                  * Atomically sets the given value and returns the old value.
                  */
-                ClientMessage HAZELCAST_API
-                atomiclong_getandset_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                            int64_t new_value);
+                ClientMessage HAZELCAST_API atomiclong_getandset_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t new_value);
 
                 /**
                  * Applies a function on the value
                  */
-                ClientMessage HAZELCAST_API
-                atomicref_apply_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                       const serialization::pimpl::data &function, int32_t return_value_type,
-                                       bool alter);
+                ClientMessage HAZELCAST_API atomicref_apply_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data &function, int32_t return_value_type, bool alter);
 
                 /**
                  * Alters the currently stored value by applying a function on it.
                  */
-                ClientMessage HAZELCAST_API
-                atomicref_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                               const serialization::pimpl::data *old_value,
-                                               const serialization::pimpl::data *new_value);
+                ClientMessage HAZELCAST_API atomicref_compareandset_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *old_value, const serialization::pimpl::data *new_value);
 
                 /**
                  * Checks if the reference contains the value.
                  */
-                ClientMessage HAZELCAST_API
-                atomicref_contains_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                          const serialization::pimpl::data *value);
+                ClientMessage HAZELCAST_API atomicref_contains_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *value);
 
                 /**
                  * Gets the current value.
                  */
-                ClientMessage HAZELCAST_API
-                atomicref_get_encode(const cp::raft_group_id &group_id, const std::string &name);
+                ClientMessage HAZELCAST_API atomicref_get_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
                  * Atomically sets the given value
                  */
-                ClientMessage HAZELCAST_API
-                atomicref_set_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                     const serialization::pimpl::data *new_value, bool return_old_value);
+                ClientMessage HAZELCAST_API atomicref_set_encode(const cp::raft_group_id &group_id, const std::string &name, const serialization::pimpl::data *new_value, bool return_old_value);
 
                 /**
                  * Sets the count to the given value if the current count is zero.
                  * If the count is not zero, then this method does nothing
                  * and returns false
                  */
-                ClientMessage HAZELCAST_API
-                countdownlatch_trysetcount_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                  int32_t count);
+                ClientMessage HAZELCAST_API countdownlatch_trysetcount_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t count);
 
                 /**
                  * Causes the current thread to wait until the latch has counted down
@@ -1649,9 +1422,7 @@ namespace hazelcast {
                  * waiting time elapses then the value false is returned.  If the time is
                  * less than or equal to zero, the method will not wait at all.
                  */
-                ClientMessage HAZELCAST_API
-                countdownlatch_await_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                            boost::uuids::uuid invocation_uid, int64_t timeout_ms);
+                ClientMessage HAZELCAST_API countdownlatch_await_encode(const cp::raft_group_id &group_id, const std::string &name, boost::uuids::uuid invocation_uid, int64_t timeout_ms);
 
                 /**
                  * Decrements the count of the latch, releasing all waiting threads if
@@ -1660,29 +1431,24 @@ namespace hazelcast {
                  * re-enabled for thread scheduling purposes, and Countdown owner is set to
                  * null. If the current count equals zero, then nothing happens.
                  */
-                ClientMessage HAZELCAST_API
-                countdownlatch_countdown_encode(const cp::raft_group_id &group_id, const std::string &name,
-                                                boost::uuids::uuid invocation_uid, int32_t expected_round);
+                ClientMessage HAZELCAST_API countdownlatch_countdown_encode(const cp::raft_group_id &group_id, const std::string &name, boost::uuids::uuid invocation_uid, int32_t expected_round);
 
                 /**
                  * Returns the current count.
                  */
-                ClientMessage HAZELCAST_API
-                countdownlatch_getcount_encode(const cp::raft_group_id &group_id, const std::string &name);
+                ClientMessage HAZELCAST_API countdownlatch_getcount_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
                  * Returns the current round. A round completes when the count value
                  * reaches to 0 and a new round starts afterwards.
                  */
-                ClientMessage HAZELCAST_API
-                countdownlatch_getround_encode(const cp::raft_group_id &group_id, const std::string &name);
+                ClientMessage HAZELCAST_API countdownlatch_getround_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
                  * Initializes the ISemaphore instance with the given permit number, if not
                  * initialized before.
                  */
-                ClientMessage HAZELCAST_API
-                semaphore_init_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t permits);
+                ClientMessage HAZELCAST_API semaphore_init_encode(const cp::raft_group_id &group_id, const std::string &name, int32_t permits);
 
                 /**
                  * Acquires the requested amount of permits if available, reducing
@@ -1690,38 +1456,28 @@ namespace hazelcast {
                  * then the current thread becomes disabled for thread scheduling purposes
                  * and lies dormant until other threads release enough permits.
                  */
-                ClientMessage HAZELCAST_API
-                semaphore_acquire_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                         int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits,
-                                         int64_t timeout_ms);
+                ClientMessage HAZELCAST_API semaphore_acquire_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits, int64_t timeout_ms);
 
                 /**
                  * Releases the given number of permits and increases the number of
                  * available permits by that amount.
                  */
-                ClientMessage HAZELCAST_API
-                semaphore_release_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                         int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits);
+                ClientMessage HAZELCAST_API semaphore_release_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits);
 
                 /**
                  * Acquires all available permits at once and returns immediately.
                  */
-                ClientMessage HAZELCAST_API
-                semaphore_drain_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                       int64_t thread_id, boost::uuids::uuid invocation_uid);
+                ClientMessage HAZELCAST_API semaphore_drain_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid);
 
                 /**
                  * Increases or decreases the number of permits by the given value.
                  */
-                ClientMessage HAZELCAST_API
-                semaphore_change_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id,
-                                        int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits);
+                ClientMessage HAZELCAST_API semaphore_change_encode(const cp::raft_group_id &group_id, const std::string &name, int64_t session_id, int64_t thread_id, boost::uuids::uuid invocation_uid, int32_t permits);
 
                 /**
                  * Returns the number of available permits.
                  */
-                ClientMessage HAZELCAST_API
-                semaphore_availablepermits_encode(const cp::raft_group_id &group_id, const std::string &name);
+                ClientMessage HAZELCAST_API semaphore_availablepermits_encode(const cp::raft_group_id &group_id, const std::string &name);
 
                 /**
                  * Returns true if the semaphore is JDK compatible
@@ -1733,33 +1489,29 @@ namespace hazelcast {
                  * be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
                  * to define when the value is outdated and thus should be removed from the replicated map.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_put_encode(const std::string &name, const serialization::pimpl::data &key,
-                                         const serialization::pimpl::data &value, int64_t ttl);
+                ClientMessage HAZELCAST_API replicatedmap_put_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t ttl);
 
                 /**
                  * Returns the number of key-value mappings in this map. If the map contains more than Integer.MAX_VALUE elements,
                  * returns Integer.MAX_VALUE.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API replicatedmap_size_encode(const std::string &name);
 
                 /**
                  * Return true if this map contains no key-value mappings
                  */
-                ClientMessage HAZELCAST_API replicatedmap_isempty_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API replicatedmap_isempty_encode(const std::string &name);
 
                 /**
                  * Returns true if this map contains a mapping for the specified key.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_containskey_encode(const std::string &name, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API replicatedmap_containskey_encode(const std::string &name, const serialization::pimpl::data &key);
 
                 /**
                  * Returns true if this map maps one or more keys to the specified value.
                  * This operation will probably require time linear in the map size for most implementations of the Map interface.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API replicatedmap_containsvalue_encode(const std::string &name, const serialization::pimpl::data &value);
 
                 /**
                  * Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
@@ -1767,8 +1519,7 @@ namespace hazelcast {
                  * necessarily indicate that the map contains no mapping for the key; it's also possible that the map
                  * explicitly maps the key to null.  The #containsKey operation may be used to distinguish these two cases.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_get_encode(const std::string &name, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API replicatedmap_get_encode(const std::string &name, const serialization::pimpl::data &key);
 
                 /**
                  * Removes the mapping for a key from this map if it is present (optional operation). Returns the value to which this map previously associated the key,
@@ -1776,8 +1527,7 @@ namespace hazelcast {
                  * null does not necessarily indicate that the map contained no mapping for the key; it's also possible that the map
                  * explicitly mapped the key to null. The map will not contain a mapping for the specified key once the call returns.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_remove_encode(const std::string &name, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API replicatedmap_remove_encode(const std::string &name, const serialization::pimpl::data &key);
 
                 /**
                  * Copies all of the mappings from the specified map to this map (optional operation). The effect of this call is
@@ -1785,8 +1535,7 @@ namespace hazelcast {
                  * v in the specified map. The behavior of this operation is undefined if the specified map is modified while the
                  * operation is in progress.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_putall_encode(const std::string &name,
-                                                                        const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries);
+                ClientMessage HAZELCAST_API replicatedmap_putall_encode(const std::string &name, const std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>> &entries);
 
                 /**
                  * The clear operation wipes data out of the replicated maps.It is the only synchronous remote operation in this
@@ -1794,46 +1543,36 @@ namespace hazelcast {
                  * it is retried for at most 3 times (on the failing nodes only). If it does not work after the third time, this
                  * method throws a OPERATION_TIMEOUT back to the caller.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_clear_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API replicatedmap_clear_encode(const std::string &name);
 
                 /**
                  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
                  * events filtered by the given predicate.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_addentrylistenertokeywithpredicate_encode(const std::string &name,
-                                                                        const serialization::pimpl::data &key,
-                                                                        const serialization::pimpl::data &predicate,
-                                                                        bool local_only);
+                ClientMessage HAZELCAST_API replicatedmap_addentrylistenertokeywithpredicate_encode(const std::string &name, const serialization::pimpl::data &key, const serialization::pimpl::data &predicate, bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addentrylistenertokeywithpredicate_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1841,38 +1580,30 @@ namespace hazelcast {
                  * Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
                  * events filtered by the given predicate.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_addentrylistenerwithpredicate_encode(const std::string &name,
-                                                                                               const serialization::pimpl::data &predicate,
-                                                                                               bool local_only);
+                ClientMessage HAZELCAST_API replicatedmap_addentrylistenerwithpredicate_encode(const std::string &name, const serialization::pimpl::data &predicate, bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addentrylistenerwithpredicate_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1880,75 +1611,60 @@ namespace hazelcast {
                  * Adds the specified entry listener for the specified key. The listener will be notified for all
                  * add/remove/update/evict events of the specified key only.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_addentrylistenertokey_encode(const std::string &name,
-                                                                                       const serialization::pimpl::data &key,
-                                                                                       bool local_only);
+                ClientMessage HAZELCAST_API replicatedmap_addentrylistenertokey_encode(const std::string &name, const serialization::pimpl::data &key, bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addentrylistenertokey_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
                 /**
                  * Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_addentrylistener_encode(const std::string &name, bool local_only);
+                ClientMessage HAZELCAST_API replicatedmap_addentrylistener_encode(const std::string &name, bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1956,8 +1672,7 @@ namespace hazelcast {
                  * Removes the specified entry listener. If there is no such listener added before, this call does no change in the
                  * cluster and returns false.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
+                ClientMessage HAZELCAST_API replicatedmap_removeentrylistener_encode(const std::string &name, boost::uuids::uuid registration_id);
 
                 /**
                  * Returns a lazy Set view of the key contained in this map. A LazySet is optimized for querying speed
@@ -1967,91 +1682,74 @@ namespace hazelcast {
                  * very poor performance if called repeatedly (for example, in a loop). If the use case is different from querying
                  * the data, please copy the resulting set into a new java.util.HashSet.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_keyset_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API replicatedmap_keyset_encode(const std::string &name);
 
                 /**
                  * Returns a lazy collection view of the values contained in this map.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_values_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API replicatedmap_values_encode(const std::string &name);
 
                 /**
                  * Gets a lazy set view of the mappings contained in this map.
                  */
-                ClientMessage HAZELCAST_API replicatedmap_entryset_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API replicatedmap_entryset_encode(const std::string &name);
 
                 /**
                  * Adds a near cache entry listener for this map. This listener will be notified when an entry is added/removed/updated/evicted/expired etc. so that the near cache entries can be invalidated.
                  */
-                ClientMessage HAZELCAST_API
-                replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value,
-                                                               bool local_only);
+                ClientMessage HAZELCAST_API replicatedmap_addnearcacheentrylistener_encode(const std::string &name, bool include_value, bool local_only);
 
                 struct HAZELCAST_API replicatedmap_addnearcacheentrylistener_handler : public impl::BaseEventHandler {
                     void handle(ClientMessage &msg);
-
                     /**
                      * @param key Key of the entry event.
                      * @param value Value of the entry event.
-                     * @param oldValue Old value of the entry event.
-                     * @param mergingValue Incoming merging value of the entry event.
-                     * @param eventType Type of the entry event. Possible values are
-                     *                  ADDED(1)
-                     *                  REMOVED(2)
-                     *                  UPDATED(4)
-                     *                  EVICTED(8)
-                     *                  EXPIRED(16)
-                     *                  EVICT_ALL(32)
-                     *                  CLEAR_ALL(64)
-                     *                  MERGED(128)
-                     *                  INVALIDATION(256)
-                     *                  LOADED(512)
+                     * @param old_value Old value of the entry event.
+                     * @param merging_value Incoming merging value of the entry event.
+                     * @param event_type Type of the entry event. Possible values are
+                     *                   ADDED(1)
+                     *                   REMOVED(2)
+                     *                   UPDATED(4)
+                     *                   EVICTED(8)
+                     *                   EXPIRED(16)
+                     *                   EVICT_ALL(32)
+                     *                   CLEAR_ALL(64)
+                     *                   MERGED(128)
+                     *                   INVALIDATION(256)
+                     *                   LOADED(512)
                      * @param uuid UUID of the member that dispatches the event.
-                     * @param numberOfAffectedEntries Number of entries affected by this event.
+                     * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key,
-                                              const boost::optional<serialization::pimpl::data> &value,
-                                              const boost::optional<serialization::pimpl::data> &old_value,
-                                              const boost::optional<serialization::pimpl::data> &merging_value,
-                                              int32_t event_type, boost::uuids::uuid uuid,
-                                              int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
                 /**
                  * Returns true if this map contains an entry for the specified key.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_containskey_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                    int64_t thread_id, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmap_containskey_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Returns the value for the specified key, or null if this map does not contain this key.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Returns the number of entries in this map.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalmap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Returns true if this map contains no entries.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalmap_isempty_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Associates the specified value with the specified key in this map. If the map previously contained a mapping for
                  * the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
                  * current transaction context till transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &key,
-                                            const serialization::pimpl::data &value, int64_t ttl);
+                ClientMessage HAZELCAST_API transactionalmap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value, int64_t ttl);
 
                 /**
                  * Associates the specified value with the specified key in this map. If the map previously contained a mapping for
@@ -2059,259 +1757,198 @@ namespace hazelcast {
                  * if the old value is not needed.
                  * The object to be set will be accessible only in the current transaction context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_set_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &key,
-                                            const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API transactionalmap_set_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value);
 
                 /**
                  * If the specified key is not already associated with a value, associate it with the given value.
                  * The object to be put will be accessible only in the current transaction context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_putifabsent_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                    int64_t thread_id, const serialization::pimpl::data &key,
-                                                    const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API transactionalmap_putifabsent_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value);
 
                 /**
                  * Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
                  * accessible only in the current transaction context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_replace_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                const serialization::pimpl::data &key,
-                                                const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API transactionalmap_replace_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value);
 
                 /**
                  * Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
                  * accessible only in the current transaction context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_replaceifsame_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                      int64_t thread_id, const serialization::pimpl::data &key,
-                                                      const serialization::pimpl::data &old_value,
-                                                      const serialization::pimpl::data &new_value);
+                ClientMessage HAZELCAST_API transactionalmap_replaceifsame_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &old_value, const serialization::pimpl::data &new_value);
 
                 /**
                  * Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the
                  * specified key once the call returns. The object to be removed will be accessible only in the current transaction
                  * context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the specified
                  * key once the call returns. This method is preferred to #remove(Object) if the old value is not needed. The object
                  * to be deleted will be removed from only the current transaction context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_delete_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmap_delete_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
                  * from only the current transaction context until the transaction is committed.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_removeifsame_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                     int64_t thread_id, const serialization::pimpl::data &key,
-                                                     const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API transactionalmap_removeifsame_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value);
 
                 /**
                  * Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
                  * are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
-                 * a query_result_size_exceeded if query result size limit is configured.
+                 * a QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalmap_keyset_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
                  * runs on all members in parallel.The set is NOT backed by the map, so changes to the map are NOT reflected in the
                  * set, and vice-versa. This method is always executed by a distributed query, so it may throw a
-                 * query_result_size_exceeded if query result size limit is configured.
+                 * QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_keysetwithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                            int64_t thread_id,
-                                                            const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API transactionalmap_keysetwithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &predicate);
 
                 /**
                  * Returns a collection clone of the values contained in this map. The collection is NOT backed by the map,
                  * so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
-                 * distributed query, so it may throw a query_result_size_exceeded if query result size limit is configured.
+                 * distributed query, so it may throw a QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalmap_values_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
                  * runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
                  * in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw
-                 * a query_result_size_exceeded if query result size limit is configured.
+                 * a QueryResultSizeExceededException if query result size limit is configured.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmap_valueswithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                            int64_t thread_id,
-                                                            const serialization::pimpl::data &predicate);
+                ClientMessage HAZELCAST_API transactionalmap_valueswithpredicate_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &predicate);
 
                 /**
                  * Stores a key-value pair in the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmultimap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                 const serialization::pimpl::data &key,
-                                                 const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API transactionalmultimap_put_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value);
 
                 /**
                  * Returns the collection of values associated with the key.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmultimap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                 const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmultimap_get_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Removes the given key value pair from the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmultimap_remove_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                    int64_t thread_id, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmultimap_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Removes all the entries associated with the given key.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmultimap_removeentry_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                         int64_t thread_id, const serialization::pimpl::data &key,
-                                                         const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API transactionalmultimap_removeentry_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key, const serialization::pimpl::data &value);
 
                 /**
                  * Returns the number of values matching the given key in the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmultimap_valuecount_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                        int64_t thread_id, const serialization::pimpl::data &key);
+                ClientMessage HAZELCAST_API transactionalmultimap_valuecount_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &key);
 
                 /**
                  * Returns the number of key-value pairs in the multimap.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id,
-                                                  int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalmultimap_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Add new item to transactional set.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalset_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                            const serialization::pimpl::data &item);
+                ClientMessage HAZELCAST_API transactionalset_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item);
 
                 /**
                  * Remove item from transactional set.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalset_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               const serialization::pimpl::data &item);
+                ClientMessage HAZELCAST_API transactionalset_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item);
 
                 /**
                  * Returns the size of the set.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalset_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Adds a new item to the transactional list.
                  */
-                ClientMessage HAZELCAST_API
-                transactionallist_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                             const serialization::pimpl::data &item);
+                ClientMessage HAZELCAST_API transactionallist_add_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item);
 
                 /**
                  * Remove item from the transactional list
                  */
-                ClientMessage HAZELCAST_API
-                transactionallist_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                const serialization::pimpl::data &item);
+                ClientMessage HAZELCAST_API transactionallist_remove_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item);
 
                 /**
                  * Returns the size of the list
                  */
-                ClientMessage HAZELCAST_API
-                transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionallist_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
                  * become available.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalqueue_offer_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                                const serialization::pimpl::data &item, int64_t timeout);
+                ClientMessage HAZELCAST_API transactionalqueue_offer_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, const serialization::pimpl::data &item, int64_t timeout);
 
                 /**
                  * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
                  * to become available.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id,
-                                               int64_t timeout);
+                ClientMessage HAZELCAST_API transactionalqueue_poll_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id, int64_t timeout);
 
                 /**
                  * Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
                  * elements, returns Integer.MAX_VALUE.
                  */
-                ClientMessage HAZELCAST_API
-                transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transactionalqueue_size_encode(const std::string &name, boost::uuids::uuid txn_id, int64_t thread_id);
 
                 /**
                  * Commits the transaction with the given id.
                  */
-                ClientMessage HAZELCAST_API
-                transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transaction_commit_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
 
                 /**
                  * Creates a transaction with the given parameters.
                  */
-                ClientMessage HAZELCAST_API
-                transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type,
-                                          int64_t thread_id);
+                ClientMessage HAZELCAST_API transaction_create_encode(int64_t timeout, int32_t durability, int32_t transaction_type, int64_t thread_id);
 
                 /**
                  * Rollbacks the transaction with the given id.
                  */
-                ClientMessage HAZELCAST_API
-                transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
+                ClientMessage HAZELCAST_API transaction_rollback_encode(boost::uuids::uuid transaction_id, int64_t thread_id);
 
                 /**
                  * Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
                  * head completed the first looparound the ring. This is because no items are getting retired.
                  */
-                ClientMessage HAZELCAST_API ringbuffer_size_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API ringbuffer_size_encode(const std::string &name);
 
                 /**
                  * Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
                  * The initial value of the tail is -1.
                  */
-                ClientMessage HAZELCAST_API ringbuffer_tailsequence_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API ringbuffer_tailsequence_encode(const std::string &name);
 
                 /**
                  * Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the ringbuffer
                  * are found. If the RingBuffer is empty, the head will be one more than the tail.
                  * The initial value of the head is 0 (1 more than tail).
                  */
-                ClientMessage HAZELCAST_API ringbuffer_headsequence_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API ringbuffer_headsequence_encode(const std::string &name);
 
                 /**
                  * Returns the capacity of this Ringbuffer.
                  */
-                ClientMessage HAZELCAST_API ringbuffer_capacity_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API ringbuffer_capacity_encode(const std::string &name);
 
                 /**
                  * Returns the remaining capacity of the ringbuffer. The returned value could be stale as soon as it is returned.
                  * If ttl is not set, the remaining capacity will always be the capacity.
                  */
-                ClientMessage HAZELCAST_API ringbuffer_remainingcapacity_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API ringbuffer_remainingcapacity_encode(const std::string &name);
 
                 /**
                  * Adds an item to the tail of the Ringbuffer. If there is space in the ringbuffer, the call
@@ -2326,8 +1963,7 @@ namespace hazelcast {
                  * this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
                  * to find that item.
                  */
-                ClientMessage HAZELCAST_API ringbuffer_add_encode(const std::string &name, int32_t overflow_policy,
-                                                                  const serialization::pimpl::data &value);
+                ClientMessage HAZELCAST_API ringbuffer_add_encode(const std::string &name, int32_t overflow_policy, const serialization::pimpl::data &value);
 
                 /**
                  * Reads one item from the Ringbuffer. If the sequence is one beyond the current tail, this call blocks until an
@@ -2335,7 +1971,7 @@ namespace hazelcast {
                  * readers or it can be read multiple times by the same reader. Currently it isn't possible to control how long this
                  * call is going to block. In the future we could add e.g. tryReadOne(long sequence, long timeout, TimeUnit unit).
                  */
-                ClientMessage HAZELCAST_API ringbuffer_readone_encode(const std::string  & name, int64_t sequence);
+                ClientMessage HAZELCAST_API ringbuffer_readone_encode(const std::string &name, int64_t sequence);
 
                 /**
                  * Adds all the items of a collection to the tail of the Ringbuffer. A addAll is likely to outperform multiple calls
@@ -2347,9 +1983,7 @@ namespace hazelcast {
                  * If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
                  * The result of the future contains the sequenceId of the last written item
                  */
-                ClientMessage HAZELCAST_API ringbuffer_addall_encode(const std::string &name,
-                                                                     const std::vector<serialization::pimpl::data> &value_list,
-                                                                     int32_t overflow_policy);
+                ClientMessage HAZELCAST_API ringbuffer_addall_encode(const std::string &name, const std::vector<serialization::pimpl::data> &value_list, int32_t overflow_policy);
 
                 /**
                  * Reads a batch of items from the Ringbuffer. If the number of available items after the first read item is smaller
@@ -2360,15 +1994,12 @@ namespace hazelcast {
                  * true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
                  * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
                  */
-                ClientMessage HAZELCAST_API
-                ringbuffer_readmany_encode(const std::string &name, int64_t start_sequence, int32_t min_count,
-                                           int32_t max_count, const serialization::pimpl::data *filter);
+                ClientMessage HAZELCAST_API ringbuffer_readmany_encode(const std::string &name, int64_t start_sequence, int32_t min_count, int32_t max_count, const serialization::pimpl::data *filter);
 
                 /**
                  * Fetches a new batch of ids for the given flake id generator.
                  */
-                ClientMessage HAZELCAST_API
-                flakeidgenerator_newidbatch_encode(const std::string &name, int32_t batch_size);
+                ClientMessage HAZELCAST_API flakeidgenerator_newidbatch_encode(const std::string &name, int32_t batch_size);
 
                 /**
                  * Query operation to retrieve the current value of the PNCounter.
@@ -2380,9 +2011,7 @@ namespace hazelcast {
                  * If smart routing is disabled, the actual member processing the client
                  * message may act as a proxy.
                  */
-                ClientMessage HAZELCAST_API pncounter_get_encode(const std::string &name,
-                                                                 const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
-                                                                 boost::uuids::uuid target_replica_uuid);
+                ClientMessage HAZELCAST_API pncounter_get_encode(const std::string &name, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d);
 
                 /**
                  * Adds a delta to the PNCounter value. The delta may be negative for a
@@ -2395,10 +2024,7 @@ namespace hazelcast {
                  * If smart routing is disabled, the actual member processing the client
                  * message may act as a proxy.
                  */
-                ClientMessage HAZELCAST_API
-                pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update,
-                                     const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps,
-                                     boost::uuids::uuid target_replica_uuid);
+                ClientMessage HAZELCAST_API pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d);
 
                 /**
                  * Returns the configured number of CRDT replicas for the PN counter with
@@ -2406,7 +2032,7 @@ namespace hazelcast {
                  * The actual replica count may be less, depending on the number of data
                  * members in the cluster (members that own data).
                  */
-                ClientMessage HAZELCAST_API pncounter_getconfiguredreplicacount_encode(const std::string  & name);
+                ClientMessage HAZELCAST_API pncounter_getconfiguredreplicacount_encode(const std::string &name);
 
                 /**
                  * Creates a new CP group with the given name
@@ -2417,28 +2043,23 @@ namespace hazelcast {
                  * Destroys the distributed object with the given name on the requested
                  * CP group
                  */
-                ClientMessage HAZELCAST_API
-                cpgroup_destroycpobject_encode(const cp::raft_group_id &group_id, const std::string &service_name,
-                                               const std::string &object_name);
+                ClientMessage HAZELCAST_API cpgroup_destroycpobject_encode(const cp::raft_group_id &group_id, const std::string &service_name, const std::string &object_name);
 
                 /**
                  * Creates a session for the caller on the given CP group.
                  */
-                ClientMessage HAZELCAST_API
-                cpsession_createsession_encode(const cp::raft_group_id &group_id, const std::string &endpoint_name);
+                ClientMessage HAZELCAST_API cpsession_createsession_encode(const cp::raft_group_id &group_id, const std::string &endpoint_name);
 
                 /**
                  * Closes the given session on the given CP group
                  */
-                ClientMessage HAZELCAST_API
-                cpsession_closesession_encode(const cp::raft_group_id &group_id, int64_t session_id);
+                ClientMessage HAZELCAST_API cpsession_closesession_encode(const cp::raft_group_id &group_id, int64_t session_id);
 
                 /**
                  * Commits a heartbeat for the given session on the given cP group and
                  * extends its session expiration time.
                  */
-                ClientMessage HAZELCAST_API
-                cpsession_heartbeatsession_encode(const cp::raft_group_id &group_id, int64_t session_id);
+                ClientMessage HAZELCAST_API cpsession_heartbeatsession_encode(const cp::raft_group_id &group_id, int64_t session_id);
 
                 /**
                  * Generates a new ID for the caller thread. The ID is unique in the given

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
@@ -48,13 +48,13 @@ namespace hazelcast {
                      * @param member_infos List of member infos  at the cluster associated with the given version
                      *                     params:
                     */
-                    virtual void handle_membersview(int32_t version, std::vector<member> const & member_infos) = 0;
+                    virtual void handle_membersview(int32_t version, std::vector<member> const &member_infos) = 0;
 
                     /**
                      * @param version Incremental state version of the partition table
                      * @param partitions The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
                     */
-                    virtual void handle_partitionsview(int32_t version, std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> const & partitions) = 0;
+                    virtual void handle_partitionsview(int32_t version, std::vector<std::pair<boost::uuids::uuid, std::vector<int>>> const &partitions) = 0;
 
                 };
 
@@ -417,7 +417,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -448,7 +448,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -479,7 +479,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -677,7 +677,7 @@ namespace hazelcast {
                      * @param partition_uuid UUID of the source partition that invalidated entry belongs to.
                      * @param sequence Sequence number of the invalidation event.
                     */
-                    virtual void handle_imapinvalidation( const boost::optional<serialization::pimpl::data> & key, boost::uuids::uuid source_uuid, boost::uuids::uuid partition_uuid, int64_t sequence) = 0;
+                    virtual void handle_imapinvalidation(const boost::optional<serialization::pimpl::data> &key, boost::uuids::uuid source_uuid, boost::uuids::uuid partition_uuid, int64_t sequence) = 0;
 
                     /**
                      * @param keys List of the keys of the invalidated entries.
@@ -685,7 +685,7 @@ namespace hazelcast {
                      * @param partition_uuids List of UUIDs of the source partitions that invalidated entries belong to.
                      * @param sequences List of sequence numbers of the invalidation events.
                     */
-                    virtual void handle_imapbatchinvalidation(std::vector<serialization::pimpl::data> const & keys, std::vector<boost::uuids::uuid> const & source_uuids, std::vector<boost::uuids::uuid> const & partition_uuids, std::vector<int64_t> const & sequences) = 0;
+                    virtual void handle_imapbatchinvalidation(std::vector<serialization::pimpl::data> const &keys, std::vector<boost::uuids::uuid> const &source_uuids, std::vector<boost::uuids::uuid> const &partition_uuids, std::vector<int64_t> const &sequences) = 0;
 
                 };
 
@@ -787,7 +787,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -817,7 +817,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -979,7 +979,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches this event.
                      * @param event_type Type of the event. It is either ADDED(1) or REMOVED(2).
                     */
-                    virtual void handle_item( const boost::optional<serialization::pimpl::data> & item, boost::uuids::uuid uuid, int32_t event_type) = 0;
+                    virtual void handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid, int32_t event_type) = 0;
 
                 };
 
@@ -1020,7 +1020,7 @@ namespace hazelcast {
                      * @param publish_time Time that the item is published to the topic.
                      * @param uuid UUID of the member that dispatches this event.
                     */
-                    virtual void handle_topic(serialization::pimpl::data const & item, int64_t publish_time, boost::uuids::uuid uuid) = 0;
+                    virtual void handle_topic(serialization::pimpl::data const &item, int64_t publish_time, boost::uuids::uuid uuid) = 0;
 
                 };
 
@@ -1101,7 +1101,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches this event.
                      * @param event_type Type of the event. It is either ADDED(1) or REMOVED(2).
                     */
-                    virtual void handle_item( const boost::optional<serialization::pimpl::data> & item, boost::uuids::uuid uuid, int32_t event_type) = 0;
+                    virtual void handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid, int32_t event_type) = 0;
 
                 };
 
@@ -1253,7 +1253,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches this event.
                      * @param event_type Type of the event. It is either ADDED(1) or REMOVED(2).
                     */
-                    virtual void handle_item( const boost::optional<serialization::pimpl::data> & item, boost::uuids::uuid uuid, int32_t event_type) = 0;
+                    virtual void handle_item(const boost::optional<serialization::pimpl::data> &item, boost::uuids::uuid uuid, int32_t event_type) = 0;
 
                 };
 
@@ -1324,7 +1324,7 @@ namespace hazelcast {
                 /**
                  * Cancels the task running on the member with the given address.
                  */
-                ClientMessage HAZELCAST_API executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_u_u_i_d, bool interrupt);
+                ClientMessage HAZELCAST_API executorservice_cancelonmember_encode(boost::uuids::uuid uuid, boost::uuids::uuid member_uuid, bool interrupt);
 
                 /**
                  * Submits the task to the member that owns the partition with the given id.
@@ -1334,7 +1334,7 @@ namespace hazelcast {
                 /**
                  * Submits the task to member specified by the address.
                  */
-                ClientMessage HAZELCAST_API executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable, boost::uuids::uuid member_u_u_i_d);
+                ClientMessage HAZELCAST_API executorservice_submittomember_encode(const std::string &name, boost::uuids::uuid uuid, const serialization::pimpl::data &callable, boost::uuids::uuid member_uuid);
 
                 /**
                  * Applies a function on the value, the actual stored value will not change
@@ -1572,7 +1572,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1603,7 +1603,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1634,7 +1634,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1664,7 +1664,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -1720,7 +1720,7 @@ namespace hazelcast {
                      * @param uuid UUID of the member that dispatches the event.
                      * @param number_of_affected_entries Number of entries affected by this event.
                     */
-                    virtual void handle_entry( const boost::optional<serialization::pimpl::data> & key,  const boost::optional<serialization::pimpl::data> & value,  const boost::optional<serialization::pimpl::data> & old_value,  const boost::optional<serialization::pimpl::data> & merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
+                    virtual void handle_entry(const boost::optional<serialization::pimpl::data> &key, const boost::optional<serialization::pimpl::data> &value, const boost::optional<serialization::pimpl::data> &old_value, const boost::optional<serialization::pimpl::data> &merging_value, int32_t event_type, boost::uuids::uuid uuid, int32_t number_of_affected_entries) = 0;
 
                 };
 
@@ -2011,7 +2011,7 @@ namespace hazelcast {
                  * If smart routing is disabled, the actual member processing the client
                  * message may act as a proxy.
                  */
-                ClientMessage HAZELCAST_API pncounter_get_encode(const std::string &name, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d);
+                ClientMessage HAZELCAST_API pncounter_get_encode(const std::string &name, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_uuid);
 
                 /**
                  * Adds a delta to the PNCounter value. The delta may be negative for a
@@ -2024,7 +2024,7 @@ namespace hazelcast {
                  * If smart routing is disabled, the actual member processing the client
                  * message may act as a proxy.
                  */
-                ClientMessage HAZELCAST_API pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_u_u_i_d);
+                ClientMessage HAZELCAST_API pncounter_add_encode(const std::string &name, int64_t delta, bool get_before_update, const std::vector<std::pair<boost::uuids::uuid, int64_t>> &replica_timestamps, boost::uuids::uuid target_replica_uuid);
 
                 /**
                  * Returns the configured number of CRDT replicas for the PN counter with


### PR DESCRIPTION
The codec files include manual changes that are not reflected in the hazelcast-client-protocol repo. This PR regenerates codecs from https://github.com/hazelcast/hazelcast-client-protocol/pull/410 to make the codecs same with generated.