### PR TITLE
Remove the openjdk architecture type in docker file for Macbook M1 to work

### DIFF
--- a/docker/hazelcast-fedora-x86_64.dockerfile
+++ b/docker/hazelcast-fedora-x86_64.dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:34
 
 RUN dnf groups install -y "Development Tools" && \
-    dnf install -y gcc-c++ gdb openssl-devel cmake java-1.8.0-openjdk.x86_64 rsync passwd \
+    dnf install -y gcc-c++ gdb openssl-devel cmake java-1.8.0-openjdk rsync passwd \
                    openssh-server ninja-build maven net-tools gcovr boost-devel thrift-devel
 
 RUN ssh-keygen -A


### PR DESCRIPTION
Removed the openjdk architecture version in docker build file so that it will use the correct one in apple M1 processor.

Test on Macbook M1 processor do this and it builds without errors:

docker build -t jenkins_linux -f docker/hazelcast-fedora-x86_64.dockerfile docker
