### PR TITLE
Hide to_objects without future parameter

### DIFF
--- a/hazelcast/include/hazelcast/client/entry_view.h
+++ b/hazelcast/include/hazelcast/client/entry_view.h
@@ -32,17 +32,27 @@ template<typename K, typename V>
 class entry_view
 {
 public:
-    entry_view(K key, V value, map::data_entry_view rhs)
+    entry_view(K key,
+               V value,
+               int64_t cost,
+               int64_t creationTime,
+               int64_t expirationTime,
+               int64_t hits,
+               int64_t lastAccessTime,
+               int64_t lastStoredTime,
+               int64_t lastUpdateTime,
+               int64_t version)
       : key(std::move(key))
       , value(std::move(value))
-      , cost(rhs.get_cost())
-      , creation_time(rhs.get_creation_time())
-      , expiration_time(rhs.get_expiration_time())
-      , hits(rhs.get_hits())
-      , last_access_time(rhs.get_last_access_time())
-      , last_stored_time(rhs.get_last_stored_time())
-      , last_update_time(rhs.get_last_update_time())
-      , version(rhs.get_version()){};
+      , cost(cost)
+      , creation_time(creationTime)
+      , expiration_time(expirationTime)
+      , hits(hits)
+      , last_access_time(lastAccessTime)
+      , last_stored_time(lastStoredTime)
+      , last_update_time(lastUpdateTime)
+      , version(version)
+    {}
 
     /**
      * key

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -738,7 +738,7 @@ public:
       query::paging_predicate<K, V>& predicate)
     {
         predicate.set_iteration_type(query::iteration_type::KEY);
-        auto futures =
+        auto future =
           key_set_for_paging_predicate_data(
             protocol::codec::holder::paging_predicate_holder::of(
               predicate, serialization_service_))
@@ -751,7 +751,7 @@ public:
                   predicate.set_anchor_data_list(std::move(result.second));
                   return result.first;
               });
-        return to_object_vector<K>(std::move(futures));
+        return to_object_vector<K>(std::move(future));
     }
 
     /**
@@ -803,7 +803,7 @@ public:
       query::paging_predicate<K, V>& predicate)
     {
         predicate.set_iteration_type(query::iteration_type::VALUE);
-        auto futures =
+        auto future =
           values_for_paging_predicate_data(
             protocol::codec::holder::paging_predicate_holder::of(
               predicate, serialization_service_))
@@ -816,7 +816,7 @@ public:
                   predicate.set_anchor_data_list(std::move(result.second));
                   return result.first;
               });
-        return to_object_vector<V>(std::move(futures));
+        return to_object_vector<V>(std::move(future));
     }
 
     /**
@@ -869,7 +869,7 @@ public:
       query::paging_predicate<K, V>& predicate)
     {
         predicate.set_iteration_type(query::iteration_type::ENTRY);
-        auto futures =
+        auto future =
           entry_set_for_paging_predicate_data(
             protocol::codec::holder::paging_predicate_holder::of(
               predicate, serialization_service_))
@@ -882,7 +882,7 @@ public:
                   predicate.set_anchor_data_list(std::move(result.second));
                   return result.first;
               });
-        return to_entry_object_vector<K, V>(std::move(futures));
+        return to_entry_object_vector<K, V>(std::move(future));
     }
 
     /**

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -634,7 +634,7 @@ public:
       const K& key)
     {
         auto f = proxy::IMapImpl::get_entry_view_data(to_data(key));
-        return to_object_entry_view<K, V>(std::move(f), std::move(key));
+        return to_object_entry_view<K, V>(std::move(f));
     }
 
     /**

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -31,7 +31,6 @@
 #include "hazelcast/client/proxy/IMapImpl.h"
 #include "hazelcast/client/impl/EntryEventHandler.h"
 #include "hazelcast/client/entry_listener.h"
-#include "hazelcast/client/entry_view.h"
 #include "hazelcast/client/serialization/serialization.h"
 #include "hazelcast/util/exception_util.h"
 #include "hazelcast/client/protocol/codec/codecs.h"
@@ -634,16 +633,8 @@ public:
     boost::future<boost::optional<entry_view<K, V>>> get_entry_view(
       const K& key)
     {
-        return proxy::IMapImpl::get_entry_view_data(to_data(key))
-          .then([=](boost::future<boost::optional<map::data_entry_view>> f) {
-              auto dataView = f.get();
-              if (!dataView) {
-                  return boost::optional<entry_view<K, V>>();
-              }
-              auto v = to_object<V>(dataView->get_value());
-              return boost::make_optional(entry_view<K, V>(
-                key, std::move(v).value(), *std::move(dataView)));
-          });
+        return to_object_entry_view<K, V>(
+          proxy::IMapImpl::get_entry_view_data(to_data(key)), key);
     }
 
     /**
@@ -692,23 +683,7 @@ public:
             futures.push_back(get_all_internal(entry.first, entry.second));
         }
 
-        return boost::when_all(futures.begin(), futures.end())
-          .then(
-            boost::launch::sync,
-            [=](boost::future<boost::csbl::vector<boost::future<EntryVector>>>
-                  results_data) {
-                std::unordered_map<K, V> result;
-                for (auto& entryVectorFuture : results_data.get()) {
-                    for (auto& entry : entryVectorFuture.get()) {
-                        auto val = to_object<V>(entry.second);
-                        // it is guaranteed that all values are non-null
-                        assert(val.has_value());
-                        result.emplace(to_object<K>(entry.first).value(),
-                                       std::move(val.value()));
-                    }
-                }
-                return result;
-            });
+        return to_object_map<K, V>(futures);
     }
 
     /**
@@ -763,23 +738,20 @@ public:
       query::paging_predicate<K, V>& predicate)
     {
         predicate.set_iteration_type(query::iteration_type::KEY);
-        return key_set_for_paging_predicate_data(
-                 protocol::codec::holder::paging_predicate_holder::of(
-                   predicate, serialization_service_))
-          .then(
-            [=, &predicate](
-              boost::future<std::pair<std::vector<serialization::pimpl::data>,
-                                      query::anchor_data_list>> f) {
-                auto result = f.get();
-                predicate.set_anchor_data_list(std::move(result.second));
-                const auto& entries = result.first;
-                std::vector<K> values;
-                values.reserve(entries.size());
-                for (const auto& e : entries) {
-                    values.emplace_back(*to_object<K>(e));
-                }
-                return values;
-            });
+        auto futures =
+          key_set_for_paging_predicate_data(
+            protocol::codec::holder::paging_predicate_holder::of(
+              predicate, serialization_service_))
+            .then(
+              boost::launch::sync,
+              [&predicate](
+                boost::future<std::pair<std::vector<serialization::pimpl::data>,
+                                        query::anchor_data_list>> f) {
+                  auto result = f.get();
+                  predicate.set_anchor_data_list(std::move(result.second));
+                  return result.first;
+              });
+        return to_object_vector<K>(std::move(futures));
     }
 
     /**
@@ -831,23 +803,20 @@ public:
       query::paging_predicate<K, V>& predicate)
     {
         predicate.set_iteration_type(query::iteration_type::VALUE);
-        return values_for_paging_predicate_data(
-                 protocol::codec::holder::paging_predicate_holder::of(
-                   predicate, serialization_service_))
-          .then(
-            [=, &predicate](
-              boost::future<std::pair<std::vector<serialization::pimpl::data>,
-                                      query::anchor_data_list>> f) {
-                auto result = f.get();
-                predicate.set_anchor_data_list(std::move(result.second));
-                const auto& entries = result.first;
-                std::vector<V> values;
-                values.reserve(entries.size());
-                for (const auto& e : entries) {
-                    values.emplace_back(*to_object<V>(e));
-                }
-                return values;
-            });
+        auto futures =
+          values_for_paging_predicate_data(
+            protocol::codec::holder::paging_predicate_holder::of(
+              predicate, serialization_service_))
+            .then(
+              boost::launch::sync,
+              [&predicate](
+                boost::future<std::pair<std::vector<serialization::pimpl::data>,
+                                        query::anchor_data_list>> f) {
+                  auto result = f.get();
+                  predicate.set_anchor_data_list(std::move(result.second));
+                  return result.first;
+              });
+        return to_object_vector<V>(std::move(futures));
     }
 
     /**
@@ -900,23 +869,20 @@ public:
       query::paging_predicate<K, V>& predicate)
     {
         predicate.set_iteration_type(query::iteration_type::ENTRY);
-        return entry_set_for_paging_predicate_data(
-                 protocol::codec::holder::paging_predicate_holder::of(
-                   predicate, serialization_service_))
-          .then([=, &predicate](
-                  boost::future<std::pair<EntryVector, query::anchor_data_list>>
-                    f) {
-              auto result = f.get();
-              predicate.set_anchor_data_list(std::move(result.second));
-              const auto& entries_data = result.first;
-              std::vector<std::pair<K, V>> entries;
-              entries.reserve(entries_data.size());
-              for (const auto& e : entries_data) {
-                  entries.emplace_back(*to_object<K>(e.first),
-                                       *to_object<V>(e.second));
-              }
-              return entries;
-          });
+        auto futures =
+          entry_set_for_paging_predicate_data(
+            protocol::codec::holder::paging_predicate_holder::of(
+              predicate, serialization_service_))
+            .then(
+              boost::launch::sync,
+              [&predicate](
+                boost::future<std::pair<EntryVector, query::anchor_data_list>>
+                  f) {
+                  auto result = f.get();
+                  predicate.set_anchor_data_list(std::move(result.second));
+                  return result.first;
+              });
+        return to_entry_object_vector<K, V>(std::move(futures));
     }
 
     /**

--- a/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
@@ -127,7 +127,7 @@ protected:
            this](boost::future<std::vector<serialization::pimpl::data>> f) {
               auto datas = f.get();
               auto size = datas.size();
-              elements.reserve(size);
+              elements.reserve(elements.size() + size);
               for (auto& data : datas) {
                   elements.push_back(to_object<T>(data).value());
               }

--- a/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
@@ -274,19 +274,26 @@ protected:
     template<typename K, typename V>
     inline boost::future<boost::optional<entry_view<K, V>>>
     to_object_entry_view(
-      boost::future<boost::optional<map::data_entry_view>> data_future,
-      K key)
+      boost::future<boost::optional<map::data_entry_view>> data_future)
     {
         return data_future.then(
           boost::launch::sync,
-          [this, key](boost::future<boost::optional<map::data_entry_view>> f) {
+          [this](boost::future<boost::optional<map::data_entry_view>> f) {
               auto dataView = f.get();
               if (!dataView) {
                   return boost::optional<entry_view<K, V>>();
               }
-              auto v = to_object<V>(dataView->get_value());
-              return boost::make_optional(entry_view<K, V>(
-                key, std::move(v).value(), *std::move(dataView)));
+              return boost::make_optional(
+                entry_view<K, V>(to_object<K>(dataView->get_key()).value(),
+                                 to_object<V>(dataView->get_value()).value(),
+                                 dataView->get_cost(),
+                                 dataView->get_creation_time(),
+                                 dataView->get_expiration_time(),
+                                 dataView->get_hits(),
+                                 dataView->get_last_access_time(),
+                                 dataView->get_last_stored_time(),
+                                 dataView->get_last_update_time(),
+                                 dataView->get_version()));
           });
     }
 

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -738,6 +738,18 @@ TEST_F(ClientQueueTest, testDrain)
     ASSERT_EQ("item1", list2[0]);
     ASSERT_EQ("item2", list2[1]);
     ASSERT_EQ("item3", list2[2]);
+
+    offer(2);
+    // drain to a non-empty vector
+    result = q->drain_to(list2).get();
+    ASSERT_EQ(2U, result);
+    // existing items
+    ASSERT_EQ("item1", list2[0]);
+    ASSERT_EQ("item2", list2[1]);
+    ASSERT_EQ("item3", list2[2]);
+    // new drained items
+    ASSERT_EQ("item1", list2[3]);
+    ASSERT_EQ("item2", list2[4]);
 }
 
 TEST_F(ClientQueueTest, testToArray)


### PR DESCRIPTION
This is the prepartion pr for compact.
We will have special kind of handling on the future continuations
for compact schemas. to_object without a future should not be
called from any proxy.