### PR TITLE
[API-604] Add generated SQL encoders, implement query_id and its encoder.

### DIFF
--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp
@@ -5716,6 +5716,77 @@ cpsession_generatethreadid_encode(const cp::raft_group_id& group_id)
     return msg;
 }
 
+ClientMessage
+sql_close_encode(const sql::impl::query_id& query_id)
+{
+    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN;
+    ClientMessage msg(initial_frame_size);
+    msg.set_retryable(false);
+    msg.set_operation_name("sql.close");
+
+    msg.set_message_type(static_cast<int32_t>(2163456));
+    msg.set_partition_id(-1);
+
+    msg.set(query_id, true);
+
+    return msg;
+}
+
+ClientMessage
+sql_execute_encode(const std::string& sql,
+                   const std::vector<serialization::pimpl::data>& parameters,
+                   int64_t timeout_millis,
+                   int32_t cursor_buffer_size,
+                   const std::string* schema,
+                   byte expected_result_type,
+                   const sql::impl::query_id& query_id,
+                   bool skip_update_statistics)
+{
+    size_t initial_frame_size =
+      ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT64_SIZE +
+      ClientMessage::INT32_SIZE + ClientMessage::UINT8_SIZE +
+      ClientMessage::UINT8_SIZE;
+    ClientMessage msg(initial_frame_size);
+    msg.set_retryable(false);
+    msg.set_operation_name("sql.execute");
+
+    msg.set_message_type(static_cast<int32_t>(2163712));
+    msg.set_partition_id(-1);
+
+    msg.set(timeout_millis);
+    msg.set(cursor_buffer_size);
+    msg.set(expected_result_type);
+    msg.set(skip_update_statistics);
+    msg.set(sql);
+
+    msg.set(parameters);
+
+    msg.set_nullable(schema);
+
+    msg.set(query_id, true);
+
+    return msg;
+}
+
+ClientMessage
+sql_fetch_encode(const sql::impl::query_id& query_id,
+                 int32_t cursor_buffer_size)
+{
+    size_t initial_frame_size =
+      ClientMessage::REQUEST_HEADER_LEN + ClientMessage::INT32_SIZE;
+    ClientMessage msg(initial_frame_size);
+    msg.set_retryable(false);
+    msg.set_operation_name("sql.fetch");
+
+    msg.set_message_type(static_cast<int32_t>(2163968));
+    msg.set_partition_id(-1);
+
+    msg.set(cursor_buffer_size);
+    msg.set(query_id, true);
+
+    return msg;
+}
+
 } // namespace codec
 } // namespace protocol
 } // namespace client

--- a/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
+++ b/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.h
@@ -3053,6 +3053,32 @@ cpsession_heartbeatsession_encode(const cp::raft_group_id& group_id,
 ClientMessage HAZELCAST_API
 cpsession_generatethreadid_encode(const cp::raft_group_id& group_id);
 
+/**
+ * Closes server-side query cursor.
+ */
+ClientMessage HAZELCAST_API
+sql_close_encode(const sql::impl::query_id& query_id);
+
+/**
+ * Starts execution of an SQL query (as of 4.2).
+ */
+ClientMessage HAZELCAST_API
+sql_execute_encode(const std::string& sql,
+                   const std::vector<serialization::pimpl::data>& parameters,
+                   int64_t timeout_millis,
+                   int32_t cursor_buffer_size,
+                   const std::string* schema,
+                   byte expected_result_type,
+                   const sql::impl::query_id& query_id,
+                   bool skip_update_statistics);
+
+/**
+ * Fetches the next row page.
+ */
+ClientMessage HAZELCAST_API
+sql_fetch_encode(const sql::impl::query_id& query_id,
+                 int32_t cursor_buffer_size);
+
 } // namespace codec
 } // namespace protocol
 } // namespace client

--- a/hazelcast/include/hazelcast/client/sql/impl/query_id.h
+++ b/hazelcast/include/hazelcast/client/sql/impl/query_id.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace hazelcast {
+namespace client {
+namespace sql {
+namespace impl {
+
+class query_id
+{
+public:
+    query_id(int64_t member_id_high,
+             int64_t member_id_low,
+             int64_t local_id_high,
+             int64_t local_id_low);
+
+    int64_t member_id_high() const;
+    int64_t member_id_low() const;
+    int64_t local_id_high() const;
+    int64_t local_id_low() const;
+
+private:
+    int64_t member_id_high_;
+    int64_t member_id_low_;
+    int64_t local_id_high_;
+    int64_t local_id_low_;
+};
+
+} // namespace impl
+} // namespace sql
+} // namespace client
+} // namespace hazelcast

--- a/hazelcast/include/hazelcast/client/sql/impl/query_id.h
+++ b/hazelcast/include/hazelcast/client/sql/impl/query_id.h
@@ -17,12 +17,14 @@
 
 #include <cstdint>
 
+#include "hazelcast/util/export.h"
+
 namespace hazelcast {
 namespace client {
 namespace sql {
 namespace impl {
 
-class query_id
+class HAZELCAST_API query_id
 {
 public:
     query_id(int64_t member_id_high,

--- a/hazelcast/src/hazelcast/client/sql.cpp
+++ b/hazelcast/src/hazelcast/client/sql.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hazelcast/client/sql/impl/query_id.h"
+
+namespace hazelcast {
+namespace client {
+namespace sql {
+namespace impl {
+
+query_id::query_id(int64_t member_id_high,
+                           int64_t member_id_low,
+                           int64_t local_id_high,
+                           int64_t local_id_low)
+  : member_id_high_{ member_id_high }
+  , member_id_low_{ member_id_low }
+  , local_id_high_{ local_id_high }
+  , local_id_low_{ local_id_low }
+{}
+
+int64_t
+query_id::member_id_high() const
+{
+    return member_id_high_;
+}
+
+int64_t
+query_id::member_id_low() const
+{
+    return member_id_low_;
+}
+
+int64_t
+query_id::local_id_high() const
+{
+    return local_id_high_;
+}
+
+int64_t
+query_id::local_id_low() const
+{
+    return local_id_low_;
+}
+
+} // namespace impl
+} // namespace sql
+} // namespace client
+} // namespace hazelcast

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2005,6 +2005,29 @@ TEST(ClientMessageTest, testFragmentedMessageHandling)
     }
 }
 
+TEST(ClientMessageTest, test_encode_sql_query_id)
+{
+    // TODO this test can be removed once the query_id encoder is generated.
+
+    protocol::ClientMessage msg;
+
+    msg.set(sql::impl::query_id{ -1LL, 1000000000000LL, 0LL, -42LL });
+
+    const std::vector<unsigned char> expected_bytes{
+        6,   0,   0,   0,   0,   16,  38,  0, 0,  0,   0,   0,   255,
+        255, 255, 255, 255, 255, 255, 255, 0, 16, 165, 212, 232, 0,
+        0,   0,   0,   0,   0,   0,   0,   0, 0,  0,   214, 255, 255,
+        255, 255, 255, 255, 255, 6,   0,   0, 0,  0,   8
+    };
+
+    std::vector<unsigned char> actual_bytes;
+    for (const auto& piece : msg.get_buffer()) {
+        actual_bytes.insert(actual_bytes.end(), piece.begin(), piece.end());
+    }
+
+    EXPECT_EQ(expected_bytes, actual_bytes);
+}
+
 } // namespace test
 } // namespace client
 } // namespace hazelcast


### PR DESCRIPTION
1. Adds generated sql_close_encode,  sql_execute_encode, and sql_fetch_encode
2. Adds `sql::impl::query_id`
3. Adds `ClientMessage::set(sql::impl::query_id)`

Related protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/411