### PR TITLE
Actions configured to run tests on scheduled runs.

### DIFF
--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -69,7 +69,7 @@ jobs:
               -DBUILD_EXAMPLES=OFF
 
       - name: Test
-        if: ${{ inputs.run_tests }}
+        if: ${{ inputs.run_tests || github.event_name == 'schedule' }}
         env:
           BUILD_DIR: build
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -83,7 +83,7 @@ jobs:
               -DBUILD_EXAMPLES=OFF
 
       - name: Test
-        if: ${{ inputs.run_tests }}
+        if: ${{ inputs.run_tests || github.event_name == 'schedule' }}
         env:
           BUILD_DIR: build
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -74,7 +74,7 @@ jobs:
               -DBUILD_EXAMPLES=OFF
 
       - name: Test
-        if: ${{ inputs.run_tests }}
+        if: ${{ inputs.run_tests || github.event_name == 'schedule' }}
         env:
           BUILD_DIR: build
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -137,7 +137,7 @@ jobs:
               -DBUILD_EXAMPLES=OFF
 
       - name: Test
-        if: ${{ inputs.run_tests }}
+        if: ${{ inputs.run_tests || github.event_name == 'schedule' }}
         env:
           BUILD_DIR: build
           BUILD_CONFIGURATION: ${{ matrix.build_type }}


### PR DESCRIPTION
Scheduled runs doesn't inject inputs with default parameters so the test step doesn't run in github actions. This fix resolves this behaviour.