### PR TITLE
[Backport] Update the test server version to update the server letsencrypt certificate

### DIFF
--- a/docker/hazelcast-fedora-i386.dockerfile
+++ b/docker/hazelcast-fedora-i386.dockerfile
@@ -1,17 +1,6 @@
-FROM fedora:latest
+FROM fedora:34
 
-RUN dnf groups install -y "Development Tools"
-RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.i686 cmake valgrind rsync passwd openssh-server ninja-build java-1.8.0-openjdk
-
-#install 32-bit libraries
-RUN dnf -y install glibc-devel.i686 glibc-devel libstdc++.i686
-
-# needed for test
-RUN dnf install -y maven net-tools gcovr
-RUN dnf install -y fedora-repos-rawhide
-RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel.i686
-
-RUN dnf install -y wget bzip2
-RUN dnf install -y wget bzip2 && wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=32 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
-
-
+RUN dnf groups install -y "Development Tools" && \
+    dnf install -y gcc-c++ gdb openssl-devel.i686 cmake valgrind rsync passwd openssh-server ninja-build \
+                   java-1.8.0-openjdk glibc-devel.i686 glibc-devel libstdc++.i686 maven net-tools gcovr \
+                   boost-devel.i686 thrift-devel.i686

--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -1,15 +1,8 @@
-FROM fedora:latest
+FROM fedora:34
 
-RUN dnf groups install -y "Development Tools"
-RUN dnf install -y gcc-c++ gdb compat-openssl10-devel.x86_64 cmake valgrind java-1.8.0-openjdk.x86_64 rsync passwd openssh-server ninja-build
-
-# needed for test
-RUN dnf install -y maven net-tools gcovr
-RUN dnf install -y fedora-repos-rawhide
-RUN dnf --disablerepo=* --enablerepo=rawhide --nogpg install -y thrift-devel
-
-# install boost
-RUN dnf install -y wget bzip2 && wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN dnf groups install -y "Development Tools" && \
+    dnf install -y gcc-c++ gdb openssl-devel cmake java-1.8.0-openjdk.x86_64 rsync passwd \
+                   openssh-server ninja-build maven net-tools gcovr boost-devel thrift-devel
 
 RUN ssh-keygen -A
 
@@ -24,4 +17,3 @@ RUN useradd -m user \
   && yes password | passwd user
 
 CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config_test_clion"]
-

--- a/docker/hazelcast-fedora22-x86_64.dockerfile
+++ b/docker/hazelcast-fedora22-x86_64.dockerfile
@@ -4,7 +4,7 @@ RUN dnf groups install -y "Development Tools"
 RUN dnf install -y gcc-c++ openssl-devel cmake tar wget bzip2 java-1.8.0-openjdk
 
 # install boost
-RUN wget --quiet https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
+RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && tar xjf boost_1_72_0.tar.bz2 && rm boost_1_72_0.tar.bz2 && cd boost_1_72_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_72_0
 
 RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh && \
     chmod +x ./cmake-3.19.0-Linux-x86_64.sh && \

--- a/hazelcast/test/CMakeLists.txt
+++ b/hazelcast/test/CMakeLists.txt
@@ -31,8 +31,11 @@ if (NOT GTest_FOUND)
     add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
             ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
             EXCLUDE_FROM_ALL)
+
+    set(GTEST_TARGET gtest)
 else()
     message(STATUS "Found an existing googletest installation and it will be used.")
+    set(GTEST_TARGET GTest::gtest)
 endif(NOT GTest_FOUND)
 
 add_subdirectory(src)

--- a/hazelcast/test/resources/hazelcast-cp-sessionless-semaphore.xml
+++ b/hazelcast/test/resources/hazelcast-cp-sessionless-semaphore.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>sessionless-semaphore</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-cp.xml
+++ b/hazelcast/test/resources/hazelcast-cp.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>cp-test</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-lite-member.xml
+++ b/hazelcast/test/resources/hazelcast-lite-member.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>lite-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-pncounter-consistency-lost-test.xml
+++ b/hazelcast/test/resources/hazelcast-pncounter-consistency-lost-test.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>consistency-lost-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-serialization-little-endian.xml
+++ b/hazelcast/test/resources/hazelcast-serialization-little-endian.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>little-endian-cluster</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-ssl.xml
+++ b/hazelcast/test/resources/hazelcast-ssl.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>ssl-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-test-executor.xml
+++ b/hazelcast/test/resources/hazelcast-test-executor.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>executor-test</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-token-credentials.xml
+++ b/hazelcast/test/resources/hazelcast-token-credentials.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>token-credentials-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast-username-password.xml
+++ b/hazelcast/test/resources/hazelcast-username-password.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>username-pass-dev</cluster-name>
 

--- a/hazelcast/test/resources/hazelcast.xml
+++ b/hazelcast/test/resources/hazelcast.xml
@@ -18,7 +18,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
 
     <cluster-name>dev</cluster-name>
 

--- a/hazelcast/test/resources/replicated-map-binary-in-memory-config-hazelcast.xml
+++ b/hazelcast/test/resources/replicated-map-binary-in-memory-config-hazelcast.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
     <cluster-name>replicated-map-binary-test</cluster-name>
 
     <replicatedmap name="default">

--- a/hazelcast/test/src/CMakeLists.txt
+++ b/hazelcast/test/src/CMakeLists.txt
@@ -3,11 +3,9 @@ cmake_minimum_required (VERSION 3.10)
 FILE(GLOB_RECURSE HZ_TEST_SOURCES "./*cpp")
 FILE(GLOB_RECURSE HZ_TEST_HEADERS "./*h")
 
-set(GOOGLETEST_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/hazelcast/test/googletest/googletest/include)
-
 add_executable(client_test ${HZ_TEST_SOURCES} ${HZ_TEST_HEADERS})
 
-target_link_libraries(client_test PRIVATE hazelcast-cpp-client gtest)
+target_link_libraries(client_test PRIVATE hazelcast-cpp-client ${GTEST_TARGET})
 
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     find_package(Thrift QUIET)

--- a/scripts/start-rc.bat
+++ b/scripts/start-rc.bat
@@ -1,7 +1,9 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-set HZ_VERSION=4.1
+if "%HZ_VERSION%"=="" (
+    set HZ_VERSION=5.2-SNAPSHOT
+)
 set HAZELCAST_TEST_VERSION=%HZ_VERSION%
 set HAZELCAST_ENTERPRISE_VERSION=%HZ_VERSION%
 set HAZELCAST_RC_VERSION="0.8-SNAPSHOT"
@@ -24,7 +26,7 @@ if exist "hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar" (
     echo "hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar already exist, not downloading from maven."
 ) else (
     echo "Downloading: remote-controller jar com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION%"
-    call mvn -q dependency:get -DrepoUrl=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION% -Ddest=hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar || (
+    call mvn -q dependency:get -Dtransitive=false -DrepoUrl=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION% -Ddest=hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar || (
         echo "Failed download remote-controller jar com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION%" 
         exit /b 1
     )
@@ -34,7 +36,7 @@ if exist  "hazelcast-%HAZELCAST_TEST_VERSION%-tests.jar" (
     echo "hazelcast-%HAZELCAST_TEST_VERSION%-tests.jar already exists, not downloading from maven."
 ) else (
     echo "Downloading: hazelcast test jar com.hazelcast:hazelcast:%HAZELCAST_TEST_VERSION%:jar:tests"
-    call mvn -q dependency:get -DrepoUrl=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast:%HAZELCAST_TEST_VERSION%:jar:tests -Ddest=hazelcast-%HAZELCAST_TEST_VERSION%-tests.jar || (
+    call mvn -q dependency:get -Dtransitive=false -DrepoUrl=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast:%HAZELCAST_TEST_VERSION%:jar:tests -Ddest=hazelcast-%HAZELCAST_TEST_VERSION%-tests.jar || (
         echo "Failed download hazelcast test jar com.hazelcast:hazelcast:%HAZELCAST_TEST_VERSION%:jar:tests"
         exit /b 1
     )
@@ -44,13 +46,23 @@ if exist "hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%.jar" (
     echo "hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%.jar already exists, not downloading from maven."
 ) else (
     echo "Downloading: hazelcast enterprise jar com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION%"
-    call mvn -q dependency:get -DrepoUrl=%ENTERPRISE_REPO% -Dartifact=com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION% -Ddest=hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%.jar || (
+    call mvn -q dependency:get -Dtransitive=false -DrepoUrl=%ENTERPRISE_REPO% -Dartifact=com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION% -Ddest=hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%.jar || (
         echo "Failed download hazelcast enterprise jar com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION%"
         exit /b 1
     )
 )
 
-set CLASSPATH="hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar;hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%.jar;hazelcast-%HAZELCAST_TEST_VERSION%-tests.jar"
+if exist "hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%-tests.jar" (
+    echo "hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%-tests.jar already exists, not downloading from maven."
+) else (
+    echo "Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION%:jar:tests"
+    call mvn -q dependency:get -Dtransitive=false -DrepoUrl=%ENTERPRISE_REPO% -Dartifact=com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION%:jar:tests -Ddest=hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%-tests.jar || (
+        echo "Failed download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION%:jar:tests"
+        exit /b 1
+    )
+)
+
+set CLASSPATH="hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar;hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%.jar;hazelcast-enterprise-%HAZELCAST_ENTERPRISE_VERSION%-tests.jar;hazelcast-%HAZELCAST_TEST_VERSION%-tests.jar"
 echo "Starting Remote Controller ... enterprise ...Using classpath: %CLASSPATH%"
 
 echo "Starting hazelcast-remote-controller"

--- a/scripts/start-rc.sh
+++ b/scripts/start-rc.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 function cleanup {
     echo "cleanup is being performed."
     if [ "x${rcPid}" != "x" ]
     then
         echo "Killing remote controller server with pid ${rcPid}"
-        kill -9 ${rcPid}
+        kill -9 ${rcPid} || true
     fi
     exit
 }
@@ -15,7 +15,7 @@ set +x
 
 trap cleanup EXIT
 
-HZ_VERSION="4.1"
+HZ_VERSION="${HZ_VERSION:-5.2-SNAPSHOT}"
 HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 HAZELCAST_RC_VERSION="0.8-SNAPSHOT"
@@ -37,7 +37,7 @@ if [ -f "hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar" ]; then
     echo "remote controller already exist, not downloading from maven."
 else
     echo "Downloading: remote-controller jar com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
-    mvn -q dependency:get -DrepoUrl=${SNAPSHOT_REPO} -Dartifact=com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION} -Ddest=hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar
+    mvn -q dependency:get -Dtransitive=false -DrepoUrl=${SNAPSHOT_REPO} -Dartifact=com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION} -Ddest=hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar
     if [ $? -ne 0 ]; then
         echo "Failed download remote-controller jar com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
         exit 1
@@ -48,7 +48,7 @@ if [ -f "hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar" ]; then
     echo "hazelcast-test.jar already exists, not downloading from maven."
 else
     echo "Downloading: hazelcast test jar com.hazelcast:hazelcast:${HAZELCAST_TEST_VERSION}:jar:tests"
-    mvn -q dependency:get -DrepoUrl=${SNAPSHOT_REPO} -Dartifact=com.hazelcast:hazelcast:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar
+    mvn -q dependency:get -Dtransitive=false -DrepoUrl=${SNAPSHOT_REPO} -Dartifact=com.hazelcast:hazelcast:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar
     if [ $? -ne 0 ]; then
         echo "Failed download hazelcast test jar com.hazelcast:hazelcast:${HAZELCAST_TEST_VERSION}:jar:tests"
         exit 1
@@ -59,16 +59,40 @@ if [ -f "hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar" ]; then
 echo "hazelcast-enterprise.jar already exists, not downloading from maven."
 else
     echo "Downloading: hazelcast enterprise jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION}"
-    mvn -q dependency:get -DrepoUrl=${ENTERPRISE_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION} -Ddest=hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar
+    mvn -q dependency:get -Dtransitive=false -DrepoUrl=${ENTERPRISE_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION} -Ddest=hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar
     if [ $? -ne 0 ]; then
         echo "Failed download hazelcast enterprise jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION}"
         exit 1
     fi
 fi
-CLASSPATH="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar:hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar:hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar"
-echo "Starting Remote Controller ... enterprise ..."
+if [ -f "hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}-tests.jar" ]; then
+echo "hazelcast-enterprise-tests.jar already exists, not downloading from maven."
+else
+    echo "Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION}:jar:tests"
+    mvn -q dependency:get -Dtransitive=false -DrepoUrl=${ENTERPRISE_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}-tests.jar
+    if [ $? -ne 0 ]; then
+        echo "Failed download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION}:jar:tests"
+        exit 1
+    fi
+fi
+CLASSPATH="\
+hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar:\
+hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar:\
+hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}-tests.jar:\
+hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar"
 
-java -Dhazelcast.enterprise.license.key=${HAZELCAST_ENTERPRISE_KEY} -cp ${CLASSPATH} -Dhazelcast.phone.home.enabled=false com.hazelcast.remotecontroller.Main --use-simple-server &
+# necessary arguments for Java 9+
+JAVA_MAJOR_VERSION=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}' | awk -F '.' '{print $1}')
+if [ "$JAVA_MAJOR_VERSION" != "1" ]; then
+    MODULE_ARGUMENTS="--add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED"
+fi
+
+echo "Starting Remote Controller ... enterprise ..."
+java -cp ${CLASSPATH} \
+     -Dhazelcast.enterprise.license.key=${HAZELCAST_ENTERPRISE_KEY} \
+     -Dhazelcast.phone.home.enabled=false \
+     $MODULE_ARGUMENTS \
+     com.hazelcast.remotecontroller.Main --use-simple-server &
 rcPid=$!
 wait ${rcPid}
 exit $?


### PR DESCRIPTION
Update the test server version to 5.2-SNAPSHOT so that the builds do not fail due to expired letsencrypt certificates. (https://github.com/hazelcast/hazelcast-cpp-client/pull/982)

Also, updated the xsd versions in test xmls and removed transitive dependency check for RC jar.

backports https://github.com/hazelcast/hazelcast-cpp-client/pull/982