### PR TITLE
[Backport] Update the test server version to update the server letsencrypt certificate 

### DIFF
--- a/hazelcast/test/resources/hazelcast-cp-sessionless-semaphore.xml
+++ b/hazelcast/test/resources/hazelcast-cp-sessionless-semaphore.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>sessionless-semaphore</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-cp.xml
+++ b/hazelcast/test/resources/hazelcast-cp.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>cp-test</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-default-ca.xml
+++ b/hazelcast/test/resources/hazelcast-default-ca.xml
@@ -1,7 +1,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>ssl-dev</cluster-name>
 
     <network>

--- a/hazelcast/test/resources/hazelcast-lite-member.xml
+++ b/hazelcast/test/resources/hazelcast-lite-member.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>lite-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-ma-optional.xml
+++ b/hazelcast/test/resources/hazelcast-ma-optional.xml
@@ -1,7 +1,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>ssl-dev</cluster-name>
     <network>
         <ssl enabled="true">

--- a/hazelcast/test/resources/hazelcast-ma-required.xml
+++ b/hazelcast/test/resources/hazelcast-ma-required.xml
@@ -1,7 +1,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>ssl-dev</cluster-name>
     <network>
         <ssl enabled="true">

--- a/hazelcast/test/resources/hazelcast-pncounter-consistency-lost-test.xml
+++ b/hazelcast/test/resources/hazelcast-pncounter-consistency-lost-test.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>consistency-lost-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-serialization-little-endian.xml
+++ b/hazelcast/test/resources/hazelcast-serialization-little-endian.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>little-endian-cluster</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-ssl-server1.xml
+++ b/hazelcast/test/resources/hazelcast-ssl-server1.xml
@@ -1,7 +1,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>ssl-dev</cluster-name>
 
     <network>

--- a/hazelcast/test/resources/hazelcast-ssl.xml
+++ b/hazelcast/test/resources/hazelcast-ssl.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>ssl-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-test-executor.xml
+++ b/hazelcast/test/resources/hazelcast-test-executor.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>executor-test</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-token-credentials.xml
+++ b/hazelcast/test/resources/hazelcast-token-credentials.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>token-credentials-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-username-password.xml
+++ b/hazelcast/test/resources/hazelcast-username-password.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>username-pass-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast.xml
+++ b/hazelcast/test/resources/hazelcast.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>dev</cluster-name>
 

--- a/hazelcast/test/resources/hot-restart.xml
+++ b/hazelcast/test/resources/hot-restart.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>hot-restart-test</cluster-name>
 
     <hot-restart-persistence enabled="true">

--- a/hazelcast/test/resources/replicated-map-binary-in-memory-config-hazelcast.xml
+++ b/hazelcast/test/resources/replicated-map-binary-in-memory-config-hazelcast.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>replicated-map-binary-test</cluster-name>
 
     <replicatedmap name="default">

--- a/hazelcast/test/resources/short-heartbeat.xml
+++ b/hazelcast/test/resources/short-heartbeat.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>short-heartbeat-cluster</cluster-name>
 
     <properties>

--- a/scripts/start-rc.bat
+++ b/scripts/start-rc.bat
@@ -2,7 +2,7 @@
 setlocal EnableDelayedExpansion
 
 if "%HZ_VERSION%"=="" (
-    set HZ_VERSION=4.2.1
+    set HZ_VERSION=5.2-SNAPSHOT
 )
 set HAZELCAST_TEST_VERSION=%HZ_VERSION%
 set HAZELCAST_ENTERPRISE_VERSION=%HZ_VERSION%
@@ -26,7 +26,7 @@ if exist "hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar" (
     echo "hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar already exist, not downloading from maven."
 ) else (
     echo "Downloading: remote-controller jar com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION%"
-    call mvn -q dependency:get -DrepoUrl=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION% -Ddest=hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar || (
+    call mvn -q dependency:get -Dtransitive=false -DrepoUrl=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION% -Ddest=hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar || (
         echo "Failed download remote-controller jar com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION%" 
         exit /b 1
     )

--- a/scripts/start-rc.sh
+++ b/scripts/start-rc.sh
@@ -15,7 +15,7 @@ set +x
 
 trap cleanup EXIT
 
-HZ_VERSION="${HZ_VERSION:-4.2.1}"
+HZ_VERSION="${HZ_VERSION:-5.2-SNAPSHOT}"
 HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 HAZELCAST_RC_VERSION="0.8-SNAPSHOT"
@@ -37,7 +37,7 @@ if [ -f "hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar" ]; then
     echo "remote controller already exist, not downloading from maven."
 else
     echo "Downloading: remote-controller jar com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
-    mvn -q dependency:get -DrepoUrl=${SNAPSHOT_REPO} -Dartifact=com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION} -Ddest=hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar
+    mvn -q dependency:get -Dtransitive=false -DrepoUrl=${SNAPSHOT_REPO} -Dartifact=com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION} -Ddest=hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar
     if [ $? -ne 0 ]; then
         echo "Failed download remote-controller jar com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
         exit 1


### PR DESCRIPTION
Update the test server version to 5.2-SNAPSHOT so that the builds do not fail due to expired letsencrypt certificates. (#982)

Also, updated the xsd versions in test xmls and removed transitive dependency check for RC jar.

backports https://github.com/hazelcast/hazelcast-cpp-client/pull/982