### PR TITLE
[BACKPORT] Make sure that the logger static lock mutex is not destroyed before any global client instance

### DIFF
--- a/hazelcast/include/hazelcast/logger.h
+++ b/hazelcast/include/hazelcast/logger.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <functional>
 #include <limits>
+#include <mutex>
 
 #include "hazelcast/util/export.h"
 
@@ -52,6 +53,7 @@ private:
     const std::string cluster_name_;
     const level level_;
     const handler_type handler_;
+    static std::mutex cout_lock_;
 };
 
 enum class logger::level : int {


### PR DESCRIPTION
Make sure that the logger static lock mutex is not destroyed before any global client instance (https://github.com/hazelcast/hazelcast-cpp-client/pull/977)

Changed the logger lock mutex so that we can control its destruction order properly. We do not want it destroyed before the client is destructed. We need to control the order. static initialization and destruction order is not controllable if it is not a member of the logger class. It can be destroyed before the any global client instance is destroyed since global variables are also in static duration (https://www.learncpp.com/cpp-tutorial/introduction-to-global-variables).
backports https://github.com/hazelcast/hazelcast-cpp-client/pull/977