### PR TITLE
Make sure that the logger static lock mutex is not destroyed before any global client instance

### DIFF
--- a/hazelcast/include/hazelcast/logger.h
+++ b/hazelcast/include/hazelcast/logger.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <functional>
 #include <limits>
+#include <mutex>
 
 #include "hazelcast/util/export.h"
 

--- a/hazelcast/include/hazelcast/logger.h
+++ b/hazelcast/include/hazelcast/logger.h
@@ -52,6 +52,7 @@ private:
     const std::string cluster_name_;
     const level level_;
     const handler_type handler_;
+    static std::mutex cout_lock_;
 };
 
 enum class logger::level : int

--- a/hazelcast/src/hazelcast/logger.cpp
+++ b/hazelcast/src/hazelcast/logger.cpp
@@ -16,7 +16,6 @@
 
 #include <iomanip>
 #include <iostream>
-#include <mutex>
 #include <sstream>
 #include <chrono>
 #include <ctime>

--- a/hazelcast/src/hazelcast/logger.cpp
+++ b/hazelcast/src/hazelcast/logger.cpp
@@ -96,6 +96,8 @@ time_t_to_localtime(const std::time_t& t)
 
 } // namespace
 
+std::mutex logger::cout_lock_;
+
 void
 logger::default_handler(const std::string& instance_name,
                         const std::string& cluster_name,
@@ -124,8 +126,7 @@ logger::default_handler(const std::string& instance_name,
           << '\n';
 
     {
-        static std::mutex cout_lock;
-        std::lock_guard<std::mutex> g(cout_lock);
+        std::lock_guard<std::mutex> g(cout_lock_);
         std::cout << sstrm.str() << std::flush;
     }
 }


### PR DESCRIPTION
Changed the logger lock mutex so that we can control its destruction order properly. We do not want it destroyed before the client is destructed. We need to control the order. static initialization and destruction order is not controllable if it is not a member of the logger class. It can be destroyed before the any global client instance is destroyed since global variables are also in static duration (https://www.learncpp.com/cpp-tutorial/introduction-to-global-variables).

See the related issue for a reproducer of the problem. Unfortunately, I could not write a unit test for it since i needed global variable and static variable destruction which would require a separate test binary. Hence, i tests manually using the test code in the issue.

fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/976