### PR TITLE
Unresolved external errors are fixed. [API-1625] (#1022)

### DIFF
--- a/hazelcast/src/hazelcast/client/serialization.cpp
+++ b/hazelcast/src/hazelcast/client/serialization.cpp
@@ -626,7 +626,7 @@ data_output::write_zero_bytes(size_t number_of_bytes)
     output_stream_.insert(output_stream_.end(), number_of_bytes, 0);
 }
 
-inline size_t
+size_t
 data_output::position()
 {
     return output_stream_.size();


### PR DESCRIPTION
> But when you define an inline member function (the {...} part), you prepend the member function’s definition with the keyword inline, and you (almost always) put the definition into a header file:

...

> The reason you (almost always) put the definition (the {...} part) of an inline function in a header file is to avoid “unresolved external” errors from the linker. That error will occur if you put the inline function’s definition in a .cpp file and if that function is called from some other .cpp file.


Ref : [isocpp.org](https://isocpp.org/wiki/faq/inline-functions#inline-member-fns)