### PR TITLE
[API-1501] Fix assert fails. (#1005)

### DIFF
--- a/hazelcast/include/hazelcast/cp/cp_impl.h
+++ b/hazelcast/include/hazelcast/cp/cp_impl.h
@@ -93,6 +93,7 @@ private:
     {
         session_state(int64_t id, int64_t ttl_millis);
         session_state(const session_state& rhs);
+        session_state& operator=(const session_state& rhs);
 
         int64_t id;
         std::chrono::milliseconds ttl;


### PR DESCRIPTION
- Removed assert statement.
- If there is an entry at the sessions then emplace doesn't happen so I changed it to something like 'upsert' operation. If the entry is already there I just update the 'session_state' to the brand-new one.

Fixes #1005 