### PR TITLE
[Forward Port] Do not interleave async_write calls

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <deque>
 
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
@@ -110,55 +111,33 @@ public:
         do_read(std::move(connection));
     }
 
-    void async_write(
-      const std::shared_ptr<connection::Connection> connection,
-      const std::shared_ptr<spi::impl::ClientInvocation> invocation) override
-    {
-        auto message = invocation->get_client_message();
-        socket_strand_.post([connection, invocation, message, this]() {
-            if (!check_connection(connection, invocation)) {
-                return;
-            }
+                    void async_write(const std::shared_ptr<connection::Connection> connection,
+                                    const std::shared_ptr<spi::impl::ClientInvocation> invocation) override {
+                        check_connection(connection, invocation);
+                        auto message = invocation->get_client_message();
+                        socket_strand_.post([connection, invocation, message, this]() {
+                            if (!check_connection(connection, invocation)) {
+                                return;
+                            }
 
-            bool success;
-            int64_t message_call_id;
-            auto call_id = ++call_id_counter_;
-            struct correlation_id
-            {
-                int32_t connnection_id;
-                int32_t call_id;
-            };
-            union
-            {
-                int64_t id;
-                correlation_id composed_id;
-            } c_id_union;
-            c_id_union.composed_id = { connection->get_connection_id(),
-                                       call_id };
-            message_call_id = c_id_union.id;
-            success =
-              connection->invocations.insert({ message_call_id, invocation })
-                .second;
-            if (success) {
-                message->set_correlation_id(c_id_union.id);
-            }
+                            add_invocation_to_map(connection, invocation, message);
 
-            auto& datas = message->get_buffer();
-            std::vector<boost::asio::const_buffer> buffers;
-            buffers.reserve(datas.size());
-            for (const auto& data : datas) {
-                buffers.push_back(boost::asio::buffer(data));
-            }
-            this->outbox_.push_back(buffers);
+                            auto &datas = message->get_buffer();
+                            std::vector<boost::asio::const_buffer> buffers;
+                            buffers.reserve(datas.size());
+                            for (const auto &data : datas) {
+                                buffers.emplace_back(boost::asio::buffer(data));
+                            }
+                            this->outbox_.push_back(buffers);
 
-            if (this->outbox_.size() > 1) {
-                // async write is in progress
-                return;
-            }
+                            if (this->outbox_.size() > 1) {
+                                // async write is in progress
+                                return;
+                            }
 
-            do_write(connection, invocation);
-        });
-    }
+                            do_write(connection, invocation);
+                        });
+                    }
 
     // always called from within the socket_strand_
     void close() override
@@ -311,6 +290,32 @@ protected:
         }
 
         return true;
+    }
+
+    inline int64_t generate_new_call_id(const std::shared_ptr<connection::Connection> &connection) {
+        auto call_id = ++call_id_counter_;
+        struct correlation_id {
+            int32_t connnection_id;
+            int32_t call_id;
+        };
+        union {
+            int64_t id;
+            correlation_id composed_id;
+        } c_id_union;
+
+        c_id_union.composed_id = {connection->get_connection_id(), call_id};
+        return c_id_union.id;
+    }
+
+    inline void add_invocation_to_map(const std::shared_ptr<connection::Connection> &connection,
+                                      const std::shared_ptr<spi::impl::ClientInvocation> &invocation,
+                                      std::shared_ptr<protocol::ClientMessage> message) {
+        int64_t message_call_id;
+        do {
+            message_call_id = generate_new_call_id(connection);
+        } while (!connection->invocations.insert({message_call_id, invocation}).second);
+
+        message->set_correlation_id(message_call_id);
     }
 
     client::config::socket_options& socket_options_;

--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -114,66 +114,49 @@ public:
       const std::shared_ptr<connection::Connection> connection,
       const std::shared_ptr<spi::impl::ClientInvocation> invocation) override
     {
-        check_connection(connection, invocation);
         auto message = invocation->get_client_message();
-        socket_strand_.post([=]() {
+        socket_strand_.post([connection, invocation, message, this]() {
             if (!check_connection(connection, invocation)) {
                 return;
             }
 
             bool success;
             int64_t message_call_id;
-            do {
-                auto call_id = ++call_id_counter_;
-                struct correlation_id
-                {
-                    int32_t connnection_id;
-                    int32_t call_id;
-                };
-                union
-                {
-                    int64_t id;
-                    correlation_id composed_id;
-                } c_id_union;
-                c_id_union.composed_id = { connection->get_connection_id(),
-                                           call_id };
-                message_call_id = c_id_union.id;
-                message->set_correlation_id(c_id_union.id);
-                success = connection->invocations
-                            .insert({ message_call_id, invocation })
-                            .second;
-            } while (!success);
-
-            auto handler = [=](const boost::system::error_code& ec,
-                               std::size_t bytes_written) {
-                if (ec) {
-                    auto message =
-                      (boost::format{ "Error %1% during invocation write for "
-                                      "%2% on connection %3%" } %
-                       ec % *invocation % *connection)
-                        .str();
-                    connection->close(message);
-                } else {
-                    // update the connection write time
-                    connection->last_write_time(
-                      std::chrono::steady_clock::now());
-                }
+            auto call_id = ++call_id_counter_;
+            struct correlation_id
+            {
+                int32_t connnection_id;
+                int32_t call_id;
             };
+            union
+            {
+                int64_t id;
+                correlation_id composed_id;
+            } c_id_union;
+            c_id_union.composed_id = { connection->get_connection_id(),
+                                       call_id };
+            message_call_id = c_id_union.id;
+            success =
+              connection->invocations.insert({ message_call_id, invocation })
+                .second;
+            if (success) {
+                message->set_correlation_id(c_id_union.id);
+            }
 
             auto& datas = message->get_buffer();
-            if (datas.size() == 1) {
-                boost::asio::async_write(socket_,
-                                         boost::asio::buffer(datas[0]),
-                                         socket_strand_.wrap(handler));
-            } else {
-                std::vector<boost::asio::const_buffer> buffers;
-                buffers.reserve(datas.size());
-                for (auto& d : datas) {
-                    buffers.push_back(boost::asio::buffer(d));
-                }
-                boost::asio::async_write(
-                  socket_, buffers, socket_strand_.wrap(handler));
+            std::vector<boost::asio::const_buffer> buffers;
+            buffers.reserve(datas.size());
+            for (const auto& data : datas) {
+                buffers.push_back(boost::asio::buffer(data));
             }
+            this->outbox_.push_back(buffers);
+
+            if (this->outbox_.size() > 1) {
+                // async write is in progress
+                return;
+            }
+
+            do_write(connection, invocation);
         });
     }
 
@@ -279,9 +262,40 @@ protected:
             }));
     }
 
+    void do_write(const std::shared_ptr<connection::Connection> connection,
+                  const std::shared_ptr<spi::impl::ClientInvocation> invocation)
+    {
+        auto handler =
+          [connection, invocation, this](const boost::system::error_code& ec,
+                                         std::size_t bytes_written) {
+              this->outbox_.pop_front();
+
+              if (ec) {
+                  auto message =
+                    (boost::format{ "Error %1% during invocation write for %2% "
+                                    "on connection %3%" } %
+                     ec % *invocation % *connection)
+                      .str();
+                  connection->close(message);
+              } else {
+                  // update the connection write time
+                  connection->last_write_time(std::chrono::steady_clock::now());
+
+                  if (!this->outbox_.empty()) {
+                      do_write(connection, invocation);
+                  }
+              }
+          };
+
+        const auto& message = outbox_[0];
+
+        boost::asio::async_write(
+          socket_, message, socket_strand_.wrap(handler));
+    }
+
     virtual void post_connect() {}
 
-    bool check_connection(
+    static bool check_connection(
       const std::shared_ptr<connection::Connection>& connection,
       const std::shared_ptr<spi::impl::ClientInvocation>& invocation)
     {
@@ -307,6 +321,8 @@ protected:
     boost::asio::ip::tcp::resolver& resolver_;
     T socket_;
     int32_t call_id_counter_{ 0 };
+    typedef std::deque<std::vector<boost::asio::const_buffer>> Outbox;
+    Outbox outbox_;
 };
 } // namespace socket
 } // namespace internal

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
@@ -1235,8 +1235,8 @@ private:
     std::string operation_name_;
 
     std::vector<std::vector<byte>> data_buffer_;
-    size_t buffer_index_;
-    size_t offset_;
+    size_t buffer_index_{ 0 };
+    size_t offset_{ 0 };
 };
 
 template<>

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/data_output.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/data_output.h
@@ -69,7 +69,7 @@ public:
         std::is_same<char, typename std::remove_cv<T>::type>::value ||
         std::is_same<char16_t, typename std::remove_cv<T>::type>::value ||
         std::is_same<bool, typename std::remove_cv<T>::type>::value ||
-        std::is_same<int8_t , typename std::remove_cv<T>::type>::value ||
+        std::is_same<int8_t, typename std::remove_cv<T>::type>::value ||
         std::is_same<int16_t, typename std::remove_cv<T>::type>::value ||
         std::is_same<int32_t, typename std::remove_cv<T>::type>::value ||
         std::is_same<int64_t, typename std::remove_cv<T>::type>::value ||

--- a/hazelcast/src/hazelcast/client/compact.cpp
+++ b/hazelcast/src/hazelcast/client/compact.cpp
@@ -760,7 +760,8 @@ compact_reader::read_string(const std::string& field_name)
 boost::optional<big_decimal>
 compact_reader::read_decimal(const std::string& field_name)
 {
-    return read_variable_size<big_decimal>(field_name, pimpl::field_kind::DECIMAL);
+    return read_variable_size<big_decimal>(field_name,
+                                           pimpl::field_kind::DECIMAL);
 }
 
 boost::optional<hazelcast::client::local_time>

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -1790,6 +1790,41 @@ TEST_F(IssueTest, testIssue753)
 
     ASSERT_OPEN_EVENTUALLY(success_async_deferred);
 }
+
+TEST_F(
+  IssueTest,
+  issue_980_frequent_heartbeat_should_not_interleave_data_messages_causing_corrupt_data)
+{
+    HazelcastServer server(default_server_factory());
+
+    hazelcast::client::client_config config;
+    config.set_property("hazelcast_client_heartbeat_interval", "10");
+    config.set_property("hazelcast_client_heartbeat_timeout", "50000");
+
+    auto hz = hazelcast::new_client(std::move(config)).get();
+
+    auto map = hz.get_map("large-payload-test-map").get();
+
+    std::string str("abcdefghijklmnopqrstuvwxyz");
+    std::string output_data;
+
+    // prepare a string of at least 800K characters
+    while (output_data.length() < 800000) {
+        output_data += str;
+    }
+
+    // put data 100 times to keep the test short enough
+    constexpr int num_iterations = 100;
+    auto pipe =
+      hazelcast::client::pipelining<std::string>::create(num_iterations);
+    std::vector<boost::future<boost::optional<std::string>>> futures;
+    for (int i = 0; i < num_iterations; ++i) {
+        auto key = "testKeyForLargePayload_" + std::to_string(i);
+        pipe->add(map->put(key, output_data));
+    }
+
+    ASSERT_NO_THROW(pipe->results());
+}
 } // namespace test
 } // namespace client
 } // namespace hazelcast

--- a/scripts/format-all.sh
+++ b/scripts/format-all.sh
@@ -4,6 +4,6 @@
 # However, you should probably use git-clang-format or your IDE to format your
 # changes before committing.
 
-find hazelcast examples    \
+find hazelcast/generated-sources hazelcast/include hazelcast/src hazelcast/test/src examples \
   | grep -E '\.(cpp|h)$'   \
   | xargs clang-format -i


### PR DESCRIPTION
Fixes the async io write logic. We need to have only one outstanding async_write operation for a single socket. Failing to do this causes interleaving the write requests and causing corrupt messages at the server side. See [this discussion](https://itecnote.com/tecnote/c-boost-asio-async_write-how-to-not-interleaving-async_write-calls/) The write requests needs to be queued and consumed either on the async_write callback handler or directly on write requests if no outstanding write is in progress.

Also, fixed the search pattern in `format-all.sh` script.

forward port #981 