### PR TITLE
[API-1362] Do not interleave async_write calls 

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -90,54 +90,45 @@ namespace hazelcast {
                                     const std::shared_ptr<spi::impl::ClientInvocation> invocation) override {
                         check_connection(connection, invocation);
                         auto message = invocation->get_client_message();
-                        socket_strand_.post([=]() {
+                        socket_strand_.post([connection, invocation, message, this]() {
                             if (!check_connection(connection, invocation)) {
                                 return;
                             }
 
                             bool success;
                             int64_t message_call_id;
-                            do {
-                                auto call_id = ++call_id_counter_;
-                                struct correlation_id {
-                                    int32_t connnection_id;
-                                    int32_t call_id;
-                                };
-                                union {
-                                    int64_t id;
-                                    correlation_id composed_id;
-                                } c_id_union;
-                                c_id_union.composed_id = {connection->get_connection_id(), call_id};
-                                message_call_id = c_id_union.id;
-                                message->set_correlation_id(c_id_union.id);
-                                success = connection->invocations.insert({message_call_id, invocation}).second;
-                            } while (!success);
-
-                            auto handler = [=](const boost::system::error_code &ec,
-                                               std::size_t bytes_written) {
-                                if (ec) {
-                                    auto message = (boost::format{
-                                            "Error %1% during invocation write for %2% on connection %3%"} %
-                                                    ec % *invocation % *connection).str();
-                                    connection->close(message);
-                                } else {
-                                    // update the connection write time
-                                    connection->last_write_time(std::chrono::steady_clock::now());
-                                }
+                            auto call_id = ++call_id_counter_;
+                            struct correlation_id {
+                                int32_t connnection_id;
+                                int32_t call_id;
                             };
+                            union {
+                                int64_t id;
+                                correlation_id composed_id;
+                            } c_id_union;
+                            c_id_union.composed_id = {connection->get_connection_id(), call_id};
+                            message_call_id = c_id_union.id;
+                            success = connection->invocations.insert({message_call_id, invocation}).second;
+                            if (success) {
+                                message->set_correlation_id(c_id_union.id);
+                            }
+
+                            //message->print_frame_sizes();
 
                             auto &datas = message->get_buffer();
-                            if (datas.size() == 1) {
-                                boost::asio::async_write(socket_, boost::asio::buffer(datas[0]),
-                                                         socket_strand_.wrap(handler));
-                            } else {
-                                std::vector<boost::asio::const_buffer> buffers;
-                                buffers.reserve(datas.size());
-                                for (auto &d : datas) {
-                                    buffers.push_back(boost::asio::buffer(d));
-                                }
-                                boost::asio::async_write(socket_, buffers, socket_strand_.wrap(handler));
+                            std::vector<boost::asio::const_buffer> buffers;
+                            buffers.reserve(datas.size());
+                            for (const auto &data : datas) {
+                                buffers.push_back(boost::asio::buffer(data));
                             }
+                            this->outbox_.push_back(buffers);
+
+                            if (this->outbox_.size() > 1) {
+                                // async write is in progress
+                                return;
+                            }
+
+                            do_write(connection, invocation);
                         });
                     }
 
@@ -226,10 +217,36 @@ namespace hazelcast {
                                                 }));
                     }
 
+                    void do_write(const std::shared_ptr<connection::Connection> connection,
+                               const std::shared_ptr<spi::impl::ClientInvocation> invocation) {
+                        auto handler = [connection, invocation, this](const boost::system::error_code &ec,
+                                                                      std::size_t bytes_written) {
+                            this->outbox_.pop_front();
+
+                            if (ec) {
+                                auto message = (boost::format{
+                                        "Error %1% during invocation write for %2% on connection %3%"} %
+                                                ec % *invocation % *connection).str();
+                                connection->close(message);
+                            } else {
+                                // update the connection write time
+                                connection->last_write_time(std::chrono::steady_clock::now());
+
+                                if (!this->outbox_.empty()) {
+                                    do_write(connection, invocation);
+                                }
+                            }
+                        };
+
+                        const auto &message = outbox_[0];
+
+                        boost::asio::async_write(socket_, message, socket_strand_.wrap(handler));
+                    }
+
                     virtual void post_connect() {
                     }
 
-                    bool check_connection(const std::shared_ptr<connection::Connection> &connection,
+                    static bool check_connection(const std::shared_ptr<connection::Connection> &connection,
                                           const std::shared_ptr<spi::impl::ClientInvocation> &invocation) {
                         if (!connection->is_alive()) {
                             invocation->notify_exception(
@@ -251,6 +268,8 @@ namespace hazelcast {
                     boost::asio::ip::tcp::resolver &resolver_;
                     T socket_;
                     int32_t call_id_counter_{0};
+                    typedef std::deque<std::vector<boost::asio::const_buffer>> Outbox;
+                    Outbox outbox_;
                 };
             }
         }

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
@@ -1020,8 +1020,8 @@ namespace hazelcast {
                 std::string operation_name_;
 
                 std::vector<std::vector<byte>> data_buffer_;
-                size_t buffer_index_;
-                size_t offset_;
+                size_t buffer_index_ {0};
+                size_t offset_ {0};
             };
 
             template<>

--- a/hazelcast/test/src/HazelcastTests1.cpp
+++ b/hazelcast/test/src/HazelcastTests1.cpp
@@ -2747,9 +2747,9 @@ namespace hazelcast {
 
                 std::array<boost::future<void>, n> futures;
                 for (int i = 0; i < n; i++) {
-                    futures[i] = boost::async(std::packaged_task<void()>([&]() {
-                        std::string key = std::to_string(hazelcast::util::get_current_thread_id());
-                        std::string key2 = key + "2";
+                    futures[i] = boost::async([&mm, this, i]() {
+                        std::string key = std::to_string(i);
+                        std::string key2 = key + "-2";
                         client_.get_multi_map("testPutGetRemove").get()->put(key, "value").get();
                         transaction_context context = client_.new_transaction_context();
                         context.begin_transaction().get();
@@ -2768,7 +2768,7 @@ namespace hazelcast {
                         context.commit_transaction().get();
 
                         ASSERT_EQ(3, (int) (mm->get<std::string, std::string>(key).get().size()));
-                    }));
+                    });
                 }
 
                 boost::wait_for_all(futures.begin(), futures.end());


### PR DESCRIPTION
Fixes the async io write logic. We need to have only one outstanding async_write operation for a single socket. Failing to do this causes interleaving the write requests and causing corrupt messages at the server side. See [this discussion](https://itecnote.com/tecnote/c-boost-asio-async_write-how-to-not-interleaving-async_write-calls/) The write requests needs to be queued and consumed either on the async_write callback handler or directly on write requests if no outstanding write is in progress.

fixes #980 
