### PR TITLE
C++17 support for Hazelcast client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ project(hazelcast-cpp-client
 
 # Set the C++ standard
 set(HZ_HAS_CXX17_SUPPORT OFF)
-if( "${HZ_HAS_CXX17_SUPPORT}" STREQUAL "ON" )
+if("${HZ_HAS_CXX17_SUPPORT}" STREQUAL "ON")
     set(CMAKE_CXX_STANDARD 17)
-elif( "${HZ_HAS_CXX17_SUPPORT}" STREQUAL "OFF" )
+elseif("${HZ_HAS_CXX17_SUPPORT}" STREQUAL "OFF")
     set(CMAKE_CXX_STANDARD 11)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,12 @@ project(hazelcast-cpp-client
         LANGUAGES CXX)
 
 # Set the C++ standard
-set(CMAKE_CXX_STANDARD 11)
+set(HZ_HAS_CXX17_SUPPORT OFF)
+if( "${HZ_HAS_CXX17_SUPPORT}" STREQUAL "ON" )
+    set(CMAKE_CXX_STANDARD 17)
+elif( "${HZ_HAS_CXX17_SUPPORT}" STREQUAL "OFF" )
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set the default build type for single-config generators if not given

--- a/hazelcast/include/hazelcast/client/client_config.h
+++ b/hazelcast/include/hazelcast/client/client_config.h
@@ -19,13 +19,13 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <memory>
-#include <boost/optional.hpp>
 
 #include "hazelcast/client/address.h"
 #include "hazelcast/client/serialization_config.h"
 #include "hazelcast/client/socket_interceptor.h"
 #include "hazelcast/client/load_balancer.h"
 #include "hazelcast/util/SynchronizedMap.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/config/reliable_topic_config.h"
 #include "hazelcast/client/config/near_cache_config.h"
 #include "hazelcast/client/config/client_network_config.h"
@@ -337,7 +337,7 @@ public:
     client_config& set_network_config(
       const config::client_network_config& network_config);
 
-    const boost::optional<std::string>& get_instance_name() const;
+    const util::optional<std::string>& get_instance_name() const;
 
     client_config& set_instance_name(const std::string& instance_name);
 
@@ -459,7 +459,7 @@ private:
 
     serialization_config serialization_config_;
 
-    boost::optional<load_balancer> load_balancer_;
+    util::optional<load_balancer> load_balancer_;
 
     std::vector<membership_listener> membership_listeners_;
 
@@ -479,7 +479,7 @@ private:
     std::unordered_map<std::string, config::near_cache_config>
       near_cache_config_map_;
 
-    boost::optional<std::string> instance_name_;
+    util::optional<std::string> instance_name_;
 
     /**
      * pool-size for internal ExecutorService which handles responses etc.

--- a/hazelcast/include/hazelcast/client/config/index_config.h
+++ b/hazelcast/include/hazelcast/client/config/index_config.h
@@ -100,7 +100,7 @@ struct HAZELCAST_API index_config
     };
 
     /** Name of the index. */
-    boost::optional<std::string> name;
+    util::optional<std::string> name;
 
     /** Type of the index. */
     index_type type;
@@ -108,7 +108,7 @@ struct HAZELCAST_API index_config
     /** Indexed attributes. */
     std::vector<std::string> attributes;
 
-    boost::optional<bitmap_index_options> options;
+    util::optional<bitmap_index_options> options;
 
     static const index_type DEFAULT_TYPE;
 

--- a/hazelcast/include/hazelcast/client/connection/AddressProvider.h
+++ b/hazelcast/include/hazelcast/client/connection/AddressProvider.h
@@ -42,7 +42,7 @@ public:
      * @param address to be translated
      * @return translated address or boost::none if no translation is found.
      */
-    virtual boost::optional<address> translate(const address& addr) = 0;
+    virtual util::optional<address> translate(const address& addr) = 0;
 
     /**
      * @return true for the \DefaultAddressProvider , false otherwise.

--- a/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
+++ b/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
@@ -130,9 +130,9 @@ public:
      * </ol>
      */
     std::shared_ptr<connection::Connection> connection_for_sql(
-      std::function<boost::optional<member>()>
+      std::function<util::optional<member>()>
         member_of_large_same_version_group,
-      std::function<boost::optional<member>(boost::uuids::uuid)>
+      std::function<util::optional<member>(boost::uuids::uuid)>
         get_cluster_member);
 
     boost::uuids::uuid get_client_uuid() const;
@@ -156,7 +156,7 @@ private:
         byte serialization_version;
         int32_t partition_count;
         boost::uuids::uuid cluster_id;
-        boost::optional<address> server_address;
+        util::optional<address> server_address;
         std::string server_version;
     };
 
@@ -243,7 +243,7 @@ private:
     const config::client_connection_strategy_config::reconnect_mode
       reconnect_mode_;
     const bool smart_routing_enabled_;
-    boost::optional<boost::asio::steady_timer> connect_to_members_timer_;
+    util::optional<boost::asio::steady_timer> connect_to_members_timer_;
     boost::uuids::uuid client_uuid_;
     boost::chrono::milliseconds authentication_timeout_;
     std::vector<std::string> labels_;

--- a/hazelcast/include/hazelcast/client/connection/Connection.h
+++ b/hazelcast/include/hazelcast/client/connection/Connection.h
@@ -86,9 +86,9 @@ public:
     void write(
       const std::shared_ptr<spi::impl::ClientInvocation>& client_invocation);
 
-    const boost::optional<address>& get_remote_address() const;
+    const util::optional<address>& get_remote_address() const;
 
-    void set_remote_address(boost::optional<address> endpoint);
+    void set_remote_address(util::optional<address> endpoint);
 
     boost::uuids::uuid get_remote_uuid() const;
 
@@ -115,7 +115,7 @@ public:
 
     void set_connected_server_version(const std::string& connected_server);
 
-    boost::optional<address> get_local_socket_address() const;
+    util::optional<address> get_local_socket_address() const;
 
     std::chrono::system_clock::time_point get_start_time() const;
 
@@ -149,7 +149,7 @@ private:
     std::exception_ptr close_cause_;
     std::string connected_server_version_string_;
     // TODO: check if they need to be atomic
-    boost::optional<address> remote_address_;
+    util::optional<address> remote_address_;
     boost::uuids::uuid remote_uuid_;
     logger& logger_;
     std::atomic_bool alive_;

--- a/hazelcast/include/hazelcast/client/endpoint.h
+++ b/hazelcast/include/hazelcast/client/endpoint.h
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "hazelcast/client/address.h"
+#include "hazelcast/util/Optional.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(push)
@@ -34,7 +35,7 @@ namespace client {
 class HAZELCAST_API endpoint
 {
 public:
-    endpoint(boost::uuids::uuid uuid, boost::optional<address> socket_address);
+    endpoint(boost::uuids::uuid uuid, util::optional<address> socket_address);
 
     /**
      * Returns the UUID of this endpoint
@@ -48,11 +49,11 @@ public:
      *
      * @return the socket address for this endpoint
      */
-    const boost::optional<address>& get_socket_address() const;
+    const util::optional<address>& get_socket_address() const;
 
 private:
     boost::uuids::uuid uuid_;
-    boost::optional<address> socket_address_;
+    util::optional<address> socket_address_;
 };
 } // namespace client
 } // namespace hazelcast

--- a/hazelcast/include/hazelcast/client/execution_callback.h
+++ b/hazelcast/include/hazelcast/client/execution_callback.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include <hazelcast/util/Optional.h>
 
 #include "hazelcast/util/export.h"
 
@@ -47,7 +47,7 @@ public:
      *
      * @param response the result of the successful execution
      */
-    virtual void on_response(const boost::optional<V>& response) = 0;
+    virtual void on_response(const util::optional<V>& response) = 0;
 
     /**
      * Called when an execution is completed with an error.

--- a/hazelcast/include/hazelcast/client/iexecutor_service.h
+++ b/hazelcast/include/hazelcast/client/iexecutor_service.h
@@ -63,7 +63,7 @@ public:
         {}
 
         executor_promise(
-          boost::future<boost::optional<T>>& future,
+          boost::future<util::optional<T>>& future,
           boost::uuids::uuid uuid,
           int partition_id,
           boost::uuids::uuid member,
@@ -91,13 +91,13 @@ public:
             return false;
         }
 
-        boost::shared_future<boost::optional<T>> get_future()
+        boost::shared_future<util::optional<T>> get_future()
         {
             return shared_future_;
         }
 
     private:
-        boost::shared_future<boost::optional<T>> shared_future_;
+        boost::shared_future<util::optional<T>> shared_future_;
         boost::uuids::uuid uuid_;
         int partition_id_;
         boost::uuids::uuid member_uuid_;

--- a/hazelcast/include/hazelcast/client/ilist.h
+++ b/hazelcast/include/hazelcast/client/ilist.h
@@ -183,7 +183,7 @@ public:
      *
      */
     template<typename E>
-    boost::future<boost::optional<E>> get(int32_t index)
+    boost::future<util::optional<E>> get(int32_t index)
     {
         return to_object<E>(proxy::IListImpl::get_data(index));
     }
@@ -200,7 +200,7 @@ public:
      * @throws index_out_of_bounds if the index is out of range.
      */
     template<typename E, typename R = E>
-    boost::future<boost::optional<R>> set(int32_t index, const E& element)
+    boost::future<util::optional<R>> set(int32_t index, const E& element)
     {
         return to_object<R>(
           proxy::IListImpl::set_data(index, to_data(element)));
@@ -230,7 +230,7 @@ public:
      * @throws index_out_of_bounds if the index is out of range.
      */
     template<typename E>
-    boost::future<boost::optional<E>> remove(int32_t index)
+    boost::future<util::optional<E>> remove(int32_t index)
     {
         return to_object<E>(proxy::IListImpl::remove_data(index));
     }

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -99,7 +99,7 @@ public:
      * boost::none.
      */
     template<typename K, typename V>
-    boost::future<boost::optional<V>> get(const K& key)
+    boost::future<util::optional<V>> get(const K& key)
     {
         return to_object<V>(get_internal(to_data(key)));
     }
@@ -112,7 +112,7 @@ public:
      * boost::none.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> put(const K& key, const V& value)
+    boost::future<util::optional<R>> put(const K& key, const V& value)
     {
         return put<K, V, R>(key, value, UNSET);
     }
@@ -130,7 +130,7 @@ public:
      * boost::none.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> put(const K& key,
+    boost::future<util::optional<R>> put(const K& key,
                                           const V& value,
                                           std::chrono::milliseconds ttl)
     {
@@ -144,7 +144,7 @@ public:
      * boost::none.
      */
     template<typename K, typename V>
-    boost::future<boost::optional<V>> remove(const K& key)
+    boost::future<util::optional<V>> remove(const K& key)
     {
         return to_object<V>(remove_internal(to_data(key)));
     }
@@ -255,7 +255,7 @@ public:
      * then returns boost::none.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<V>> put_if_absent(const K& key,
+    boost::future<util::optional<V>> put_if_absent(const K& key,
                                                     const V& value)
     {
         return put_if_absent(key, value, UNSET);
@@ -273,7 +273,7 @@ public:
      * then returns boost::none.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<V>>
+    boost::future<util::optional<V>>
     put_if_absent(const K& key, const V& value, std::chrono::milliseconds ttl)
     {
         return to_object<R>(
@@ -304,7 +304,7 @@ public:
      * then returns boost::none.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> replace(const K& key, const V& value)
+    boost::future<util::optional<R>> replace(const K& key, const V& value)
     {
         return to_object<R>(replace_internal(to_data(key), to_data(value)));
     }
@@ -630,7 +630,7 @@ public:
      * @see EntryView
      */
     template<typename K, typename V>
-    boost::future<boost::optional<entry_view<K, V>>> get_entry_view(
+    boost::future<util::optional<entry_view<K, V>>> get_entry_view(
       const K& key)
     {
         auto f = proxy::IMapImpl::get_entry_view_data(to_data(key));
@@ -939,7 +939,7 @@ public:
      * @return result of entry process.
      */
     template<typename K, typename ResultType, typename EntryProcessor>
-    boost::future<boost::optional<ResultType>> execute_on_key(
+    boost::future<util::optional<ResultType>> execute_on_key(
       const K& key,
       const EntryProcessor& entry_processor)
     {
@@ -957,7 +957,7 @@ public:
      * @return Future from which the result of the operation can be retrieved.
      */
     template<typename K, typename ResultType, typename EntryProcessor>
-    boost::future<boost::optional<ResultType>> submit_to_key(
+    boost::future<util::optional<ResultType>> submit_to_key(
       const K& key,
       const EntryProcessor& entry_processor)
     {
@@ -979,7 +979,7 @@ public:
      * @param entryProcessor that will be applied
      */
     template<typename K, typename ResultType, typename EntryProcessor>
-    boost::future<std::unordered_map<K, boost::optional<ResultType>>>
+    boost::future<std::unordered_map<K, util::optional<ResultType>>>
     execute_on_keys(const std::unordered_set<K>& keys,
                     const EntryProcessor& entry_processor)
     {
@@ -1001,7 +1001,7 @@ public:
      * @param entryProcessor that will be applied
      */
     template<typename K, typename ResultType, typename EntryProcessor>
-    boost::future<std::unordered_map<K, boost::optional<ResultType>>>
+    boost::future<std::unordered_map<K, util::optional<ResultType>>>
     execute_on_entries(const EntryProcessor& entry_processor)
     {
         return to_object_map<K, ResultType>(
@@ -1027,7 +1027,7 @@ public:
              typename ResultType,
              typename EntryProcessor,
              typename P>
-    boost::future<std::unordered_map<K, boost::optional<ResultType>>>
+    boost::future<std::unordered_map<K, util::optional<ResultType>>>
     execute_on_entries(const EntryProcessor& entry_processor,
                        const P& predicate)
     {
@@ -1137,7 +1137,7 @@ protected:
 
     monitor::impl::LocalMapStatsImpl local_map_stats_;
 
-    virtual boost::future<boost::optional<serialization::pimpl::data>>
+    virtual boost::future<util::optional<serialization::pimpl::data>>
     get_internal(const serialization::pimpl::data& key_data)
     {
         return proxy::IMapImpl::get_data(key_data);
@@ -1149,7 +1149,7 @@ protected:
         return proxy::IMapImpl::contains_key(key_data);
     }
 
-    virtual boost::future<boost::optional<serialization::pimpl::data>>
+    virtual boost::future<util::optional<serialization::pimpl::data>>
     remove_internal(const serialization::pimpl::data& key_data)
     {
         return proxy::IMapImpl::remove_data(key_data);
@@ -1189,7 +1189,7 @@ protected:
         return proxy::IMapImpl::try_put(key_data, value_data, timeout);
     }
 
-    virtual boost::future<boost::optional<serialization::pimpl::data>>
+    virtual boost::future<util::optional<serialization::pimpl::data>>
     put_internal(const serialization::pimpl::data& key_data,
                  const serialization::pimpl::data& value_data,
                  std::chrono::milliseconds ttl)
@@ -1205,7 +1205,7 @@ protected:
         return proxy::IMapImpl::put_transient(key_data, value_data, ttl);
     }
 
-    virtual boost::future<boost::optional<serialization::pimpl::data>>
+    virtual boost::future<util::optional<serialization::pimpl::data>>
     put_if_absent_internal(const serialization::pimpl::data& key_data,
                            const serialization::pimpl::data& value_data,
                            std::chrono::milliseconds ttl)
@@ -1221,7 +1221,7 @@ protected:
         return proxy::IMapImpl::replace(key_data, value_data, new_value_data);
     }
 
-    virtual boost::future<boost::optional<serialization::pimpl::data>>
+    virtual boost::future<util::optional<serialization::pimpl::data>>
     replace_internal(const serialization::pimpl::data& key_data,
                      const serialization::pimpl::data& value_data)
     {
@@ -1249,14 +1249,14 @@ protected:
         return proxy::IMapImpl::get_all_data(partition_id, partition_keys);
     }
 
-    virtual boost::future<boost::optional<serialization::pimpl::data>>
+    virtual boost::future<util::optional<serialization::pimpl::data>>
     execute_on_key_internal(const serialization::pimpl::data& key_data,
                             const serialization::pimpl::data& processor)
     {
         return proxy::IMapImpl::execute_on_key_data(key_data, processor);
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     submit_to_key_internal(const serialization::pimpl::data& key_data,
                            const serialization::pimpl::data& processor)
     {
@@ -1288,12 +1288,12 @@ protected:
 
 private:
     template<typename K, typename V>
-    std::vector<std::pair<K, boost::optional<V>>> sort_and_get(
+    std::vector<std::pair<K, util::optional<V>>> sort_and_get(
       query::paging_predicate<K, V>& predicate,
       query::iteration_type iteration_type,
       std::vector<std::pair<K, V>> entries)
     {
-        std::vector<std::pair<K, boost::optional<V>>> optionalEntries;
+        std::vector<std::pair<K, util::optional<V>>> optionalEntries;
         optionalEntries.reserve(entries.size());
         for (auto&& pair : entries) {
             optionalEntries.emplace_back(pair.first,
@@ -1303,15 +1303,15 @@ private:
     }
 
     template<typename K, typename V>
-    std::vector<std::pair<K, boost::optional<V>>> sort_and_get(
+    std::vector<std::pair<K, util::optional<V>>> sort_and_get(
       query::paging_predicate<K, V>& predicate,
       query::iteration_type iteration_type,
-      std::vector<std::pair<K, boost::optional<V>>> entries)
+      std::vector<std::pair<K, util::optional<V>>> entries)
     {
         std::sort(entries.begin(),
                   entries.end(),
-                  [&](const std::pair<K, boost::optional<V>>& lhs,
-                      const std::pair<K, boost::optional<V>>& rhs) {
+                  [&](const std::pair<K, util::optional<V>>& lhs,
+                      const std::pair<K, util::optional<V>>& rhs) {
                       auto comparator = predicate.getComparator();
                       if (!comparator) {
                           switch (predicate.getIterationType()) {
@@ -1340,7 +1340,7 @@ private:
         std::pair<size_t, size_t> range =
           update_anchor<K, V>(entries, predicate, iteration_type);
 
-        std::vector<std::pair<K, boost::optional<V>>> result;
+        std::vector<std::pair<K, util::optional<V>>> result;
         for (size_t i = range.first; i < range.second; ++i) {
             auto entry = entries[i];
             result.push_back(std::make_pair(entry.first, entry.second));

--- a/hazelcast/include/hazelcast/client/imap.h
+++ b/hazelcast/include/hazelcast/client/imap.h
@@ -1297,7 +1297,7 @@ private:
         optionalEntries.reserve(entries.size());
         for (auto&& pair : entries) {
             optionalEntries.emplace_back(pair.first,
-                                         boost::make_optional(pair.second));
+                                         util::make_optional(pair.second));
         }
         return sortAndGet(predicate, iteration_type, optionalEntries);
     }

--- a/hazelcast/include/hazelcast/client/impl/EntryEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/EntryEventHandler.h
@@ -54,10 +54,10 @@ public:
     {}
 
     void handle_entry(
-      const boost::optional<serialization::pimpl::data>& key,
-      const boost::optional<serialization::pimpl::data>& value,
-      const boost::optional<serialization::pimpl::data>& old_value,
-      const boost::optional<serialization::pimpl::data>& merging_value,
+      const util::optional<serialization::pimpl::data>& key,
+      const util::optional<serialization::pimpl::data>& value,
+      const util::optional<serialization::pimpl::data>& old_value,
+      const util::optional<serialization::pimpl::data>& merging_value,
       int32_t event_type,
       boost::uuids::uuid uuid,
       int32_t number_of_affected_entries) override
@@ -85,10 +85,10 @@ public:
 
 private:
     void fire_map_wide_event(
-      const boost::optional<serialization::pimpl::data>& key,
-      const boost::optional<serialization::pimpl::data>& value,
-      const boost::optional<serialization::pimpl::data>& old_value,
-      const boost::optional<serialization::pimpl::data>& merging_value,
+      const util::optional<serialization::pimpl::data>& key,
+      const util::optional<serialization::pimpl::data>& value,
+      const util::optional<serialization::pimpl::data>& old_value,
+      const util::optional<serialization::pimpl::data>& merging_value,
       int32_t event_type,
       boost::uuids::uuid uuid,
       int32_t number_of_affected_entries)
@@ -108,10 +108,10 @@ private:
     }
 
     void fire_entry_event(
-      const boost::optional<serialization::pimpl::data>& key,
-      const boost::optional<serialization::pimpl::data>& value,
-      const boost::optional<serialization::pimpl::data>& old_value,
-      const boost::optional<serialization::pimpl::data>& merging_value,
+      const util::optional<serialization::pimpl::data>& key,
+      const util::optional<serialization::pimpl::data>& value,
+      const util::optional<serialization::pimpl::data>& old_value,
+      const util::optional<serialization::pimpl::data>& merging_value,
       int32_t event_type,
       boost::uuids::uuid uuid,
       int32_t number_of_affected_entries)

--- a/hazelcast/include/hazelcast/client/impl/ItemEventHandler.h
+++ b/hazelcast/include/hazelcast/client/impl/ItemEventHandler.h
@@ -41,7 +41,7 @@ public:
       , listener_(std::move(listener))
       , include_value_(include_value){};
 
-    void handle_item(const boost::optional<serialization::pimpl::data>& item,
+    void handle_item(const util::optional<serialization::pimpl::data>& item,
                      boost::uuids::uuid uuid,
                      int32_t event_type) override
     {

--- a/hazelcast/include/hazelcast/client/impl/Partition.h
+++ b/hazelcast/include/hazelcast/client/impl/Partition.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
-
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/util/export.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -51,7 +50,7 @@ public:
      *
      * @return the owner member of the partition
      */
-    virtual boost::optional<member> get_owner() const = 0;
+    virtual util::optional<member> get_owner() const = 0;
 
     virtual ~Partition() = default;
 };

--- a/hazelcast/include/hazelcast/client/impl/metrics/metric_descriptor.h
+++ b/hazelcast/include/hazelcast/client/impl/metrics/metric_descriptor.h
@@ -18,8 +18,7 @@
 
 #include <string>
 
-#include <boost/optional.hpp>
-
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/util/export.h"
 
 namespace hazelcast {
@@ -55,15 +54,15 @@ public:
 
     const std::string& prefix() const;
     const std::string& metric() const;
-    const boost::optional<std::string>& discriminator() const;
-    const boost::optional<std::string>& discriminator_value() const;
+    const util::optional<std::string>& discriminator() const;
+    const util::optional<std::string>& discriminator_value() const;
     probe_unit unit() const;
 
 private:
     std::string prefix_;
     std::string metric_;
-    boost::optional<std::string> discriminator_;
-    boost::optional<std::string> discriminator_value_;
+    util::optional<std::string> discriminator_;
+    util::optional<std::string> discriminator_value_;
     probe_unit unit_;
 };
 

--- a/hazelcast/include/hazelcast/client/impl/metrics/metrics_compressor.h
+++ b/hazelcast/include/hazelcast/client/impl/metrics/metrics_compressor.h
@@ -21,12 +21,11 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #include "hazelcast/client/impl/metrics/metric_descriptor.h"
 #include "hazelcast/client/impl/metrics/metrics_dictionary.h"
 #include "hazelcast/util/byte.h"
 #include "hazelcast/util/export.h"
+#include "hazelcast/util/Optional.h"
 
 namespace hazelcast {
 namespace client {
@@ -56,13 +55,13 @@ public:
 
 private:
     byte calculate_descriptor_mask(const metric_descriptor& descriptor);
-    int get_dictionary_id(const boost::optional<std::string>& word);
+    int get_dictionary_id(const util::optional<std::string>& word);
     void write_descriptor(const metric_descriptor& descriptor);
     void write_dictionary();
 
     int metrics_count{ 0 };
     metrics_dictionary dictionary_{};
-    boost::optional<metric_descriptor> last_descriptor_{};
+    util::optional<metric_descriptor> last_descriptor_{};
     output_buffer metrics_buffer_{};
     output_buffer dictionary_buffer_{};
 };

--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -161,7 +161,7 @@ public:
      *
      * @returns An address that represents the local endpoint of the socket.
      */
-    boost::optional<address> local_socket_address() const override
+    util::optional<address> local_socket_address() const override
     {
         boost::system::error_code ec;
         boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> localEndpoint =
@@ -169,7 +169,7 @@ public:
         if (ec) {
             return boost::none;
         }
-        return boost::optional<address>(
+        return util::optional<address>(
           address(localEndpoint.address().to_string(), localEndpoint.port()));
     }
 

--- a/hazelcast/include/hazelcast/client/iqueue.h
+++ b/hazelcast/include/hazelcast/client/iqueue.h
@@ -110,7 +110,7 @@ public:
      * added.
      */
     template<typename E>
-    boost::future<boost::optional<E>> take()
+    boost::future<util::optional<E>> take()
     {
         return to_object<E>(proxy::IQueueImpl::take_data());
     }
@@ -122,7 +122,7 @@ public:
      * time.
      */
     template<typename E>
-    boost::future<boost::optional<E>> poll(std::chrono::milliseconds timeout)
+    boost::future<util::optional<E>> poll(std::chrono::milliseconds timeout)
     {
         return to_object<E>(proxy::IQueueImpl::poll_data(timeout));
     }
@@ -183,7 +183,7 @@ public:
      * available returns empty constructed shared_ptr.
      */
     template<typename E>
-    boost::future<boost::optional<E>> poll()
+    boost::future<util::optional<E>> poll()
     {
         return poll<E>(std::chrono::milliseconds(0));
     }
@@ -195,7 +195,7 @@ public:
      * constructed shared_ptr.
      */
     template<typename E>
-    boost::future<boost::optional<E>> peek()
+    boost::future<util::optional<E>> peek()
     {
         return to_object<E>(proxy::IQueueImpl::peek_data());
     }

--- a/hazelcast/include/hazelcast/client/load_balancer.h
+++ b/hazelcast/include/hazelcast/client/load_balancer.h
@@ -90,7 +90,7 @@ private:
      * one can add membership through this class for future notifications.
      */
     std::function<void(cluster&)> init_ = util::noop<cluster&>;
-    std::function<boost::optional<member>(cluster&)> next_ = [](cluster&) {
+    std::function<util::optional<member>(cluster&)> next_ = [](cluster&) {
         return boost::none;
     };
 

--- a/hazelcast/include/hazelcast/client/local_endpoint.h
+++ b/hazelcast/include/hazelcast/client/local_endpoint.h
@@ -33,7 +33,7 @@ class HAZELCAST_API local_endpoint : public endpoint
 {
 public:
     local_endpoint(boost::uuids::uuid uuid,
-                   boost::optional<address> socket_address,
+                   util::optional<address> socket_address,
                    std::string name,
                    std::unordered_set<std::string> labels);
 

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -138,7 +138,7 @@ protected:
         return imap::contains_key_internal(*key);
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> get_internal(
+    boost::future<util::optional<serialization::pimpl::data>> get_internal(
       const serialization::pimpl::data& key_data) override
     {
         auto key = std::make_shared<serialization::pimpl::data>(key_data);
@@ -146,7 +146,7 @@ protected:
         if (cached) {
             if (internal::nearcache::NearCache<K, V>::NULL_OBJECT == cached) {
                 return boost::make_ready_future(
-                  boost::optional<serialization::pimpl::data>());
+                  util::optional<serialization::pimpl::data>());
             }
             return boost::make_ready_future(boost::make_optional(*cached));
         }
@@ -158,7 +158,7 @@ protected:
             if (marked) {
                 return future.then(
                   boost::launch::sync,
-                  [=](boost::future<boost::optional<serialization::pimpl::data>>
+                  [=](boost::future<util::optional<serialization::pimpl::data>>
                         f) {
                       auto data = f.get();
                       auto cachedValue =
@@ -190,7 +190,7 @@ protected:
         }
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> remove_internal(
+    boost::future<util::optional<serialization::pimpl::data>> remove_internal(
       const serialization::pimpl::data& key_data) override
     {
         try {
@@ -259,7 +259,7 @@ protected:
         }
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> put_internal(
+    boost::future<util::optional<serialization::pimpl::data>> put_internal(
       const serialization::pimpl::data& key_data,
       const serialization::pimpl::data& value_data,
       std::chrono::milliseconds ttl) override
@@ -290,7 +290,7 @@ protected:
         }
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     put_if_absent_internal(const serialization::pimpl::data& key_data,
                            const serialization::pimpl::data& value_data,
                            std::chrono::milliseconds ttl) override
@@ -322,7 +322,7 @@ protected:
         }
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> replace_internal(
+    boost::future<util::optional<serialization::pimpl::data>> replace_internal(
       const serialization::pimpl::data& key_data,
       const serialization::pimpl::data& value_data) override
     {
@@ -427,7 +427,7 @@ protected:
         }
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     execute_on_key_internal(
       const serialization::pimpl::data& key_data,
       const serialization::pimpl::data& processor) override
@@ -517,7 +517,7 @@ private:
         void on_listener_register() override { near_cache_->clear(); }
 
         void handle_imapinvalidation(
-          const boost::optional<serialization::pimpl::data>& key,
+          const util::optional<serialization::pimpl::data>& key,
           boost::uuids::uuid source_uuid,
           boost::uuids::uuid partition_uuid,
           int64_t sequence) override

--- a/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
+++ b/hazelcast/include/hazelcast/client/map/NearCachedClientMapProxy.h
@@ -148,7 +148,7 @@ protected:
                 return boost::make_ready_future(
                   util::optional<serialization::pimpl::data>());
             }
-            return boost::make_ready_future(boost::make_optional(*cached));
+            return boost::make_ready_future(util::make_optional(*cached));
         }
 
         bool marked = key_state_marker_->try_mark(*key);

--- a/hazelcast/include/hazelcast/client/pipelining.h
+++ b/hazelcast/include/hazelcast/client/pipelining.h
@@ -113,9 +113,9 @@ public:
      * @return the List of results.
      * @throws IException if something fails getting the results.
      */
-    std::vector<boost::optional<E>> results()
+    std::vector<util::optional<E>> results()
     {
-        std::vector<boost::optional<E>> result;
+        std::vector<util::optional<E>> result;
         result.reserve(futures_.size());
         auto result_futures = when_all(futures_.begin(), futures_.end());
         for (auto& f : result_futures.get()) {
@@ -133,7 +133,7 @@ public:
      * @param future the future to add.
      * @throws null_pointer if future is null.
      */
-    void add(boost::future<boost::optional<E>> future)
+    void add(boost::future<util::optional<E>> future)
     {
         down();
 
@@ -171,7 +171,7 @@ private:
     }
 
     int permits_;
-    std::vector<boost::shared_future<boost::optional<E>>> futures_;
+    std::vector<boost::shared_future<util::optional<E>>> futures_;
 };
 } // namespace client
 } // namespace hazelcast

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
@@ -30,7 +30,6 @@
 
 #include <boost/endian/arithmetic.hpp>
 #include <boost/endian/conversion.hpp>
-#include <boost/optional.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 
@@ -47,6 +46,7 @@
 #include "hazelcast/client/sql/impl/sql_error.h"
 #include "hazelcast/client/sql/sql_column_type.h"
 #include "hazelcast/client/protocol/codec/builtin/custom_type_factory.h"
+#include "hazelcast/util/Optional.h"
 
 namespace hazelcast {
 namespace util {

--- a/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
+++ b/hazelcast/include/hazelcast/client/protocol/ClientMessage.h
@@ -974,7 +974,7 @@ public:
             rd_ptr(SIZE_OF_FRAME_LENGTH_AND_FLAGS);
             return boost::none;
         }
-        return boost::make_optional(decoder(*this));
+        return util::make_optional(decoder(*this));
     }
 
     template<typename T>

--- a/hazelcast/include/hazelcast/client/protocol/codec/ErrorCodec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/ErrorCodec.h
@@ -17,7 +17,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/optional.hpp>
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/util/export.h"
 
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
@@ -35,7 +35,7 @@ struct HAZELCAST_API StackTraceElement
 {
     std::string declaring_class;
     std::string method_name;
-    boost::optional<std::string> file_name;
+    util::optional<std::string> file_name;
     int line_number;
 };
 
@@ -43,7 +43,7 @@ struct HAZELCAST_API ErrorHolder
 {
     int32_t error_code;
     std::string class_name;
-    boost::optional<std::string> message;
+    util::optional<std::string> message;
     std::vector<codec::StackTraceElement> stack_trace;
 
     std::string to_string() const;

--- a/hazelcast/include/hazelcast/client/protocol/codec/builtin/list_cn_fixed_size_codec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/builtin/list_cn_fixed_size_codec.h
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "hazelcast/util/export.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/protocol/ClientMessage.h"
 
 namespace hazelcast {
@@ -31,7 +31,7 @@ class HAZELCAST_API list_cn_fixed_size_codec
 {
 public:
     template<typename T>
-    static std::vector<boost::optional<T>> decode(ClientMessage& msg)
+    static std::vector<util::optional<T>> decode(ClientMessage& msg)
     {
         msg.skip_frame_header_bytes();
 
@@ -40,7 +40,7 @@ public:
         assert(count0 >= 0);
         auto count = static_cast<std::size_t>(count0);
 
-        std::vector<boost::optional<T>> res(count);
+        std::vector<util::optional<T>> res(count);
 
         auto element_type = static_cast<contains_nullable_list_type>(type);
         switch (element_type) {

--- a/hazelcast/include/hazelcast/client/protocol/codec/builtin/sql_page_codec.h
+++ b/hazelcast/include/hazelcast/client/protocol/codec/builtin/sql_page_codec.h
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "hazelcast/util/export.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/protocol/ClientMessage.h"
 #include "hazelcast/client/sql/sql_page.h"
 #include "hazelcast/client/protocol/codec/builtin/list_cn_fixed_size_codec.h"
@@ -40,7 +40,7 @@ public:
 private:
     template<typename T>
     static std::vector<boost::any> to_vector_of_any(
-      std::vector<boost::optional<T>> values)
+      std::vector<util::optional<T>> values)
     {
         auto size = values.size();
         std::vector<boost::any> vector_of_any(size);

--- a/hazelcast/include/hazelcast/client/proxy/IListImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IListImpl.h
@@ -90,17 +90,17 @@ protected:
     boost::future<bool> retain_all_data(
       const std::vector<serialization::pimpl::data>& elements);
 
-    boost::future<boost::optional<serialization::pimpl::data>> get_data(
+    boost::future<util::optional<serialization::pimpl::data>> get_data(
       int32_t index);
 
-    boost::future<boost::optional<serialization::pimpl::data>> set_data(
+    boost::future<util::optional<serialization::pimpl::data>> set_data(
       int32_t index,
       const serialization::pimpl::data& element);
 
     boost::future<void> add(int32_t index,
                             const serialization::pimpl::data& element);
 
-    boost::future<boost::optional<serialization::pimpl::data>> remove_data(
+    boost::future<util::optional<serialization::pimpl::data>> remove_data(
       int32_t index);
 
     boost::future<int32_t> index_of(const serialization::pimpl::data& element);

--- a/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IMapImpl.h
@@ -110,10 +110,10 @@ protected:
 
     boost::future<bool> contains_value(const serialization::pimpl::data& value);
 
-    boost::future<boost::optional<serialization::pimpl::data>> get_data(
+    boost::future<util::optional<serialization::pimpl::data>> get_data(
       const serialization::pimpl::data& key);
 
-    boost::future<boost::optional<serialization::pimpl::data>> remove_data(
+    boost::future<util::optional<serialization::pimpl::data>> remove_data(
       const serialization::pimpl::data& key);
 
     boost::future<bool> remove(const serialization::pimpl::data& key,
@@ -132,7 +132,7 @@ protected:
                                 const serialization::pimpl::data& value,
                                 std::chrono::milliseconds timeout);
 
-    boost::future<boost::optional<serialization::pimpl::data>> put_data(
+    boost::future<util::optional<serialization::pimpl::data>> put_data(
       const serialization::pimpl::data& key,
       const serialization::pimpl::data& value,
       std::chrono::milliseconds ttl);
@@ -142,7 +142,7 @@ protected:
       const serialization::pimpl::data& value,
       std::chrono::milliseconds ttl);
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     put_if_absent_data(const serialization::pimpl::data& key,
                        const serialization::pimpl::data& value,
                        std::chrono::milliseconds ttl);
@@ -151,7 +151,7 @@ protected:
                                 const serialization::pimpl::data& old_value,
                                 const serialization::pimpl::data& new_value);
 
-    boost::future<boost::optional<serialization::pimpl::data>> replace_data(
+    boost::future<util::optional<serialization::pimpl::data>> replace_data(
       const serialization::pimpl::data& key,
       const serialization::pimpl::data& value);
 
@@ -202,7 +202,7 @@ protected:
       serialization::pimpl::data&& key,
       int32_t listener_flags);
 
-    boost::future<boost::optional<map::data_entry_view>> get_entry_view_data(
+    boost::future<util::optional<map::data_entry_view>> get_entry_view_data(
       const serialization::pimpl::data& key);
 
     boost::future<bool> evict(const serialization::pimpl::data& key);
@@ -247,11 +247,11 @@ protected:
       int partition_id,
       const EntryVector& entries);
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     execute_on_key_data(const serialization::pimpl::data& key,
                         const serialization::pimpl::data& processor);
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     submit_to_key_data(const serialization::pimpl::data& key,
                        const serialization::pimpl::data& processor);
 
@@ -268,7 +268,7 @@ protected:
 
     template<typename K, typename V>
     std::pair<size_t, size_t> update_anchor(
-      std::vector<std::pair<K, boost::optional<V>>>& entries,
+      std::vector<std::pair<K, util::optional<V>>>& entries,
       query::paging_predicate<K, V>& predicate,
       query::iteration_type iteration_type)
     {
@@ -299,7 +299,7 @@ protected:
 
     template<typename K, typename V>
     static void set_anchor(
-      std::vector<std::pair<K, boost::optional<V>>>& entries,
+      std::vector<std::pair<K, util::optional<V>>>& entries,
       query::paging_predicate<K, V>& predicate,
       int nearest_page)
     {

--- a/hazelcast/include/hazelcast/client/proxy/IQueueImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/IQueueImpl.h
@@ -83,7 +83,7 @@ protected:
 
     boost::future<void> put(const serialization::pimpl::data& element);
 
-    boost::future<boost::optional<serialization::pimpl::data>> poll_data(
+    boost::future<util::optional<serialization::pimpl::data>> poll_data(
       std::chrono::milliseconds timeout);
 
     boost::future<bool> remove(const serialization::pimpl::data& element);
@@ -95,9 +95,9 @@ protected:
 
     boost::future<std::vector<serialization::pimpl::data>> drain_to_data();
 
-    boost::future<boost::optional<serialization::pimpl::data>> take_data();
+    boost::future<util::optional<serialization::pimpl::data>> take_data();
 
-    boost::future<boost::optional<serialization::pimpl::data>> peek_data();
+    boost::future<util::optional<serialization::pimpl::data>> peek_data();
 
     boost::future<std::vector<serialization::pimpl::data>> to_array_data();
 

--- a/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
@@ -236,7 +236,7 @@ protected:
         auto sharedKey = std::make_shared<serialization::pimpl::data>(key);
         auto cachedValue = get_cached_data(sharedKey);
         if (cachedValue) {
-            return boost::make_ready_future(boost::make_optional(*cachedValue));
+            return boost::make_ready_future(util::make_optional(*cachedValue));
         }
         auto request =
           protocol::codec::replicatedmap_get_encode(get_name(), *sharedKey);
@@ -257,7 +257,7 @@ protected:
                     if (near_cache_) {
                         near_cache_->put(sharedKey, sharedValue);
                     }
-                    return boost::make_optional(*sharedValue);
+                    return util::make_optional(*sharedValue);
                 } catch (...) {
                     invalidate(sharedKey);
                     throw;

--- a/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/ReplicatedMapImpl.h
@@ -89,7 +89,7 @@ public:
     }
 
 protected:
-    boost::future<boost::optional<serialization::pimpl::data>> put_data(
+    boost::future<util::optional<serialization::pimpl::data>> put_data(
       serialization::pimpl::data&& key_data,
       serialization::pimpl::data&& value_data,
       std::chrono::milliseconds ttl)
@@ -102,7 +102,7 @@ protected:
               std::chrono::duration_cast<std::chrono::milliseconds>(ttl)
                 .count());
             auto result = invoke_and_get_future<
-              boost::optional<serialization::pimpl::data>>(request, key_data);
+              util::optional<serialization::pimpl::data>>(request, key_data);
 
             invalidate(std::move(key_data));
 
@@ -113,7 +113,7 @@ protected:
         }
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> remove_data(
+    boost::future<util::optional<serialization::pimpl::data>> remove_data(
       serialization::pimpl::data&& key_data)
     {
         std::shared_ptr<serialization::pimpl::data> sharedKey(
@@ -122,7 +122,7 @@ protected:
             auto request =
               protocol::codec::replicatedmap_remove_encode(name_, *sharedKey);
             auto result = invoke_and_get_future<
-              boost::optional<serialization::pimpl::data>>(request, *sharedKey);
+              util::optional<serialization::pimpl::data>>(request, *sharedKey);
 
             invalidate(sharedKey);
 
@@ -230,7 +230,7 @@ protected:
           request, target_partition_id_);
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> get_data(
+    boost::future<util::optional<serialization::pimpl::data>> get_data(
       serialization::pimpl::data&& key)
     {
         auto sharedKey = std::make_shared<serialization::pimpl::data>(key);
@@ -241,14 +241,14 @@ protected:
         auto request =
           protocol::codec::replicatedmap_get_encode(get_name(), *sharedKey);
         return invoke_and_get_future<
-                 boost::optional<serialization::pimpl::data>>(request, key)
+                 util::optional<serialization::pimpl::data>>(request, key)
           .then(
             boost::launch::sync,
-            [=](boost::future<boost::optional<serialization::pimpl::data>> f) {
+            [=](boost::future<util::optional<serialization::pimpl::data>> f) {
                 try {
                     auto response = f.get();
                     if (!response) {
-                        return boost::optional<serialization::pimpl::data>();
+                        return util::optional<serialization::pimpl::data>();
                     }
 
                     auto sharedValue =
@@ -477,10 +477,10 @@ private:
         void on_listener_register() override { near_cache_->clear(); }
 
         void handle_entry(
-          const boost::optional<serialization::pimpl::data>& key,
-          const boost::optional<serialization::pimpl::data>& value,
-          const boost::optional<serialization::pimpl::data>& old_value,
-          const boost::optional<serialization::pimpl::data>& merging_value,
+          const util::optional<serialization::pimpl::data>& key,
+          const util::optional<serialization::pimpl::data>& value,
+          const util::optional<serialization::pimpl::data>& old_value,
+          const util::optional<serialization::pimpl::data>& merging_value,
           int32_t event_type,
           boost::uuids::uuid uuid,
           int32_t number_of_affected_entries) override

--- a/hazelcast/include/hazelcast/client/proxy/RingbufferImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/RingbufferImpl.h
@@ -186,14 +186,14 @@ protected:
         return invoke_and_get_future<int64_t>(request, partition_id_);
     }
 
-    boost::future<boost::optional<serialization::pimpl::data>> read_one_data(
+    boost::future<util::optional<serialization::pimpl::data>> read_one_data(
       int64_t sequence)
     {
         check_sequence(sequence);
         auto request =
           protocol::codec::ringbuffer_readone_encode(get_name(), sequence);
         return invoke_and_get_future<
-          boost::optional<serialization::pimpl::data>>(request, partition_id_);
+          util::optional<serialization::pimpl::data>>(request, partition_id_);
     }
 
     boost::future<int64_t> add_all_data(

--- a/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
@@ -205,18 +205,18 @@ protected:
     }
 
     template<typename T>
-    inline boost::future<boost::optional<T>> to_object(
-      boost::future<boost::optional<serialization::pimpl::data>> f)
+    inline boost::future<util::optional<T>> to_object(
+      boost::future<util::optional<serialization::pimpl::data>> f)
     {
         return f.then(
           boost::launch::sync,
-          [this](boost::future<boost::optional<serialization::pimpl::data>> f) {
+          [this](boost::future<util::optional<serialization::pimpl::data>> f) {
               return to_object<T>(f.get().get_ptr());
           });
     }
 
     template<typename T>
-    boost::future<boost::optional<T>> to_object(
+    boost::future<util::optional<T>> to_object(
       boost::future<serialization::pimpl::data> f)
     {
         return f.then(boost::launch::sync,
@@ -226,7 +226,7 @@ protected:
     }
 
     template<typename T>
-    boost::future<boost::optional<T>> to_object(
+    boost::future<util::optional<T>> to_object(
       boost::future<std::unique_ptr<serialization::pimpl::data>> f)
     {
         return f.then(
@@ -255,13 +255,13 @@ protected:
     }
 
     template<typename K, typename V>
-    boost::future<std::unordered_map<K, boost::optional<V>>> to_object_map(
+    boost::future<std::unordered_map<K, util::optional<V>>> to_object_map(
       boost::future<EntryVector> entries_data)
     {
         return entries_data.then(
           boost::launch::sync, [this](boost::future<EntryVector> f) {
               auto entries = f.get();
-              std::unordered_map<K, boost::optional<V>> result;
+              std::unordered_map<K, util::optional<V>> result;
               result.reserve(entries.size());
               for (const auto& e : entries) {
                   result.insert({ std::move(to_object<K>(e.first)).value(),
@@ -272,16 +272,16 @@ protected:
     }
 
     template<typename K, typename V>
-    inline boost::future<boost::optional<entry_view<K, V>>>
+    inline boost::future<util::optional<entry_view<K, V>>>
     to_object_entry_view(
-      boost::future<boost::optional<map::data_entry_view>> data_future)
+      boost::future<util::optional<map::data_entry_view>> data_future)
     {
         return data_future.then(
           boost::launch::sync,
-          [this](boost::future<boost::optional<map::data_entry_view>> f) {
+          [this](boost::future<util::optional<map::data_entry_view>> f) {
               auto dataView = f.get();
               if (!dataView) {
-                  return boost::optional<entry_view<K, V>>();
+                  return util::optional<entry_view<K, V>>();
               }
               return boost::make_optional(
                 entry_view<K, V>(to_object<K>(dataView->get_key()).value(),
@@ -362,7 +362,7 @@ protected:
 
 protected:
     template<typename T>
-    static boost::future<boost::optional<T>> decode_optional_var_sized(
+    static boost::future<util::optional<T>> decode_optional_var_sized(
       boost::future<protocol::ClientMessage> f)
     {
         return f.then(boost::launch::sync,
@@ -403,7 +403,7 @@ private:
     template<typename T>
     typename std::enable_if<
       std::is_same<char*, typename std::remove_cv<T>::type>::value,
-      boost::optional<std::string>>::
+      util::optional<std::string>>::
       type inline to_object(const serialization::pimpl::data& data)
     {
         return to_object<std::string>(data);
@@ -413,20 +413,20 @@ private:
     typename std::enable_if<
       std::is_array<T>::value &&
         std::is_same<typename std::remove_all_extents<T>::type, char>::value,
-      boost::optional<std::string>>::
+      util::optional<std::string>>::
       type inline to_object(const serialization::pimpl::data& data)
     {
         return to_object<std::string>(data);
     }
 
     template<typename T>
-    inline boost::optional<T> to_object(const serialization::pimpl::data& data)
+    inline util::optional<T> to_object(const serialization::pimpl::data& data)
     {
         return serialization_service_.template to_object<T>(data);
     }
 
     template<typename T>
-    inline boost::optional<T> to_object(const serialization::pimpl::data* data)
+    inline util::optional<T> to_object(const serialization::pimpl::data* data)
     {
         if (!data) {
             return boost::none;
@@ -436,43 +436,43 @@ private:
     }
 
     template<typename T>
-    inline boost::optional<T> to_object(
+    inline util::optional<T> to_object(
       std::unique_ptr<serialization::pimpl::data>&& data)
     {
         return to_object<T>(data.get());
     }
 
     template<typename T>
-    inline boost::optional<T> to_object(
+    inline util::optional<T> to_object(
       std::unique_ptr<serialization::pimpl::data>& data)
     {
         return to_object<T>(data.get());
     }
 
     template<typename T>
-    inline boost::optional<T> to_object(
-      const boost::optional<serialization::pimpl::data>& data)
+    inline util::optional<T> to_object(
+      const util::optional<serialization::pimpl::data>& data)
     {
         return to_object<T>(data.get_ptr());
     }
 };
 
 template<>
-boost::future<boost::optional<serialization::pimpl::data>> HAZELCAST_API
+boost::future<util::optional<serialization::pimpl::data>> HAZELCAST_API
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request);
 
 template<>
-boost::future<boost::optional<map::data_entry_view>> HAZELCAST_API
+boost::future<util::optional<map::data_entry_view>> HAZELCAST_API
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
                                         const serialization::pimpl::data& key);
 
 template<>
-boost::future<boost::optional<serialization::pimpl::data>> HAZELCAST_API
+boost::future<util::optional<serialization::pimpl::data>> HAZELCAST_API
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
                                         int partition_id);
 
 template<>
-boost::future<boost::optional<serialization::pimpl::data>> HAZELCAST_API
+boost::future<util::optional<serialization::pimpl::data>> HAZELCAST_API
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
                                         const serialization::pimpl::data& key);
 

--- a/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
+++ b/hazelcast/include/hazelcast/client/proxy/SerializingProxy.h
@@ -283,7 +283,7 @@ protected:
               if (!dataView) {
                   return util::optional<entry_view<K, V>>();
               }
-              return boost::make_optional(
+              return util::make_optional(
                 entry_view<K, V>(to_object<K>(dataView->get_key()).value(),
                                  to_object<V>(dataView->get_value()).value(),
                                  dataView->get_cost(),

--- a/hazelcast/include/hazelcast/client/proxy/TransactionalMapImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/TransactionalMapImpl.h
@@ -42,21 +42,21 @@ protected:
     boost::future<bool> contains_key_data(
       const serialization::pimpl::data& key);
 
-    boost::future<boost::optional<serialization::pimpl::data>> get_data(
+    boost::future<util::optional<serialization::pimpl::data>> get_data(
       const serialization::pimpl::data& key);
 
-    boost::future<boost::optional<serialization::pimpl::data>> put_data(
+    boost::future<util::optional<serialization::pimpl::data>> put_data(
       const serialization::pimpl::data& key,
       const serialization::pimpl::data& value);
 
     boost::future<void> set_data(const serialization::pimpl::data& key,
                                  const serialization::pimpl::data& value);
 
-    boost::future<boost::optional<serialization::pimpl::data>>
+    boost::future<util::optional<serialization::pimpl::data>>
     put_if_absent_data(const serialization::pimpl::data& key,
                        const serialization::pimpl::data& value);
 
-    boost::future<boost::optional<serialization::pimpl::data>> replace_data(
+    boost::future<util::optional<serialization::pimpl::data>> replace_data(
       const serialization::pimpl::data& key,
       const serialization::pimpl::data& value);
 
@@ -65,7 +65,7 @@ protected:
       const serialization::pimpl::data& old_value,
       const serialization::pimpl::data& new_value);
 
-    boost::future<boost::optional<serialization::pimpl::data>> remove_data(
+    boost::future<util::optional<serialization::pimpl::data>> remove_data(
       const serialization::pimpl::data& key);
 
     boost::future<void> delete_entry_data(

--- a/hazelcast/include/hazelcast/client/proxy/TransactionalQueueImpl.h
+++ b/hazelcast/include/hazelcast/client/proxy/TransactionalQueueImpl.h
@@ -37,7 +37,7 @@ public:
     boost::future<bool> offer(const serialization::pimpl::data& e,
                               std::chrono::milliseconds timeout);
 
-    boost::future<boost::optional<serialization::pimpl::data>> poll_data(
+    boost::future<util::optional<serialization::pimpl::data>> poll_data(
       std::chrono::milliseconds timeout);
 };
 } // namespace proxy

--- a/hazelcast/include/hazelcast/client/query/paging_predicate.h
+++ b/hazelcast/include/hazelcast/client/query/paging_predicate.h
@@ -70,7 +70,7 @@ struct anchor_data_list
 {
     std::vector<int32_t> page_list;
     std::vector<std::pair<serialization::pimpl::data,
-                          boost::optional<serialization::pimpl::data>>>
+                          util::optional<serialization::pimpl::data>>>
       data_list;
 };
 
@@ -177,8 +177,8 @@ private:
     size_t page_size_;
     size_t page_;
     iteration_type iteration_type_;
-    boost::optional<serialization::pimpl::data> comparator_data_;
-    boost::optional<serialization::pimpl::data> predicate_data_;
+    util::optional<serialization::pimpl::data> comparator_data_;
+    util::optional<serialization::pimpl::data> predicate_data_;
 
     /**
      * Construct with a pageSize

--- a/hazelcast/include/hazelcast/client/reliable_topic.h
+++ b/hazelcast/include/hazelcast/client/reliable_topic.h
@@ -344,7 +344,7 @@ private:
         topic::message to_message(
           topic::impl::reliable::ReliableTopicMessage& message)
         {
-            boost::optional<member> m;
+            util::optional<member> m;
             auto& addr = message.get_publisher_address();
             if (addr.has_value()) {
                 m = boost::make_optional<member>(addr.value());

--- a/hazelcast/include/hazelcast/client/reliable_topic.h
+++ b/hazelcast/include/hazelcast/client/reliable_topic.h
@@ -347,7 +347,7 @@ private:
             util::optional<member> m;
             auto& addr = message.get_publisher_address();
             if (addr.has_value()) {
-                m = boost::make_optional<member>(addr.value());
+                m = util::make_optional<member>(addr.value());
             }
             return topic::message(name_,
                                   typed_data(std::move(message.get_payload()),

--- a/hazelcast/include/hazelcast/client/replicated_map.h
+++ b/hazelcast/include/hazelcast/client/replicated_map.h
@@ -64,7 +64,7 @@ public:
      *         <tt>empty</tt> if there was no mapping for <tt>key</tt>.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> put(const K& key,
+    boost::future<util::optional<R>> put(const K& key,
                                           const V& value,
                                           std::chrono::milliseconds ttl)
     {
@@ -274,7 +274,7 @@ public:
      * @return The value of the key if the key exist, null pointer otherwise.
      */
     template<typename K, typename V>
-    boost::future<boost::optional<V>> get(const K& key)
+    boost::future<util::optional<V>> get(const K& key)
     {
         return to_object<V>(get_data(to_data(key)));
     }
@@ -287,7 +287,7 @@ public:
      * otherwise.
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> put(const K& key, const V& value)
+    boost::future<util::optional<R>> put(const K& key, const V& value)
     {
         return put<K, V, R>(key, value, std::chrono::milliseconds(0));
     }
@@ -298,7 +298,7 @@ public:
      * @return The value associated with the removed key.
      */
     template<typename K, typename V>
-    boost::future<boost::optional<V>> remove(const K& key)
+    boost::future<util::optional<V>> remove(const K& key)
     {
         return to_object<V>(remove_data(to_data(key)));
     }
@@ -326,10 +326,10 @@ private:
         {}
 
         void handle_entry(
-          const boost::optional<serialization::pimpl::data>& key,
-          const boost::optional<serialization::pimpl::data>& value,
-          const boost::optional<serialization::pimpl::data>& old_value,
-          const boost::optional<serialization::pimpl::data>& merging_value,
+          const util::optional<serialization::pimpl::data>& key,
+          const util::optional<serialization::pimpl::data>& value,
+          const util::optional<serialization::pimpl::data>& old_value,
+          const util::optional<serialization::pimpl::data>& merging_value,
           int32_t event_type,
           boost::uuids::uuid uuid,
           int32_t number_of_affected_entries) override
@@ -357,10 +357,10 @@ private:
 
     private:
         void fire_map_wide_event(
-          const boost::optional<serialization::pimpl::data>& key,
-          const boost::optional<serialization::pimpl::data>& value,
-          const boost::optional<serialization::pimpl::data>& old_value,
-          const boost::optional<serialization::pimpl::data>& merging_value,
+          const util::optional<serialization::pimpl::data>& key,
+          const util::optional<serialization::pimpl::data>& value,
+          const util::optional<serialization::pimpl::data>& old_value,
+          const util::optional<serialization::pimpl::data>& merging_value,
           int32_t event_type,
           boost::uuids::uuid uuid,
           int32_t number_of_affected_entries)
@@ -375,10 +375,10 @@ private:
         }
 
         void fire_entry_event(
-          const boost::optional<serialization::pimpl::data>& key,
-          const boost::optional<serialization::pimpl::data>& value,
-          const boost::optional<serialization::pimpl::data>& old_value,
-          const boost::optional<serialization::pimpl::data>& merging_value,
+          const util::optional<serialization::pimpl::data>& key,
+          const util::optional<serialization::pimpl::data>& value,
+          const util::optional<serialization::pimpl::data>& old_value,
+          const util::optional<serialization::pimpl::data>& merging_value,
           int32_t event_type,
           boost::uuids::uuid uuid,
           int32_t number_of_affected_entries)

--- a/hazelcast/include/hazelcast/client/ringbuffer.h
+++ b/hazelcast/include/hazelcast/client/ringbuffer.h
@@ -134,7 +134,7 @@ public:
      * blocking.
      */
     template<typename E>
-    boost::future<boost::optional<E>> read_one(int64_t sequence)
+    boost::future<util::optional<E>> read_one(int64_t sequence)
     {
         return to_object<E>(read_one_data(sequence));
     }

--- a/hazelcast/include/hazelcast/client/ringbuffer/read_result_set.h
+++ b/hazelcast/include/hazelcast/client/ringbuffer/read_result_set.h
@@ -39,7 +39,7 @@ public:
       int32_t read_count,
       std::vector<serialization::pimpl::data>&& data_items,
       serialization::pimpl::SerializationService& serialization_service,
-      boost::optional<std::vector<int64_t>>& item_seqs,
+      util::optional<std::vector<int64_t>>& item_seqs,
       int64_t next_seq)
       : items_read_count_(read_count)
       , item_seqs_(std::move(item_seqs))
@@ -116,7 +116,7 @@ public:
 private:
     int32_t items_read_count_;
     std::vector<typed_data> items_;
-    boost::optional<std::vector<int64_t>> item_seqs_;
+    util::optional<std::vector<int64_t>> item_seqs_;
     int64_t next_seq_;
 };
 } // namespace rb

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/compact.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/compact.h
@@ -212,7 +212,7 @@ public:
      * schema or the type of the field does not match with the one defined
      *in  the schema.
      */
-    boost::optional<std::string> read_string(const std::string& field_name);
+    util::optional<std::string> read_string(const std::string& field_name);
 
     /**
      * Reads an arbitrary precision and scale floating point number.
@@ -223,7 +223,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<big_decimal> read_decimal(const std::string& field_name);
+    util::optional<big_decimal> read_decimal(const std::string& field_name);
 
     /**
      * Reads a time consisting of hour, minute, second, and nano seconds.
@@ -234,7 +234,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<local_time> read_time(const std::string& field_name);
+    util::optional<local_time> read_time(const std::string& field_name);
 
     /**
      * Reads a date consisting of year, month, and day.
@@ -245,7 +245,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<local_date> read_date(const std::string& field_name);
+    util::optional<local_date> read_date(const std::string& field_name);
 
     /**
      * Reads a timestamp consisting of date and time.
@@ -256,7 +256,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<local_date_time> read_timestamp(
+    util::optional<local_date_time> read_timestamp(
       const std::string& field_name);
 
     /**
@@ -269,7 +269,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<offset_date_time> read_timestamp_with_timezone(
+    util::optional<offset_date_time> read_timestamp_with_timezone(
       const std::string& field_name);
 
     /**
@@ -282,7 +282,7 @@ public:
      * in the schema.
      */
     template<typename T>
-    boost::optional<T> read_compact(const std::string& field_name);
+    util::optional<T> read_compact(const std::string& field_name);
 
     /**
      * Reads an array of booleans.
@@ -293,7 +293,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<bool>> read_array_of_boolean(
+    util::optional<std::vector<bool>> read_array_of_boolean(
       const std::string& field_name);
 
     /**
@@ -305,7 +305,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<int8_t>> read_array_of_int8(
+    util::optional<std::vector<int8_t>> read_array_of_int8(
       const std::string& field_name);
 
     /**
@@ -317,7 +317,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<int16_t>> read_array_of_int16(
+    util::optional<std::vector<int16_t>> read_array_of_int16(
       const std::string& field_name);
 
     /**
@@ -329,7 +329,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<int32_t>> read_array_of_int32(
+    util::optional<std::vector<int32_t>> read_array_of_int32(
       const std::string& field_name);
 
     /**
@@ -341,7 +341,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<int64_t>> read_array_of_int64(
+    util::optional<std::vector<int64_t>> read_array_of_int64(
       const std::string& field_name);
 
     /**
@@ -353,7 +353,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<float>> read_array_of_float32(
+    util::optional<std::vector<float>> read_array_of_float32(
       const std::string& field_name);
 
     /**
@@ -365,7 +365,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<double>> read_array_of_float64(
+    util::optional<std::vector<double>> read_array_of_float64(
       const std::string& field_name);
 
     /**
@@ -377,7 +377,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<std::string>>>
+    util::optional<std::vector<util::optional<std::string>>>
     read_array_of_string(const std::string& field_name);
 
     /**
@@ -389,7 +389,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<big_decimal>>>
+    util::optional<std::vector<util::optional<big_decimal>>>
     read_array_of_decimal(const std::string& field_name);
 
     /**
@@ -402,7 +402,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<local_time>>>
+    util::optional<std::vector<util::optional<local_time>>>
     read_array_of_time(const std::string& field_name);
 
     /**
@@ -414,7 +414,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<local_date>>>
+    util::optional<std::vector<util::optional<local_date>>>
     read_array_of_date(const std::string& field_name);
 
     /**
@@ -426,7 +426,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<local_date_time>>>
+    util::optional<std::vector<util::optional<local_date_time>>>
     read_array_of_timestamp(const std::string& field_name);
 
     /**
@@ -439,7 +439,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<offset_date_time>>>
+    util::optional<std::vector<util::optional<offset_date_time>>>
     read_array_of_timestamp_with_timezone(const std::string& field_name);
 
     /**
@@ -452,7 +452,7 @@ public:
      * in the schema.
      */
     template<typename T>
-    boost::optional<std::vector<boost::optional<T>>> read_array_of_compact(
+    util::optional<std::vector<util::optional<T>>> read_array_of_compact(
       const std::string& field_name);
 
     /**
@@ -464,7 +464,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<bool> read_nullable_boolean(const std::string& field_name);
+    util::optional<bool> read_nullable_boolean(const std::string& field_name);
 
     /**
      * Reads a nullable 8-bit two's complement signed integer.
@@ -475,7 +475,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<int8_t> read_nullable_int8(const std::string& field_name);
+    util::optional<int8_t> read_nullable_int8(const std::string& field_name);
 
     /**
      * Reads a nullable 16-bit two's complement signed integer.
@@ -486,7 +486,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<int16_t> read_nullable_int16(const std::string& field_name);
+    util::optional<int16_t> read_nullable_int16(const std::string& field_name);
 
     /**
      * Reads a nullable 32-bit two's complement signed integer.
@@ -497,7 +497,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<int32_t> read_nullable_int32(const std::string& field_name);
+    util::optional<int32_t> read_nullable_int32(const std::string& field_name);
 
     /**
      * Reads a nullable 64-bit two's complement signed integer.
@@ -508,7 +508,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<int64_t> read_nullable_int64(const std::string& field_name);
+    util::optional<int64_t> read_nullable_int64(const std::string& field_name);
 
     /**
      * Reads a nullable 32-bit IEEE 754 floating point number.
@@ -519,7 +519,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<float> read_nullable_float32(const std::string& field_name);
+    util::optional<float> read_nullable_float32(const std::string& field_name);
 
     /**
      * Reads a nullable 64-bit IEEE 754 floating point number.
@@ -530,7 +530,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<double> read_nullable_float64(
+    util::optional<double> read_nullable_float64(
       const std::string& field_name);
 
     /**
@@ -542,7 +542,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<bool>>>
+    util::optional<std::vector<util::optional<bool>>>
     read_array_of_nullable_boolean(const std::string& field_name);
 
     /**
@@ -555,7 +555,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<int8_t>>>
+    util::optional<std::vector<util::optional<int8_t>>>
     read_array_of_nullable_int8(const std::string& field_name);
 
     /**
@@ -568,7 +568,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<int16_t>>>
+    util::optional<std::vector<util::optional<int16_t>>>
     read_array_of_nullable_int16(const std::string& field_name);
 
     /**
@@ -581,7 +581,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<int32_t>>>
+    util::optional<std::vector<util::optional<int32_t>>>
     read_array_of_nullable_int32(const std::string& field_name);
 
     /**
@@ -594,7 +594,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<int64_t>>>
+    util::optional<std::vector<util::optional<int64_t>>>
     read_array_of_nullable_int64(const std::string& field_name);
 
     /**
@@ -607,7 +607,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<float>>>
+    util::optional<std::vector<util::optional<float>>>
     read_array_of_nullable_float32(const std::string& field_name);
 
     /**
@@ -620,7 +620,7 @@ public:
      * schema or the type of the field does not match with the one defined
      * in the schema.
      */
-    boost::optional<std::vector<boost::optional<double>>>
+    util::optional<std::vector<util::optional<double>>>
     read_array_of_nullable_float64(const std::string& field_name);
 
 private:
@@ -646,10 +646,10 @@ private:
       const std::string& field_name,
       enum pimpl::field_kind field_kind) const;
     template<typename T>
-    boost::optional<T> read_variable_size(
+    util::optional<T> read_variable_size(
       const pimpl::field_descriptor& field_descriptor);
     template<typename T>
-    boost::optional<T> read_variable_size(const std::string& field_name,
+    util::optional<T> read_variable_size(const std::string& field_name,
                                           enum pimpl::field_kind field_kind);
     template<typename T>
     T read_variable_size_as_non_null(
@@ -678,25 +678,25 @@ private:
                      typename std::remove_cv<T>::type>::value ||
         std::is_same<std::vector<double>,
                      typename std::remove_cv<T>::type>::value ||
-        std::is_same<std::vector<boost::optional<std::string>>,
+        std::is_same<std::vector<util::optional<std::string>>,
                      typename std::remove_cv<T>::type>::value,
-      typename boost::optional<T>>::type
+      typename util::optional<T>>::type
     read();
     template<typename T>
     typename std::enable_if<
       std::is_base_of<compact_serializer, hz_serializer<T>>::value,
-      typename boost::optional<T>>::type
+      typename util::optional<T>>::type
     read();
     template<typename T>
     typename std::enable_if<
       std::is_same<std::vector<bool>, typename std::remove_cv<T>::type>::value,
-      typename boost::optional<T>>::type
+      typename util::optional<T>>::type
     read();
     template<typename T>
     typename std::enable_if<
-      std::is_same<std::vector<boost::optional<bool>>,
+      std::is_same<std::vector<util::optional<bool>>,
                    typename std::remove_cv<T>::type>::value,
-      typename boost::optional<T>>::type
+      typename util::optional<T>>::type
     read();
     template<typename T>
     typename std::enable_if<
@@ -706,20 +706,20 @@ private:
         std::is_same<local_date_time,
                      typename std::remove_cv<T>::type>::value ||
         std::is_same<offset_date_time, typename std::remove_cv<T>::type>::value,
-      typename boost::optional<T>>::type
+      typename util::optional<T>>::type
     read();
     template<typename T>
-    boost::optional<T> read_array_of_primitive(
+    util::optional<T> read_array_of_primitive(
       const std::string& field_name,
       enum pimpl::field_kind field_kind,
       enum pimpl::field_kind nullable_field_kind,
       const std::string& method_suffix);
     template<typename T>
-    boost::optional<std::vector<boost::optional<T>>>
+    util::optional<std::vector<util::optional<T>>>
     read_array_of_variable_size(
       const pimpl::field_descriptor& field_descriptor);
     template<typename T>
-    boost::optional<T> read_nullable_array_as_primitive_array(
+    util::optional<T> read_nullable_array_as_primitive_array(
       const pimpl::field_descriptor& field_descriptor,
       const std::string& field_name,
       const std::string& method_suffix);
@@ -729,17 +729,17 @@ private:
     static const offset_func SHORT_OFFSET_READER;
     static const offset_func INT_OFFSET_READER;
     template<typename T>
-    boost::optional<T> read_nullable_primitive(
+    util::optional<T> read_nullable_primitive(
       const std::string& field_name,
       enum pimpl::field_kind field_kind,
       enum pimpl::field_kind nullable_field_kind);
     template<typename T>
-    boost::optional<std::vector<boost::optional<T>>> read_array_of_nullable(
+    util::optional<std::vector<util::optional<T>>> read_array_of_nullable(
       const std::string& field_name,
       enum pimpl::field_kind field_kind,
       enum pimpl::field_kind nullable_field_kind);
     template<typename T>
-    boost::optional<std::vector<boost::optional<T>>>
+    util::optional<std::vector<util::optional<T>>>
     read_primitive_array_as_nullable_array(
       const pimpl::field_descriptor& field_descriptor);
     static std::function<
@@ -850,7 +850,7 @@ public:
      * @param value to be written.
      */
     void write_string(const std::string& field_name,
-                      const boost::optional<std::string>& value);
+                      const util::optional<std::string>& value);
 
     /**
      * Writes an arbitrary precision and scale floating point number.
@@ -859,7 +859,7 @@ public:
      * @param value to be written.
      */
     void write_decimal(const std::string& field_name,
-                       const boost::optional<big_decimal>& value);
+                       const util::optional<big_decimal>& value);
 
     /**
      *  Writes a time consisting of hour, minute, second, and nanoseconds.
@@ -868,7 +868,7 @@ public:
      *  @param value to be written.
      */
     void write_time(const std::string& field_name,
-                    const boost::optional<local_time>& value);
+                    const util::optional<local_time>& value);
 
     /**
      * Writes a date consisting of year, month, and day.
@@ -877,7 +877,7 @@ public:
      * @param value to be written.
      */
     void write_date(const std::string& field_name,
-                    const boost::optional<local_date>& value);
+                    const util::optional<local_date>& value);
 
     /**
      * Writes a timestamp consisting of date and time.
@@ -886,7 +886,7 @@ public:
      * @param value to be written.
      */
     void write_timestamp(const std::string& field_name,
-                         const boost::optional<local_date_time>& value);
+                         const util::optional<local_date_time>& value);
 
     /**
      * Writes a timestamp with timezone consisting of date, time and timezone
@@ -897,7 +897,7 @@ public:
      */
     void write_timestamp_with_timezone(
       const std::string& field_name,
-      const boost::optional<offset_date_time>& value);
+      const util::optional<offset_date_time>& value);
 
     /**
      * Writes a nested compact object.
@@ -907,7 +907,7 @@ public:
      */
     template<typename T>
     void write_compact(const std::string& field_name,
-                       const boost::optional<T>& value);
+                       const util::optional<T>& value);
 
     /**
      * Writes an array of booleans.
@@ -917,7 +917,7 @@ public:
      */
     void write_array_of_boolean(
       const std::string& field_name,
-      const boost::optional<std::vector<bool>>& value);
+      const util::optional<std::vector<bool>>& value);
 
     /**
      * Writes an array of 8-bit two's complement signed integers.
@@ -926,7 +926,7 @@ public:
      * @param value to be written.
      */
     void write_array_of_int8(const std::string& field_name,
-                             const boost::optional<std::vector<int8_t>>& value);
+                             const util::optional<std::vector<int8_t>>& value);
 
     /**
      * Writes an array of 16-bit two's complement signed integers.
@@ -936,7 +936,7 @@ public:
      */
     void write_array_of_int16(
       const std::string& field_name,
-      const boost::optional<std::vector<int16_t>>& value);
+      const util::optional<std::vector<int16_t>>& value);
 
     /**
      * Writes an array of 32-bit two's complement signed integers.
@@ -946,7 +946,7 @@ public:
      */
     void write_array_of_int32(
       const std::string& field_name,
-      const boost::optional<std::vector<int32_t>>& value);
+      const util::optional<std::vector<int32_t>>& value);
 
     /**
      * Writes an array of 64-bit two's complement signed integers.
@@ -956,7 +956,7 @@ public:
      */
     void write_array_of_int64(
       const std::string& field_name,
-      const boost::optional<std::vector<int64_t>>& value);
+      const util::optional<std::vector<int64_t>>& value);
 
     /**
      * Writes an array of 32-bit IEEE 754 floating point numbers.
@@ -966,7 +966,7 @@ public:
      */
     void write_array_of_float32(
       const std::string& field_name,
-      const boost::optional<std::vector<float>>& value);
+      const util::optional<std::vector<float>>& value);
 
     /**
      * Writes an array of 64-bit IEEE 754 floating point numbers.
@@ -976,7 +976,7 @@ public:
      */
     void write_array_of_float64(
       const std::string& field_name,
-      const boost::optional<std::vector<double>>& value);
+      const util::optional<std::vector<double>>& value);
 
     /**
      * Writes an array of UTF-8 encoded strings.
@@ -986,7 +986,7 @@ public:
      */
     void write_array_of_string(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<std::string>>>& value);
+      const util::optional<std::vector<util::optional<std::string>>>& value);
 
     /**
      * Writes an array of arbitrary precision and scale floating point numbers.
@@ -996,7 +996,7 @@ public:
      */
     void write_array_of_decimal(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<big_decimal>>>& value);
+      const util::optional<std::vector<util::optional<big_decimal>>>& value);
 
     /**
      * Writes an array of times consisting of hour, minute, second, and nano
@@ -1007,7 +1007,7 @@ public:
      */
     void write_array_of_time(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<local_time>>>& value);
+      const util::optional<std::vector<util::optional<local_time>>>& value);
 
     /**
      * Writes an array of dates consisting of year, month, and day.
@@ -1017,7 +1017,7 @@ public:
      */
     void write_array_of_date(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<local_date>>>& value);
+      const util::optional<std::vector<util::optional<local_date>>>& value);
 
     /**
      * Writes an array of timestamps consisting of date and time.
@@ -1027,7 +1027,7 @@ public:
      */
     void write_array_of_timestamp(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<local_date_time>>>&
+      const util::optional<std::vector<util::optional<local_date_time>>>&
         value);
 
     /**
@@ -1039,7 +1039,7 @@ public:
      */
     void write_array_of_timestamp_with_timezone(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<offset_date_time>>>&
+      const util::optional<std::vector<util::optional<offset_date_time>>>&
         value);
 
     /**
@@ -1051,7 +1051,7 @@ public:
     template<typename T>
     void write_array_of_compact(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<T>>>& value);
+      const util::optional<std::vector<util::optional<T>>>& value);
 
     /**
      * Writes a nullable boolean.
@@ -1060,7 +1060,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_boolean(const std::string& field_name,
-                                const boost::optional<bool>& value);
+                                const util::optional<bool>& value);
 
     /**
      * Writes a nullable 8-bit two's complement signed integer.
@@ -1069,7 +1069,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_int8(const std::string& field_name,
-                             const boost::optional<int8_t>& value);
+                             const util::optional<int8_t>& value);
 
     /**
      * Writes a nullable 16-bit two's complement signed integer.
@@ -1078,7 +1078,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_int16(const std::string& field_name,
-                              const boost::optional<int16_t>& value);
+                              const util::optional<int16_t>& value);
 
     /**
      * Writes a nullable 32-bit two's complement signed integer.
@@ -1087,7 +1087,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_int32(const std::string& field_name,
-                              const boost::optional<int32_t>& value);
+                              const util::optional<int32_t>& value);
 
     /**
      * Writes a nullable 64-bit two's complement signed integer.
@@ -1096,7 +1096,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_int64(const std::string& field_name,
-                              const boost::optional<int64_t>& value);
+                              const util::optional<int64_t>& value);
 
     /**
      * Writes a nullable 32-bit IEEE 754 floating point number.
@@ -1105,7 +1105,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_float32(const std::string& field_name,
-                                const boost::optional<float>& value);
+                                const util::optional<float>& value);
 
     /**
      * Writes a nullable 64-bit IEEE 754 floating point number.
@@ -1114,7 +1114,7 @@ public:
      * @param value to be written.
      */
     void write_nullable_float64(const std::string& field_name,
-                                const boost::optional<double>& value);
+                                const util::optional<double>& value);
 
     /**
      * Writes a nullable array of nullable booleans.
@@ -1124,7 +1124,7 @@ public:
      */
     void write_array_of_nullable_boolean(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<bool>>>& value);
+      const util::optional<std::vector<util::optional<bool>>>& value);
 
     /**
      * Writes a nullable array of nullable 8-bit two's complement signed
@@ -1135,7 +1135,7 @@ public:
      */
     void write_array_of_nullable_int8(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int8_t>>>& value);
+      const util::optional<std::vector<util::optional<int8_t>>>& value);
 
     /**
      * Writes a nullable array of nullable 16-bit two's complement signed
@@ -1146,7 +1146,7 @@ public:
      */
     void write_array_of_nullable_int16(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int16_t>>>& value);
+      const util::optional<std::vector<util::optional<int16_t>>>& value);
 
     /**
      * Writes a nullable array of nullable 32-bit two's complement signed
@@ -1157,7 +1157,7 @@ public:
      */
     void write_array_of_nullable_int32(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int32_t>>>& value);
+      const util::optional<std::vector<util::optional<int32_t>>>& value);
 
     /**
      * Writes a nullable array of nullable 64-bit two's complement signed
@@ -1168,7 +1168,7 @@ public:
      */
     void write_array_of_nullable_int64(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int64_t>>>& value);
+      const util::optional<std::vector<util::optional<int64_t>>>& value);
 
     /**
      * Writes a nullable array of nullable 32-bit IEEE 754 floating point
@@ -1179,7 +1179,7 @@ public:
      */
     void write_array_of_nullable_float32(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<float>>>& value);
+      const util::optional<std::vector<util::optional<float>>>& value);
 
     /**
      * Writes a nullable array of nullable 64-bit IEEE 754 floating point
@@ -1190,7 +1190,7 @@ public:
      */
     void write_array_of_nullable_float64(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<double>>>& value);
+      const util::optional<std::vector<util::optional<double>>>& value);
 
 private:
     friend compact_writer pimpl::create_compact_writer(
@@ -1239,100 +1239,100 @@ public:
     void write_float32(const std::string& field_name, float value);
     void write_float64(const std::string& field_name, double value);
     void write_string(const std::string& field_name,
-                      const boost::optional<std::string>& value);
+                      const util::optional<std::string>& value);
     void write_decimal(const std::string& field_name,
-                       const boost::optional<big_decimal>& value);
+                       const util::optional<big_decimal>& value);
     void write_time(const std::string& field_name,
-                    const boost::optional<local_time>& value);
+                    const util::optional<local_time>& value);
     void write_date(const std::string& field_name,
-                    const boost::optional<local_date>& value);
+                    const util::optional<local_date>& value);
     void write_timestamp(const std::string& field_name,
-                         const boost::optional<local_date_time>& value);
+                         const util::optional<local_date_time>& value);
     void write_timestamp_with_timezone(
       const std::string& field_name,
-      const boost::optional<offset_date_time>& value);
+      const util::optional<offset_date_time>& value);
     template<typename T>
     void write_compact(const std::string& field_name,
-                       const boost::optional<T>& value);
+                       const util::optional<T>& value);
     void write_array_of_boolean(
       const std::string& field_name,
-      const boost::optional<std::vector<bool>>& value);
+      const util::optional<std::vector<bool>>& value);
     void write_array_of_int8(const std::string& field_name,
-                             const boost::optional<std::vector<int8_t>>& value);
+                             const util::optional<std::vector<int8_t>>& value);
     void write_array_of_int16(
       const std::string& field_name,
-      const boost::optional<std::vector<int16_t>>& value);
+      const util::optional<std::vector<int16_t>>& value);
     void write_array_of_int32(
       const std::string& field_name,
-      const boost::optional<std::vector<int32_t>>& value);
+      const util::optional<std::vector<int32_t>>& value);
     void write_array_of_int64(
       const std::string& field_name,
-      const boost::optional<std::vector<int64_t>>& value);
+      const util::optional<std::vector<int64_t>>& value);
     void write_array_of_float32(
       const std::string& field_name,
-      const boost::optional<std::vector<float>>& value);
+      const util::optional<std::vector<float>>& value);
     void write_array_of_float64(
       const std::string& field_name,
-      const boost::optional<std::vector<double>>& value);
+      const util::optional<std::vector<double>>& value);
     void write_array_of_string(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<std::string>>>& value);
+      const util::optional<std::vector<util::optional<std::string>>>& value);
     void write_array_of_decimal(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<big_decimal>>>& value);
+      const util::optional<std::vector<util::optional<big_decimal>>>& value);
     void write_array_of_time(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<local_time>>>& value);
+      const util::optional<std::vector<util::optional<local_time>>>& value);
     void write_array_of_date(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<local_date>>>& value);
+      const util::optional<std::vector<util::optional<local_date>>>& value);
     void write_array_of_timestamp(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<local_date_time>>>&
+      const util::optional<std::vector<util::optional<local_date_time>>>&
         value);
     void write_array_of_timestamp_with_timezone(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<offset_date_time>>>&
+      const util::optional<std::vector<util::optional<offset_date_time>>>&
         value);
     template<typename T>
     void write_array_of_compact(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<T>>>& value);
+      const util::optional<std::vector<util::optional<T>>>& value);
     void write_nullable_boolean(const std::string& field_name,
-                                const boost::optional<bool>& value);
+                                const util::optional<bool>& value);
     void write_nullable_int8(const std::string& field_name,
-                             const boost::optional<int8_t>& value);
+                             const util::optional<int8_t>& value);
     void write_nullable_int16(const std::string& field_name,
-                              const boost::optional<int16_t>& value);
+                              const util::optional<int16_t>& value);
     void write_nullable_int32(const std::string& field_name,
-                              const boost::optional<int32_t>& value);
+                              const util::optional<int32_t>& value);
     void write_nullable_int64(const std::string& field_name,
-                              const boost::optional<int64_t>& value);
+                              const util::optional<int64_t>& value);
     void write_nullable_float32(const std::string& field_name,
-                                const boost::optional<float>& value);
+                                const util::optional<float>& value);
     void write_nullable_float64(const std::string& field_name,
-                                const boost::optional<double>& value);
+                                const util::optional<double>& value);
     void write_array_of_nullable_boolean(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<bool>>>& value);
+      const util::optional<std::vector<util::optional<bool>>>& value);
     void write_array_of_nullable_int8(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int8_t>>>& value);
+      const util::optional<std::vector<util::optional<int8_t>>>& value);
     void write_array_of_nullable_int16(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int16_t>>>& value);
+      const util::optional<std::vector<util::optional<int16_t>>>& value);
     void write_array_of_nullable_int32(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int32_t>>>& value);
+      const util::optional<std::vector<util::optional<int32_t>>>& value);
     void write_array_of_nullable_int64(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<int64_t>>>& value);
+      const util::optional<std::vector<util::optional<int64_t>>>& value);
     void write_array_of_nullable_float32(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<float>>>& value);
+      const util::optional<std::vector<util::optional<float>>>& value);
     void write_array_of_nullable_float64(
       const std::string& field_name,
-      const boost::optional<std::vector<boost::optional<double>>>& value);
+      const util::optional<std::vector<util::optional<double>>>& value);
     void end();
 
 private:
@@ -1346,7 +1346,7 @@ private:
     template<typename T>
     void write_variable_size_field(const std::string& field_name,
                                    enum field_kind field_kind,
-                                   const boost::optional<T>& value);
+                                   const util::optional<T>& value);
 
     template<typename T>
     typename std::enable_if<
@@ -1392,7 +1392,7 @@ private:
     void write_array_of_variable_size(
       const std::string& field_name,
       enum field_kind field_kind,
-      const boost::optional<std::vector<boost::optional<T>>>& value);
+      const util::optional<std::vector<util::optional<T>>>& value);
 
     void set_position(const std::string& field_name,
                       enum field_kind field_kind);

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/compact.i.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/compact.i.h
@@ -177,7 +177,7 @@ compact_reader::read()
 {
     int32_t len = object_data_input.read<int32_t>();
     if (len == 0) {
-        return boost::make_optional(std::vector<bool>(0));
+        return util::make_optional(std::vector<bool>(0));
     }
     std::vector<bool> values(len);
     int index = 0;
@@ -191,7 +191,7 @@ compact_reader::read()
         index++;
         values[i] = result;
     }
-    return boost::make_optional(std::move(values));
+    return util::make_optional(std::move(values));
 }
 
 template<typename T>
@@ -202,10 +202,10 @@ compact_reader::read()
 {
     int32_t len = object_data_input.read<int32_t>();
     if (len == 0) {
-        return boost::make_optional<std::vector<util::optional<bool>>>(
+        return util::make_optional<std::vector<util::optional<bool>>>(
           std::vector<util::optional<bool>>(0));
     }
-    auto values = boost::make_optional<std::vector<util::optional<bool>>>(
+    auto values = util::make_optional<std::vector<util::optional<bool>>>(
       std::vector<util::optional<bool>>(len));
     int index = 0;
     byte current_byte = object_data_input.read<byte>();
@@ -215,7 +215,7 @@ compact_reader::read()
             current_byte = object_data_input.read<byte>();
         }
         bool result = ((current_byte >> index) & 1) != 0;
-        values.value()[i] = boost::make_optional<bool>(std::move(result));
+        values.value()[i] = util::make_optional<bool>(std::move(result));
         index++;
     }
     return values;
@@ -231,7 +231,7 @@ typename std::enable_if<
   typename util::optional<T>>::type
 compact_reader::read()
 {
-    return boost::make_optional<T>(
+    return util::make_optional<T>(
       pimpl::serialization_util::read<T>(object_data_input));
 }
 
@@ -324,7 +324,7 @@ compact_reader::read_nullable_primitive(
 {
     auto& field_descriptor = get_field_descriptor(field_name);
     if (field_descriptor.field_kind == field_kind) {
-        return boost::make_optional<T>(read_primitive<T>(field_descriptor));
+        return util::make_optional<T>(read_primitive<T>(field_descriptor));
     } else if (field_descriptor.field_kind == nullable_field_kind) {
         return read_variable_size<T>(field_descriptor);
     }
@@ -365,9 +365,9 @@ compact_reader::read_primitive_array_as_nullable_array(
     std::vector<util::optional<T>> values(item_count);
 
     for (int i = 0; i < item_count; ++i) {
-        values[i] = boost::make_optional(object_data_input.read<T>());
+        values[i] = util::make_optional(object_data_input.read<T>());
     }
-    return boost::make_optional(std::move(values));
+    return util::make_optional(std::move(values));
 }
 
 template<>

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/compact.i.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/compact.i.h
@@ -92,7 +92,7 @@ bool inline compact_reader::read_primitive<bool>(
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 compact_reader::read_variable_size(
   const pimpl::field_descriptor& field_descriptor)
 {
@@ -109,7 +109,7 @@ compact_reader::read_variable_size(
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 compact_reader::read_variable_size(const std::string& field_name,
                                    enum pimpl::field_kind field_kind)
 {
@@ -152,9 +152,9 @@ typename std::enable_if<
     std::is_same<std::vector<float>, typename std::remove_cv<T>::type>::value ||
     std::is_same<std::vector<double>,
                  typename std::remove_cv<T>::type>::value ||
-    std::is_same<std::vector<boost::optional<std::string>>,
+    std::is_same<std::vector<util::optional<std::string>>,
                  typename std::remove_cv<T>::type>::value,
-  typename boost::optional<T>>::type
+  typename util::optional<T>>::type
 compact_reader::read()
 {
     return object_data_input.template read<T>();
@@ -163,7 +163,7 @@ compact_reader::read()
 template<typename T>
 typename std::enable_if<
   std::is_base_of<compact_serializer, hz_serializer<T>>::value,
-  typename boost::optional<T>>::type
+  typename util::optional<T>>::type
 compact_reader::read()
 {
     return compact_stream_serializer.template read<T>(object_data_input);
@@ -172,7 +172,7 @@ compact_reader::read()
 template<typename T>
 typename std::enable_if<
   std::is_same<std::vector<bool>, typename std::remove_cv<T>::type>::value,
-  typename boost::optional<T>>::type
+  typename util::optional<T>>::type
 compact_reader::read()
 {
     int32_t len = object_data_input.read<int32_t>();
@@ -195,18 +195,18 @@ compact_reader::read()
 }
 
 template<typename T>
-typename std::enable_if<std::is_same<std::vector<boost::optional<bool>>,
+typename std::enable_if<std::is_same<std::vector<util::optional<bool>>,
                                      typename std::remove_cv<T>::type>::value,
-                        typename boost::optional<T>>::type
+                        typename util::optional<T>>::type
 compact_reader::read()
 {
     int32_t len = object_data_input.read<int32_t>();
     if (len == 0) {
-        return boost::make_optional<std::vector<boost::optional<bool>>>(
-          std::vector<boost::optional<bool>>(0));
+        return boost::make_optional<std::vector<util::optional<bool>>>(
+          std::vector<util::optional<bool>>(0));
     }
-    auto values = boost::make_optional<std::vector<boost::optional<bool>>>(
-      std::vector<boost::optional<bool>>(len));
+    auto values = boost::make_optional<std::vector<util::optional<bool>>>(
+      std::vector<util::optional<bool>>(len));
     int index = 0;
     byte current_byte = object_data_input.read<byte>();
     for (int i = 0; i < len; ++i) {
@@ -228,7 +228,7 @@ typename std::enable_if<
     std::is_same<local_date, typename std::remove_cv<T>::type>::value ||
     std::is_same<local_date_time, typename std::remove_cv<T>::type>::value ||
     std::is_same<offset_date_time, typename std::remove_cv<T>::type>::value,
-  typename boost::optional<T>>::type
+  typename util::optional<T>>::type
 compact_reader::read()
 {
     return boost::make_optional<T>(
@@ -236,7 +236,7 @@ compact_reader::read()
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 compact_reader::read_array_of_primitive(
   const std::string& field_name,
   enum pimpl::field_kind field_kind,
@@ -254,7 +254,7 @@ compact_reader::read_array_of_primitive(
 }
 
 template<typename T>
-boost::optional<std::vector<boost::optional<T>>>
+util::optional<std::vector<util::optional<T>>>
 compact_reader::read_array_of_variable_size(
   const pimpl::field_descriptor& field_descriptor)
 {
@@ -270,7 +270,7 @@ compact_reader::read_array_of_variable_size(
     int32_t data_length = object_data_input.read<int32_t>();
     int32_t item_count = object_data_input.read<int32_t>();
     int data_start_pos = object_data_input.position();
-    std::vector<boost::optional<T>> values(item_count);
+    std::vector<util::optional<T>> values(item_count);
     auto offset_reader = get_offset_reader(data_length);
     int offsets_position = data_start_pos + data_length;
     for (int i = 0; i < item_count; ++i) {
@@ -284,7 +284,7 @@ compact_reader::read_array_of_variable_size(
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 compact_reader::read_nullable_array_as_primitive_array(
   const pimpl::field_descriptor& field_descriptor,
   const std::string& field_name,
@@ -316,7 +316,7 @@ compact_reader::read_nullable_array_as_primitive_array(
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 compact_reader::read_nullable_primitive(
   const std::string& field_name,
   enum pimpl::field_kind field_kind,
@@ -332,7 +332,7 @@ compact_reader::read_nullable_primitive(
 }
 
 template<typename T>
-boost::optional<std::vector<boost::optional<T>>>
+util::optional<std::vector<util::optional<T>>>
 compact_reader::read_array_of_nullable(
   const std::string& field_name,
   enum pimpl::field_kind field_kind,
@@ -348,7 +348,7 @@ compact_reader::read_array_of_nullable(
 }
 
 template<typename T>
-boost::optional<std::vector<boost::optional<T>>>
+util::optional<std::vector<util::optional<T>>>
 compact_reader::read_primitive_array_as_nullable_array(
   const pimpl::field_descriptor& field_descriptor)
 {
@@ -362,7 +362,7 @@ compact_reader::read_primitive_array_as_nullable_array(
     }
     object_data_input.position(pos);
     int32_t item_count = object_data_input.read<int32_t>();
-    std::vector<boost::optional<T>> values(item_count);
+    std::vector<util::optional<T>> values(item_count);
 
     for (int i = 0; i < item_count; ++i) {
         values[i] = boost::make_optional(object_data_input.read<T>());
@@ -371,23 +371,23 @@ compact_reader::read_primitive_array_as_nullable_array(
 }
 
 template<>
-boost::optional<std::vector<boost::optional<bool>>> inline compact_reader::
+util::optional<std::vector<util::optional<bool>>> inline compact_reader::
   read_primitive_array_as_nullable_array(
     const pimpl::field_descriptor& field_descriptor)
 {
-    return read_variable_size<std::vector<boost::optional<bool>>>(
+    return read_variable_size<std::vector<util::optional<bool>>>(
       field_descriptor);
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 compact_reader::read_compact(const std::string& field_name)
 {
     return read_variable_size<T>(field_name, pimpl::field_kind::COMPACT);
 }
 
 template<typename T>
-boost::optional<std::vector<boost::optional<T>>>
+util::optional<std::vector<util::optional<T>>>
 compact_reader::read_array_of_compact(const std::string& field_name)
 {
     const auto& descriptor =
@@ -398,7 +398,7 @@ compact_reader::read_array_of_compact(const std::string& field_name)
 template<typename T>
 void
 compact_writer::write_compact(const std::string& field_name,
-                              const boost::optional<T>& value)
+                              const util::optional<T>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_compact(field_name, value);
@@ -411,7 +411,7 @@ template<typename T>
 void
 compact_writer::write_array_of_compact(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<T>>>& value)
+  const util::optional<std::vector<util::optional<T>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_compact<T>(field_name, value);
@@ -427,7 +427,7 @@ void
 default_compact_writer::write_variable_size_field(
   const std::string& field_name,
   enum field_kind field_kind,
-  const boost::optional<T>& value)
+  const util::optional<T>& value)
 {
     if (!value.has_value()) {
         set_position_as_null(field_name, field_kind);
@@ -440,7 +440,7 @@ default_compact_writer::write_variable_size_field(
 template<typename T>
 void
 default_compact_writer::write_compact(const std::string& field_name,
-                                      const boost::optional<T>& value)
+                                      const util::optional<T>& value)
 {
     write_variable_size_field<T>(field_name, field_kind::COMPACT, value);
 }
@@ -449,7 +449,7 @@ template<typename T>
 void
 default_compact_writer::write_array_of_compact(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<T>>>& value)
+  const util::optional<std::vector<util::optional<T>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_COMPACT, value);
@@ -460,7 +460,7 @@ void
 default_compact_writer::write_array_of_variable_size(
   const std::string& field_name,
   enum field_kind field_kind,
-  const boost::optional<std::vector<boost::optional<T>>>& value)
+  const util::optional<std::vector<util::optional<T>>>& value)
 {
     if (!value.has_value()) {
         set_position_as_null(field_name, field_kind);

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
@@ -172,7 +172,7 @@ public:
             return boost::none;
         }
 
-        return boost::make_optional(read_string(charCount));
+        return util::make_optional(read_string(charCount));
     }
 
     template<typename T>
@@ -244,7 +244,7 @@ public:
         for (int32_t i = 0; i < len; i++) {
             values.push_back(read<typename T::value_type>());
         }
-        return boost::make_optional(values);
+        return util::make_optional(values);
     }
 
     int position() { return pos_; }

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
@@ -17,6 +17,7 @@
 
 #include "hazelcast/util/ByteBuffer.h"
 #include "hazelcast/util/Bits.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/exception/protocol_exceptions.h"
 
 #include <vector>
@@ -162,7 +163,7 @@ public:
 
     template<typename T>
     typename std::enable_if<
-      std::is_same<boost::optional<std::string>,
+      std::is_same<util::optional<std::string>,
                    typename std::remove_cv<T>::type>::value,
       T>::type inline read()
     {
@@ -216,9 +217,9 @@ public:
                      typename std::remove_cv<T>::type>::value ||
         std::is_same<std::vector<std::string>,
                      typename std::remove_cv<T>::type>::value ||
-        std::is_same<std::vector<boost::optional<std::string>>,
+        std::is_same<std::vector<util::optional<std::string>>,
                      typename std::remove_cv<T>::type>::value,
-      typename boost::optional<T>>::type inline read()
+      typename util::optional<T>>::type inline read()
     {
         int32_t len = read<int32_t>();
         if (util::Bits::NULL_ARRAY == len) {

--- a/hazelcast/include/hazelcast/client/serialization/serialization.h
+++ b/hazelcast/include/hazelcast/client/serialization/serialization.h
@@ -20,7 +20,6 @@
 #include <type_traits>
 
 #include <boost/any.hpp>
-#include <boost/optional.hpp>
 #include <boost/optional/optional_io.hpp>
 #include <boost/uuid/uuid.hpp>
 
@@ -32,6 +31,7 @@
 #include "hazelcast/client/partition_aware.h"
 #include "hazelcast/util/SynchronizedMap.h"
 #include "hazelcast/util/Disposable.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/big_decimal.h"
 #include "hazelcast/client/local_time.h"
 #include "hazelcast/client/local_date.h"
@@ -160,7 +160,7 @@ public:
      * @return The object instance of type T.
      */
     template<typename T>
-    boost::optional<T> get() const;
+    util::optional<T> get() const;
 
     /**
      * Internal API
@@ -779,38 +779,38 @@ public:
     typename std::enable_if<
       !(std::is_array<T>::value &&
         std::is_same<typename std::remove_all_extents<T>::type, char>::value),
-      boost::optional<T>>::type inline read_object();
+      util::optional<T>>::type inline read_object();
 
     template<typename T>
     typename std::enable_if<
       std::is_array<T>::value &&
         std::is_same<typename std::remove_all_extents<T>::type, char>::value,
-      boost::optional<std::string>>::type inline read_object();
+      util::optional<std::string>>::type inline read_object();
 
     template<typename T>
     typename std::enable_if<
       std::is_base_of<identified_data_serializer, hz_serializer<T>>::value,
-      boost::optional<T>>::type inline read_object(int32_t type_id);
+      util::optional<T>>::type inline read_object(int32_t type_id);
 
     template<typename T>
     typename std::enable_if<
       std::is_base_of<portable_serializer, hz_serializer<T>>::value,
-      boost::optional<T>>::type inline read_object(int32_t type_id);
+      util::optional<T>>::type inline read_object(int32_t type_id);
 
     template<typename T>
     typename std::enable_if<
       std::is_base_of<compact_serializer, hz_serializer<T>>::value,
-      boost::optional<T>>::type inline read_object(int32_t type_id);
+      util::optional<T>>::type inline read_object(int32_t type_id);
 
     template<typename T>
     typename std::enable_if<
       std::is_base_of<builtin_serializer, hz_serializer<T>>::value,
-      boost::optional<T>>::type inline read_object(int32_t type_id);
+      util::optional<T>>::type inline read_object(int32_t type_id);
 
     template<typename T>
     typename std::enable_if<
       std::is_base_of<custom_serializer, hz_serializer<T>>::value,
-      boost::optional<T>>::type inline read_object(int32_t type_id);
+      util::optional<T>>::type inline read_object(int32_t type_id);
 
     /**
      * Global serialization
@@ -825,7 +825,7 @@ public:
         std::is_base_of<compact_serializer, hz_serializer<T>>::value ||
         std::is_base_of<builtin_serializer, hz_serializer<T>>::value ||
         std::is_base_of<custom_serializer, hz_serializer<T>>::value),
-      boost::optional<T>>::type inline read_object(int32_t type_id);
+      util::optional<T>>::type inline read_object(int32_t type_id);
 
 private:
     pimpl::PortableSerializer& portable_serializer_;
@@ -854,14 +854,14 @@ public:
     template<typename T>
     void write_object(const T* object);
 
-    /* enable_if needed here since 'boost::optional<char [5]>' can not be
+    /* enable_if needed here since 'util::optional<char [5]>' can not be
      * composed this template match */
     template<typename T>
     typename std::enable_if<
       !(std::is_array<T>::value &&
         std::is_same<typename std::remove_all_extents<T>::type, char>::value),
       void>::type
-    write_object(const boost::optional<T>& object);
+    write_object(const util::optional<T>& object);
 
     template<typename T>
     typename std::enable_if<
@@ -1411,7 +1411,7 @@ public:
 
     template<typename T>
     typename std::enable_if<
-      std::is_same<boost::optional<std::string>,
+      std::is_same<util::optional<std::string>,
                    typename std::remove_cv<T>::type>::value,
       T>::type
     read(const std::string& field_name)
@@ -1440,7 +1440,7 @@ public:
                      typename std::remove_cv<T>::type>::value ||
         std::is_same<std::vector<std::string>,
                      typename std::remove_cv<T>::type>::value,
-      boost::optional<T>>::type
+      util::optional<T>>::type
     read(const std::string& field_name)
     {
         set_position(field_name, PortableContext::get_type<T>());
@@ -1460,7 +1460,7 @@ protected:
                                  int class_id) const;
 
     template<typename T>
-    boost::optional<T> get_portable_instance(const std::string& field_name);
+    util::optional<T> get_portable_instance(const std::string& field_name);
 
     std::shared_ptr<ClassDefinition> cd_;
     object_data_input* data_input_;
@@ -1480,10 +1480,10 @@ public:
                           std::shared_ptr<ClassDefinition> cd);
 
     template<typename T>
-    boost::optional<T> read_portable(const std::string& field_name);
+    util::optional<T> read_portable(const std::string& field_name);
 
     template<typename T>
-    boost::optional<std::vector<T>> read_portable_array(
+    util::optional<std::vector<T>> read_portable_array(
       const std::string& field_name);
 };
 
@@ -1540,7 +1540,7 @@ public:
 
     template<typename T>
     typename std::enable_if<
-      std::is_same<boost::optional<std::string>,
+      std::is_same<util::optional<std::string>,
                    typename std::remove_cv<T>::type>::value,
       T>::type
     read(const std::string& field_name)
@@ -1571,7 +1571,7 @@ public:
                      typename std::remove_cv<T>::type>::value ||
         std::is_same<std::vector<std::string>,
                      typename std::remove_cv<T>::type>::value,
-      boost::optional<T>>::type
+      util::optional<T>>::type
     read(const std::string& field_name)
     {
         if (!cd_->has_field(field_name)) {
@@ -1581,10 +1581,10 @@ public:
     }
 
     template<typename T>
-    boost::optional<T> read_portable(const std::string& field_name);
+    util::optional<T> read_portable(const std::string& field_name);
 
     template<typename T>
-    boost::optional<std::vector<T>> read_portable_array(
+    util::optional<std::vector<T>> read_portable_array(
       const std::string& field_name);
 
 private:
@@ -1716,7 +1716,7 @@ class HAZELCAST_API DataSerializer
 {
 public:
     template<typename T>
-    static boost::optional<T> read_object(object_data_input& in)
+    static util::optional<T> read_object(object_data_input& in)
     {
         bool identified = in.read<bool>();
         if (!identified) {
@@ -1860,7 +1860,7 @@ public:
     }
 
     template<typename T>
-    inline boost::optional<T> to_object(const data* data)
+    inline util::optional<T> to_object(const data* data)
     {
         if (!data) {
             return boost::none;
@@ -1873,7 +1873,7 @@ public:
       !(std::is_same<T, const char*>::value ||
         std::is_same<T, const char*>::value ||
         std::is_same<T, typed_data>::value),
-      boost::optional<T>>::type inline to_object(const data& data)
+      util::optional<T>>::type inline to_object(const data& data)
     {
         if (is_null_data(data)) {
             return boost::none;
@@ -1897,7 +1897,7 @@ public:
     template<typename T>
     typename std::enable_if<
       std::is_same<T, typed_data>::value,
-      boost::optional<T>>::type inline to_object(const data& d)
+      util::optional<T>>::type inline to_object(const data& d)
     {
         return boost::make_optional(typed_data(data(d), *this));
     }
@@ -1905,7 +1905,7 @@ public:
     template<typename T>
     typename std::enable_if<
       std::is_same<T, const char*>::value,
-      boost::optional<std::string>>::type inline to_object(const data& data)
+      util::optional<std::string>>::type inline to_object(const data& data)
     {
         return to_object<std::string>(data);
     }
@@ -1914,7 +1914,7 @@ public:
     typename std::enable_if<
       std::is_array<T>::value &&
         std::is_same<typename std::remove_all_extents<T>::type, char>::value,
-      boost::optional<std::string>>::type inline to_object(const data& data)
+      util::optional<std::string>>::type inline to_object(const data& data)
     {
         return to_object<std::string>(data);
     }
@@ -2036,7 +2036,7 @@ public:
                      typename std::remove_cv<T>::type>::value ||
         std::is_same<std::vector<std::string>,
                      typename std::remove_cv<T>::type>::value,
-      boost::optional<T>>::type
+      util::optional<T>>::type
     read(const std::string& field_name)
     {
         if (is_default_reader_)
@@ -2050,7 +2050,7 @@ public:
      * @return the portable value read
      */
     template<typename T>
-    boost::optional<T> read_portable(const std::string& field_name);
+    util::optional<T> read_portable(const std::string& field_name);
 
     /**
      * @tparam type of the portable class in array
@@ -2058,7 +2058,7 @@ public:
      * @return the portable array value read
      */
     template<typename T>
-    boost::optional<std::vector<T>> read_portable_array(
+    util::optional<std::vector<T>> read_portable_array(
       const std::string& field_name);
 
     /**
@@ -2079,8 +2079,8 @@ public:
 
 private:
     bool is_default_reader_;
-    boost::optional<pimpl::DefaultPortableReader> default_portable_reader_;
-    boost::optional<pimpl::MorphingPortableReader> morphing_portable_reader_;
+    util::optional<pimpl::DefaultPortableReader> default_portable_reader_;
+    util::optional<pimpl::MorphingPortableReader> morphing_portable_reader_;
 };
 
 /**
@@ -2164,7 +2164,7 @@ private:
 };
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 portable_reader::read_portable(const std::string& field_name)
 {
     if (is_default_reader_)
@@ -2179,7 +2179,7 @@ portable_reader::read_portable(const std::string& field_name)
  * @throws io_exception
  */
 template<typename T>
-boost::optional<std::vector<T>>
+util::optional<std::vector<T>>
 portable_reader::read_portable_array(const std::string& field_name)
 {
     if (is_default_reader_)
@@ -2251,7 +2251,7 @@ typename std::enable_if<
   !(std::is_array<T>::value &&
     std::is_same<typename std::remove_all_extents<T>::type, char>::value),
   void>::type
-object_data_output::write_object(const boost::optional<T>& object)
+object_data_output::write_object(const util::optional<T>& object)
 {
     if (is_no_write_) {
         return;
@@ -2380,7 +2380,7 @@ template<typename T>
 typename std::enable_if<
   !(std::is_array<T>::value &&
     std::is_same<typename std::remove_all_extents<T>::type, char>::value),
-  boost::optional<T>>::type inline object_data_input::read_object()
+  util::optional<T>>::type inline object_data_input::read_object()
 {
     int32_t typeId = read(boost::endian::order::big);
     if (static_cast<int32_t>(
@@ -2394,7 +2394,7 @@ template<typename T>
 typename std::enable_if<
   std::is_array<T>::value &&
     std::is_same<typename std::remove_all_extents<T>::type, char>::value,
-  boost::optional<std::string>>::type inline object_data_input::read_object()
+  util::optional<std::string>>::type inline object_data_input::read_object()
 {
     return read_object<std::string>();
 }
@@ -2402,7 +2402,7 @@ typename std::enable_if<
 template<typename T>
 typename std::enable_if<
   std::is_base_of<identified_data_serializer, hz_serializer<T>>::value,
-  boost::optional<T>>::type inline object_data_input::read_object(int32_t
+  util::optional<T>>::type inline object_data_input::read_object(int32_t
                                                                     type_id)
 {
     if (type_id != static_cast<int32_t>(
@@ -2422,7 +2422,7 @@ typename std::enable_if<
 template<typename T>
 typename std::enable_if<
   std::is_base_of<portable_serializer, hz_serializer<T>>::value,
-  boost::optional<T>>::type inline object_data_input::read_object(int32_t
+  util::optional<T>>::type inline object_data_input::read_object(int32_t
                                                                     type_id)
 {
     if (type_id != static_cast<int32_t>(
@@ -2442,7 +2442,7 @@ typename std::enable_if<
 template<typename T>
 typename std::enable_if<
   std::is_base_of<compact_serializer, hz_serializer<T>>::value,
-  boost::optional<T>>::type inline object_data_input::read_object(int32_t
+  util::optional<T>>::type inline object_data_input::read_object(int32_t
                                                                     type_id)
 {
     return compact_serializer_.template read<T>(*this);
@@ -2451,7 +2451,7 @@ typename std::enable_if<
 template<typename T>
 typename std::enable_if<
   std::is_base_of<custom_serializer, hz_serializer<T>>::value,
-  boost::optional<T>>::type inline object_data_input::read_object(int32_t
+  util::optional<T>>::type inline object_data_input::read_object(int32_t
                                                                     type_id)
 {
     if (type_id != hz_serializer<T>::get_type_id()) {
@@ -2464,18 +2464,18 @@ typename std::enable_if<
             .str()));
     }
 
-    return boost::optional<T>(hz_serializer<T>::read(*this));
+    return util::optional<T>(hz_serializer<T>::read(*this));
 }
 
 template<typename T>
 typename std::enable_if<
   std::is_base_of<builtin_serializer, hz_serializer<T>>::value,
-  boost::optional<T>>::type inline object_data_input::read_object(int32_t
+  util::optional<T>>::type inline object_data_input::read_object(int32_t
                                                                     type_id)
 {
     assert(type_id == static_cast<int32_t>(hz_serializer<T>::get_type_id()));
 
-    return boost::optional<T>(read<T>());
+    return util::optional<T>(read<T>());
 }
 
 template<typename T>
@@ -2485,7 +2485,7 @@ typename std::enable_if<
     std::is_base_of<compact_serializer, hz_serializer<T>>::value ||
     std::is_base_of<builtin_serializer, hz_serializer<T>>::value ||
     std::is_base_of<custom_serializer, hz_serializer<T>>::value),
-  boost::optional<T>>::type inline object_data_input::read_object(int32_t
+  util::optional<T>>::type inline object_data_input::read_object(int32_t
                                                                     type_id)
 {
     if (!global_serializer_) {
@@ -2505,7 +2505,7 @@ typename std::enable_if<
             .str()));
     }
 
-    return boost::optional<T>(
+    return util::optional<T>(
       boost::any_cast<T>(std::move(global_serializer_->read(*this))));
 }
 
@@ -2515,14 +2515,14 @@ data
 SerializationService::to_data(const typed_data* object);
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 DefaultPortableReader::read_portable(const std::string& field_name)
 {
     return get_portable_instance<T>(field_name);
 }
 
 template<typename T>
-boost::optional<std::vector<T>>
+util::optional<std::vector<T>>
 DefaultPortableReader::read_portable_array(const std::string& field_name)
 {
     PortableReaderBase::set_position(field_name,
@@ -2557,14 +2557,14 @@ DefaultPortableReader::read_portable_array(const std::string& field_name)
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 MorphingPortableReader::read_portable(const std::string& field_name)
 {
     return get_portable_instance<T>(field_name);
 }
 
 template<typename T>
-boost::optional<std::vector<T>>
+util::optional<std::vector<T>>
 MorphingPortableReader::read_portable_array(const std::string& field_name)
 {
     PortableReaderBase::set_position(field_name,
@@ -2725,7 +2725,7 @@ PortableContext::lookup_or_register_class_definition(const T& portable)
 }
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 PortableReaderBase::get_portable_instance(const std::string& field_name)
 {
     set_position(field_name, field_type::TYPE_PORTABLE);
@@ -2848,7 +2848,7 @@ ClassDefinitionWriter::create_nested_class_def(const T& portable)
 } // namespace serialization
 
 template<typename T>
-boost::optional<T>
+util::optional<T>
 typed_data::get() const
 {
     return ss_->to_object<T>(data_);

--- a/hazelcast/include/hazelcast/client/serialization/serialization.h
+++ b/hazelcast/include/hazelcast/client/serialization/serialization.h
@@ -1739,7 +1739,7 @@ public:
                 .str()));
         }
 
-        return boost::make_optional(hz_serializer<T>::read_data(in));
+        return util::make_optional(hz_serializer<T>::read_data(in));
     }
 
     template<typename T>
@@ -1899,7 +1899,7 @@ public:
       std::is_same<T, typed_data>::value,
       util::optional<T>>::type inline to_object(const data& d)
     {
-        return boost::make_optional(typed_data(data(d), *this));
+        return util::make_optional(typed_data(data(d), *this));
     }
 
     template<typename T>
@@ -2597,7 +2597,7 @@ MorphingPortableReader::read_portable_array(const std::string& field_name)
         }
     }
 
-    return boost::make_optional(std::move(portables));
+    return util::make_optional(std::move(portables));
 }
 
 template<typename T>

--- a/hazelcast/include/hazelcast/client/socket.h
+++ b/hazelcast/include/hazelcast/client/socket.h
@@ -59,7 +59,7 @@ public:
      *
      * @returns An address that represents the local endpoint of the socket.
      */
-    virtual boost::optional<address> local_socket_address() const = 0;
+    virtual util::optional<address> local_socket_address() const = 0;
 
     virtual const address& get_remote_endpoint() const = 0;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientClusterServiceImpl.h
@@ -59,7 +59,7 @@ public:
 
     void shutdown();
 
-    boost::optional<member> get_member(boost::uuids::uuid uuid) const;
+    util::optional<member> get_member(boost::uuids::uuid uuid) const;
 
     std::vector<member> get_member_list() const;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientPartitionServiceImpl.h
@@ -87,7 +87,7 @@ private:
 
         int get_partition_id() const override;
 
-        boost::optional<member> get_owner() const override;
+        util::optional<member> get_owner() const override;
 
     private:
         int partition_id_;

--- a/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressProvider.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/DefaultAddressProvider.h
@@ -38,7 +38,7 @@ public:
 
     std::vector<address> load_addresses() override;
 
-    boost::optional<address> translate(const address& addr) override;
+    util::optional<address> translate(const address& addr) override;
 
     bool is_default_provider() override;
 

--- a/hazelcast/include/hazelcast/client/spi/impl/ListenerMessageCodec.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ListenerMessageCodec.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <boost/uuid/uuid.hpp>
 
 #include "hazelcast/util/export.h"

--- a/hazelcast/include/hazelcast/client/spi/impl/discovery/remote_address_provider.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/discovery/remote_address_provider.h
@@ -42,7 +42,7 @@ public:
 
     std::vector<address> load_addresses() override;
 
-    boost::optional<address> translate(const address& addr) override;
+    util::optional<address> translate(const address& addr) override;
 
 private:
     std::function<std::unordered_map<address, address>()> refresh_address_map_;

--- a/hazelcast/include/hazelcast/client/sql/hazelcast_sql_exception.h
+++ b/hazelcast/include/hazelcast/client/sql/hazelcast_sql_exception.h
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <boost/uuid/uuid.hpp>
-#include <boost/optional.hpp>
 
 #include "hazelcast/util/export.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/exception/protocol_exceptions.h"
 
 namespace hazelcast {
@@ -31,8 +31,8 @@ public:
     hazelcast_sql_exception(std::string source,
                             boost::uuids::uuid originating_member_id,
                             int32_t code,
-                            boost::optional<std::string> message,
-                            boost::optional<std::string> suggestion,
+                            util::optional<std::string> message,
+                            util::optional<std::string> suggestion,
                             std::exception_ptr cause = nullptr);
 
     /**
@@ -48,12 +48,12 @@ public:
     /**
      * Gets the suggested SQL statement to remediate experienced error
      */
-    const boost::optional<std::string>& suggestion() const;
+    const util::optional<std::string>& suggestion() const;
 
 private:
     boost::uuids::uuid originating_member_id_;
     int32_t code_;
-    boost::optional<std::string> suggestion_;
+    util::optional<std::string> suggestion_;
 };
 
 } // namespace sql

--- a/hazelcast/include/hazelcast/client/sql/impl/query_utils.h
+++ b/hazelcast/include/hazelcast/client/sql/impl/query_utils.h
@@ -39,7 +39,7 @@ public:
      * @param members list of all members
      * @return the chosen member or none, if no data member is found
      */
-    static boost::optional<member> member_of_same_larger_version_group(
+    static util::optional<member> member_of_same_larger_version_group(
       const std::vector<member>& members);
 };
 } // namespace impl

--- a/hazelcast/include/hazelcast/client/sql/sql_page.h
+++ b/hazelcast/include/hazelcast/client/sql/sql_page.h
@@ -17,10 +17,10 @@
 
 #include <vector>
 #include <boost/any.hpp>
-#include <boost/optional.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
 #include "hazelcast/util/export.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/sql/sql_column_type.h"
 #include "hazelcast/client/sql/sql_row_metadata.h"
 #include "hazelcast/client/serialization/serialization.h"
@@ -67,7 +67,7 @@ public:
          * @see sql_column_metadata::type
          */
         template<typename T>
-        boost::optional<T> get_object(std::size_t column_index) const
+        util::optional<T> get_object(std::size_t column_index) const
         {
             check_index(column_index);
 
@@ -96,7 +96,7 @@ public:
          * @see sql_column_metadata::type
          */
         template<typename T>
-        boost::optional<T> get_object(const std::string& column_name) const
+        util::optional<T> get_object(const std::string& column_name) const
         {
             auto column_index = resolve_index(column_name);
             return page_->get_column_value<T>(column_index, row_index_);
@@ -176,7 +176,7 @@ private:
     serialization::pimpl::SerializationService* serialization_service_;
 
     template<typename T>
-    boost::optional<T> get_column_value(std::size_t column_index,
+    util::optional<T> get_column_value(std::size_t column_index,
                                         std::size_t row_index) const
     {
         assert(column_index < column_count());

--- a/hazelcast/include/hazelcast/client/sql/sql_result.h
+++ b/hazelcast/include/hazelcast/client/sql/sql_result.h
@@ -188,7 +188,7 @@ private:
     boost::future<std::shared_ptr<sql_page>> fetch_page();
 
     template<typename T>
-    boost::optional<T> to_object(serialization::pimpl::data data)
+    util::optional<T> to_object(serialization::pimpl::data data)
     {
         return client_context_->get_serialization_service().to_object<T>(data);
     }

--- a/hazelcast/include/hazelcast/client/sql/sql_service.h
+++ b/hazelcast/include/hazelcast/client/sql/sql_service.h
@@ -137,7 +137,7 @@ private:
         int64_t update_count;
         std::shared_ptr<sql_row_metadata> row_metadata;
         std::shared_ptr<sql_page> first_page;
-        boost::optional<impl::sql_error> error;
+        util::optional<impl::sql_error> error;
         bool is_infinite_rows = false;
         bool is_infinite_rows_exist = false;
     };
@@ -145,7 +145,7 @@ private:
     struct sql_fetch_response_parameters
     {
         std::shared_ptr<sql_page> page;
-        boost::optional<impl::sql_error> error;
+        util::optional<impl::sql_error> error;
     };
 
     explicit sql_service(client::spi::ClientContext& context);
@@ -179,7 +179,7 @@ private:
       protocol::ClientMessage message);
 
     static void handle_fetch_response_error(
-      boost::optional<impl::sql_error> error);
+      util::optional<impl::sql_error> error);
 
     /**
      * Close remote query cursor.

--- a/hazelcast/include/hazelcast/client/sql/sql_statement.h
+++ b/hazelcast/include/hazelcast/client/sql/sql_statement.h
@@ -19,9 +19,8 @@
 #include <cstddef>
 #include <string>
 
-#include <boost/optional/optional.hpp>
-
 #include "hazelcast/util/export.h"
+#include "hazelcast/util/Optional.h"
 #include "hazelcast/client/serialization/pimpl/data.h"
 #include "hazelcast/client/serialization/serialization.h"
 #include "hazelcast/client/sql/sql_expected_result_type.h"
@@ -200,7 +199,7 @@ public:
      * @return the schema name or \code{.cpp}boost::none\endcode if there is
      * none
      */
-    const boost::optional<std::string>& schema() const;
+    const util::optional<std::string>& schema() const;
 
     /**
      * Sets the schema name. The engine will try to resolve the non-qualified
@@ -216,7 +215,7 @@ public:
      * @param schema the current schema name
      * @return this instance for chaining
      */
-    sql_statement& schema(boost::optional<std::string> schema);
+    sql_statement& schema(util::optional<std::string> schema);
 
 private:
     using data = serialization::pimpl::data;
@@ -229,7 +228,7 @@ private:
     int32_t cursor_buffer_size_;
     std::chrono::milliseconds timeout_;
     sql::sql_expected_result_type expected_result_type_;
-    boost::optional<std::string> schema_;
+    util::optional<std::string> schema_;
 
     serialization_service& serialization_service_;
 

--- a/hazelcast/include/hazelcast/client/topic/impl/reliable/ReliableTopicMessage.h
+++ b/hazelcast/include/hazelcast/client/topic/impl/reliable/ReliableTopicMessage.h
@@ -46,13 +46,13 @@ public:
 
     std::chrono::system_clock::time_point get_publish_time() const;
 
-    const boost::optional<address>& get_publisher_address() const;
+    const util::optional<address>& get_publisher_address() const;
 
     serialization::pimpl::data& get_payload();
 
 private:
     std::chrono::system_clock::time_point publish_time_;
-    boost::optional<address> publisher_address_;
+    util::optional<address> publisher_address_;
     serialization::pimpl::data payload_;
 };
 } // namespace reliable

--- a/hazelcast/include/hazelcast/client/topic/message.h
+++ b/hazelcast/include/hazelcast/client/topic/message.h
@@ -35,7 +35,7 @@ public:
     message(const std::string& topic_name,
             typed_data&& msg,
             int64_t publish_time,
-            boost::optional<member>&& member)
+            util::optional<member>&& member)
       : message(topic_name,
                 std::move(msg),
                 std::chrono::system_clock::from_time_t(
@@ -48,7 +48,7 @@ public:
     message(std::string topic_name,
             typed_data&& msg,
             std::chrono::system_clock::time_point publish_time,
-            boost::optional<member>&& member)
+            util::optional<member>&& member)
       : message_object_(msg)
       , publish_time_(publish_time)
       , publishing_member_(member)
@@ -74,7 +74,7 @@ public:
 private:
     typed_data message_object_;
     std::chrono::system_clock::time_point publish_time_;
-    boost::optional<member> publishing_member_;
+    util::optional<member> publishing_member_;
     std::string name_;
 };
 } // namespace topic

--- a/hazelcast/include/hazelcast/client/transactional_map.h
+++ b/hazelcast/include/hazelcast/client/transactional_map.h
@@ -46,7 +46,7 @@ public:
      * @see imap#get(keu)
      */
     template<typename K, typename V>
-    boost::future<boost::optional<V>> get(const K& key)
+    boost::future<util::optional<V>> get(const K& key)
     {
         return to_object<V>(get_data(to_data(key)));
     }
@@ -60,7 +60,7 @@ public:
      * @see imap#put(key, value)
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> put(const K& key, const V& value)
+    boost::future<util::optional<R>> put(const K& key, const V& value)
     {
         return to_object<R>(put_data(to_data(key), to_data(value)));
     }
@@ -88,7 +88,7 @@ public:
      * @see imap#putIfAbsent(key, value)
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> put_if_absent(const K& key,
+    boost::future<util::optional<R>> put_if_absent(const K& key,
                                                     const V& value)
     {
         return to_object<R>(put_if_absent_data(to_data(key), to_data(value)));
@@ -103,7 +103,7 @@ public:
      * @see imap#replace(key, value)
      */
     template<typename K, typename V, typename R = V>
-    boost::future<boost::optional<R>> replace(const K& key, const V& value)
+    boost::future<util::optional<R>> replace(const K& key, const V& value)
     {
         return to_object<R>(replace_data(to_data(key), to_data(value)));
     }
@@ -134,7 +134,7 @@ public:
      * @see imap#remove(key)
      */
     template<typename K, typename V>
-    boost::future<boost::optional<V>> remove(const K& key)
+    boost::future<util::optional<V>> remove(const K& key)
     {
         return to_object<V>(remove_data(to_data(key)));
     }

--- a/hazelcast/include/hazelcast/client/transactional_queue.h
+++ b/hazelcast/include/hazelcast/client/transactional_queue.h
@@ -58,7 +58,7 @@ public:
      * @see iqueue::poll()
      */
     template<typename E>
-    boost::future<boost::optional<E>> poll()
+    boost::future<util::optional<E>> poll()
     {
         return poll<E>(std::chrono::milliseconds::zero());
     }
@@ -70,7 +70,7 @@ public:
      * @see iqueue::poll(std::chrono::milliseconds timeout)
      */
     template<typename E>
-    boost::future<boost::optional<E>> poll(std::chrono::milliseconds timeout)
+    boost::future<util::optional<E>> poll(std::chrono::milliseconds timeout)
     {
         return to_object<E>(proxy::TransactionalQueueImpl::poll_data(timeout));
     }

--- a/hazelcast/include/hazelcast/cp/cp.h
+++ b/hazelcast/include/hazelcast/cp/cp.h
@@ -230,7 +230,7 @@ public:
      * @return the result of the function application
      */
     template<typename F, typename R>
-    boost::future<boost::optional<R>> apply(const F& function)
+    boost::future<util::optional<R>> apply(const F& function)
     {
         auto f = to_data(function);
         return to_object<R>(apply_data(f));
@@ -257,7 +257,7 @@ private:
       client::serialization::pimpl::data& function_data,
       alter_result_type result_type);
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     apply_data(client::serialization::pimpl::data& function_data);
 };
 
@@ -273,13 +273,13 @@ public:
                      const std::string& object_name);
 
     template<typename T>
-    boost::future<boost::optional<typename std::remove_pointer<T>::type>> get()
+    boost::future<util::optional<typename std::remove_pointer<T>::type>> get()
     {
         return to_object<typename std::remove_pointer<T>::type>(get_data());
     }
 
     template<typename T>
-    boost::future<boost::optional<typename std::remove_pointer<T>::type>> set(
+    boost::future<util::optional<typename std::remove_pointer<T>::type>> set(
       T new_value)
     {
         return to_object<typename std::remove_pointer<T>::type>(
@@ -287,7 +287,7 @@ public:
     }
 
     template<typename T>
-    boost::future<boost::optional<typename std::remove_pointer<T>::type>>
+    boost::future<util::optional<typename std::remove_pointer<T>::type>>
     get_and_set(T new_value)
     {
         return to_object<typename std::remove_pointer<T>::type>(
@@ -321,7 +321,7 @@ public:
     }
 
     template<typename T, typename F>
-    boost::future<boost::optional<typename std::remove_pointer<T>::type>>
+    boost::future<util::optional<typename std::remove_pointer<T>::type>>
     alter_and_get(const F& function)
     {
         return to_object<typename std::remove_pointer<T>::type>(
@@ -329,7 +329,7 @@ public:
     }
 
     template<typename T, typename F>
-    boost::future<boost::optional<typename std::remove_pointer<T>::type>>
+    boost::future<util::optional<typename std::remove_pointer<T>::type>>
     get_and_alter(const F& function)
     {
         return to_object<typename std::remove_pointer<T>::type>(
@@ -337,7 +337,7 @@ public:
     }
 
     template<typename R, typename F>
-    boost::future<boost::optional<R>> apply(const F& function)
+    boost::future<util::optional<R>> apply(const F& function)
     {
         return to_object<R>(apply_data(to_data(function)));
     }
@@ -352,13 +352,13 @@ private:
         NEW
     };
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     get_data();
 
-    boost::future<boost::optional<client::serialization::pimpl::data>> set_data(
+    boost::future<util::optional<client::serialization::pimpl::data>> set_data(
       const client::serialization::pimpl::data& new_value_data);
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     get_and_set_data(const client::serialization::pimpl::data& new_value_data);
 
     boost::future<bool> compare_and_set_data(
@@ -371,16 +371,16 @@ private:
     boost::future<void> alter_data(
       const client::serialization::pimpl::data& function_data);
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     alter_and_get_data(const client::serialization::pimpl::data& function_data);
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     get_and_alter_data(const client::serialization::pimpl::data& function_data);
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     apply_data(const client::serialization::pimpl::data& function_data);
 
-    boost::future<boost::optional<client::serialization::pimpl::data>>
+    boost::future<util::optional<client::serialization::pimpl::data>>
     invoke_apply(const client::serialization::pimpl::data function_data,
                  return_value_type return_type,
                  bool alter);

--- a/hazelcast/include/hazelcast/util/Optional.h
+++ b/hazelcast/include/hazelcast/util/Optional.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2022, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,28 +15,19 @@
  */
 #pragma once
 
-#include <cstdint>
-#include <string>
-
-#include <boost/uuid/uuid.hpp>
-
-#include "hazelcast/util/export.h"
-#include "hazelcast/util/Optional.h"
+#if defined(HZ_HAS_CXX17_SUPPORT)
+#include <optional>
+#else
+#include <boost/optional.hpp>
+#endif
 
 namespace hazelcast {
-namespace client {
-namespace sql {
-namespace impl {
-
-struct HAZELCAST_API sql_error
-{
-    int32_t code;
-    util::optional<std::string> message;
-    boost::uuids::uuid originating_member_id;
-    util::optional<std::string> suggestion;
-};
-
-} // namespace impl
-} // namespace sql
+namespace util {
+    
+#if defined(HZ_HAS_CXX17_SUPPORT)
+    template <typename T> using optional = std::optional<T>;
+#else
+    template <typename T> using optional = boost::optional<T>;
+#endif
 } // namespace client
 } // namespace hazelcast

--- a/hazelcast/include/hazelcast/util/Optional.h
+++ b/hazelcast/include/hazelcast/util/Optional.h
@@ -26,8 +26,18 @@ namespace util {
     
 #if defined(HZ_HAS_CXX17_SUPPORT)
     template <typename T> using optional = std::optional<T>;
+    template <typename... T>
+    auto make_optional(T&&... t) -> decltype(std::make_optional(std::forward<T>(t)...))
+    {
+        return std::make_optional(std::forward<T>(t)...);
+    }
 #else
     template <typename T> using optional = boost::optional<T>;
+    template <typename... T>
+    auto make_optional(T&&... t) -> decltype(boost::make_optional(std::forward<T>(t)...))
+    {
+        return boost::make_optional(std::forward<T>(t)...);
+    }
 #endif
 } // namespace client
 } // namespace hazelcast

--- a/hazelcast/src/hazelcast/client/cluster.cpp
+++ b/hazelcast/src/hazelcast/client/cluster.cpp
@@ -167,7 +167,7 @@ operator==(const member& lhs, const member& rhs)
 }
 
 endpoint::endpoint(boost::uuids::uuid uuid,
-                   boost::optional<address> socket_address)
+                   util::optional<address> socket_address)
   : uuid_(uuid)
   , socket_address_(std::move(socket_address))
 {}
@@ -178,7 +178,7 @@ endpoint::get_uuid() const
     return uuid_;
 }
 
-const boost::optional<address>&
+const util::optional<address>&
 endpoint::get_socket_address() const
 {
     return socket_address_;
@@ -224,7 +224,7 @@ membership_event::get_member() const
 }
 
 local_endpoint::local_endpoint(boost::uuids::uuid uuid,
-                               boost::optional<address> socket_address,
+                               util::optional<address> socket_address,
                                std::string name,
                                std::unordered_set<std::string> labels)
   : endpoint(uuid, std::move(socket_address))

--- a/hazelcast/src/hazelcast/client/compact.cpp
+++ b/hazelcast/src/hazelcast/client/compact.cpp
@@ -102,7 +102,7 @@ compact_writer::write_float64(const std::string& field_name, double value)
 
 void
 compact_writer::write_string(const std::string& field_name,
-                             const boost::optional<std::string>& value)
+                             const util::optional<std::string>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_string(field_name, value);
@@ -113,7 +113,7 @@ compact_writer::write_string(const std::string& field_name,
 
 void
 compact_writer::write_decimal(const std::string& field_name,
-                              const boost::optional<big_decimal>& value)
+                              const util::optional<big_decimal>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_decimal(field_name, value);
@@ -125,7 +125,7 @@ compact_writer::write_decimal(const std::string& field_name,
 void
 compact_writer::write_time(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::local_time>& value)
+  const util::optional<hazelcast::client::local_time>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_time(field_name, value);
@@ -137,7 +137,7 @@ compact_writer::write_time(
 void
 compact_writer::write_date(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::local_date>& value)
+  const util::optional<hazelcast::client::local_date>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_date(field_name, value);
@@ -149,7 +149,7 @@ compact_writer::write_date(
 void
 compact_writer::write_timestamp(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::local_date_time>& value)
+  const util::optional<hazelcast::client::local_date_time>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_timestamp(field_name, value);
@@ -161,7 +161,7 @@ compact_writer::write_timestamp(
 void
 compact_writer::write_timestamp_with_timezone(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::offset_date_time>& value)
+  const util::optional<hazelcast::client::offset_date_time>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_timestamp_with_timezone(field_name,
@@ -175,7 +175,7 @@ compact_writer::write_timestamp_with_timezone(
 void
 compact_writer::write_array_of_boolean(
   const std::string& field_name,
-  const boost::optional<std::vector<bool>>& value)
+  const util::optional<std::vector<bool>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_boolean(field_name, value);
@@ -188,7 +188,7 @@ compact_writer::write_array_of_boolean(
 void
 compact_writer::write_array_of_int8(
   const std::string& field_name,
-  const boost::optional<std::vector<int8_t>>& value)
+  const util::optional<std::vector<int8_t>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_int8(field_name, value);
@@ -200,7 +200,7 @@ compact_writer::write_array_of_int8(
 void
 compact_writer::write_array_of_int16(
   const std::string& field_name,
-  const boost::optional<std::vector<int16_t>>& value)
+  const util::optional<std::vector<int16_t>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_int16(field_name, value);
@@ -212,7 +212,7 @@ compact_writer::write_array_of_int16(
 void
 compact_writer::write_array_of_int32(
   const std::string& field_name,
-  const boost::optional<std::vector<int32_t>>& value)
+  const util::optional<std::vector<int32_t>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_int32(field_name, value);
@@ -224,7 +224,7 @@ compact_writer::write_array_of_int32(
 void
 compact_writer::write_array_of_int64(
   const std::string& field_name,
-  const boost::optional<std::vector<int64_t>>& value)
+  const util::optional<std::vector<int64_t>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_int64(field_name, value);
@@ -236,7 +236,7 @@ compact_writer::write_array_of_int64(
 void
 compact_writer::write_array_of_float32(
   const std::string& field_name,
-  const boost::optional<std::vector<float>>& value)
+  const util::optional<std::vector<float>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_float32(field_name, value);
@@ -249,7 +249,7 @@ compact_writer::write_array_of_float32(
 void
 compact_writer::write_array_of_float64(
   const std::string& field_name,
-  const boost::optional<std::vector<double>>& value)
+  const util::optional<std::vector<double>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_float64(field_name, value);
@@ -262,7 +262,7 @@ compact_writer::write_array_of_float64(
 void
 compact_writer::write_array_of_string(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<std::string>>>& value)
+  const util::optional<std::vector<util::optional<std::string>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_string(field_name, value);
@@ -275,7 +275,7 @@ compact_writer::write_array_of_string(
 void
 compact_writer::write_array_of_decimal(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<big_decimal>>>& value)
+  const util::optional<std::vector<util::optional<big_decimal>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_decimal(field_name, value);
@@ -288,7 +288,7 @@ compact_writer::write_array_of_decimal(
 void
 compact_writer::write_array_of_time(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<local_time>>>& value)
+  const util::optional<std::vector<util::optional<local_time>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_time(field_name, value);
@@ -300,7 +300,7 @@ compact_writer::write_array_of_time(
 void
 compact_writer::write_array_of_date(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<local_date>>>& value)
+  const util::optional<std::vector<util::optional<local_date>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_date(field_name, value);
@@ -312,7 +312,7 @@ compact_writer::write_array_of_date(
 void
 compact_writer::write_array_of_timestamp(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<local_date_time>>>& value)
+  const util::optional<std::vector<util::optional<local_date_time>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_timestamp(field_name, value);
@@ -325,7 +325,7 @@ compact_writer::write_array_of_timestamp(
 void
 compact_writer::write_array_of_timestamp_with_timezone(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<offset_date_time>>>& value)
+  const util::optional<std::vector<util::optional<offset_date_time>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_timestamp_with_timezone(
@@ -338,7 +338,7 @@ compact_writer::write_array_of_timestamp_with_timezone(
 
 void
 compact_writer::write_nullable_boolean(const std::string& field_name,
-                                       const boost::optional<bool>& value)
+                                       const util::optional<bool>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_boolean(field_name, value);
@@ -350,7 +350,7 @@ compact_writer::write_nullable_boolean(const std::string& field_name,
 
 void
 compact_writer::write_nullable_int8(const std::string& field_name,
-                                    const boost::optional<int8_t>& value)
+                                    const util::optional<int8_t>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_int8(field_name, value);
@@ -361,7 +361,7 @@ compact_writer::write_nullable_int8(const std::string& field_name,
 
 void
 compact_writer::write_nullable_int16(const std::string& field_name,
-                                     const boost::optional<int16_t>& value)
+                                     const util::optional<int16_t>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_int16(field_name, value);
@@ -372,7 +372,7 @@ compact_writer::write_nullable_int16(const std::string& field_name,
 
 void
 compact_writer::write_nullable_int32(const std::string& field_name,
-                                     const boost::optional<int32_t>& value)
+                                     const util::optional<int32_t>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_int32(field_name, value);
@@ -383,7 +383,7 @@ compact_writer::write_nullable_int32(const std::string& field_name,
 
 void
 compact_writer::write_nullable_int64(const std::string& field_name,
-                                     const boost::optional<int64_t>& value)
+                                     const util::optional<int64_t>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_int64(field_name, value);
@@ -394,7 +394,7 @@ compact_writer::write_nullable_int64(const std::string& field_name,
 
 void
 compact_writer::write_nullable_float32(const std::string& field_name,
-                                       const boost::optional<float>& value)
+                                       const util::optional<float>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_float32(field_name, value);
@@ -406,7 +406,7 @@ compact_writer::write_nullable_float32(const std::string& field_name,
 
 void
 compact_writer::write_nullable_float64(const std::string& field_name,
-                                       const boost::optional<double>& value)
+                                       const util::optional<double>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_nullable_float64(field_name, value);
@@ -419,7 +419,7 @@ compact_writer::write_nullable_float64(const std::string& field_name,
 void
 compact_writer::write_array_of_nullable_boolean(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<bool>>>& value)
+  const util::optional<std::vector<util::optional<bool>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_boolean(field_name,
@@ -433,7 +433,7 @@ compact_writer::write_array_of_nullable_boolean(
 void
 compact_writer::write_array_of_nullable_int8(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int8_t>>>& value)
+  const util::optional<std::vector<util::optional<int8_t>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_int8(field_name, value);
@@ -446,7 +446,7 @@ compact_writer::write_array_of_nullable_int8(
 void
 compact_writer::write_array_of_nullable_int16(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int16_t>>>& value)
+  const util::optional<std::vector<util::optional<int16_t>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_int16(field_name,
@@ -460,7 +460,7 @@ compact_writer::write_array_of_nullable_int16(
 void
 compact_writer::write_array_of_nullable_int32(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int32_t>>>& value)
+  const util::optional<std::vector<util::optional<int32_t>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_int32(field_name,
@@ -474,7 +474,7 @@ compact_writer::write_array_of_nullable_int32(
 void
 compact_writer::write_array_of_nullable_int64(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int64_t>>>& value)
+  const util::optional<std::vector<util::optional<int64_t>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_int64(field_name,
@@ -488,7 +488,7 @@ compact_writer::write_array_of_nullable_int64(
 void
 compact_writer::write_array_of_nullable_float32(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<float>>>& value)
+  const util::optional<std::vector<util::optional<float>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_float32(field_name,
@@ -502,7 +502,7 @@ compact_writer::write_array_of_nullable_float32(
 void
 compact_writer::write_array_of_nullable_float64(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<double>>>& value)
+  const util::optional<std::vector<util::optional<double>>>& value)
 {
     if (default_compact_writer != nullptr) {
         default_compact_writer->write_array_of_nullable_float64(field_name,
@@ -750,49 +750,49 @@ compact_reader::read_float64(const std::string& field_name)
                                   "float64");
 }
 
-boost::optional<std::string>
+util::optional<std::string>
 compact_reader::read_string(const std::string& field_name)
 {
     return read_variable_size<std::string>(field_name,
                                            pimpl::field_kind::STRING);
 }
 
-boost::optional<big_decimal>
+util::optional<big_decimal>
 compact_reader::read_decimal(const std::string& field_name)
 {
     return read_variable_size<big_decimal>(field_name,
                                            pimpl::field_kind::DECIMAL);
 }
 
-boost::optional<hazelcast::client::local_time>
+util::optional<hazelcast::client::local_time>
 compact_reader::read_time(const std::string& field_name)
 {
     return read_variable_size<hazelcast::client::local_time>(
       field_name, pimpl::field_kind::TIME);
 }
 
-boost::optional<hazelcast::client::local_date>
+util::optional<hazelcast::client::local_date>
 compact_reader::read_date(const std::string& field_name)
 {
     return read_variable_size<hazelcast::client::local_date>(
       field_name, pimpl::field_kind::DATE);
 }
 
-boost::optional<hazelcast::client::local_date_time>
+util::optional<hazelcast::client::local_date_time>
 compact_reader::read_timestamp(const std::string& field_name)
 {
     return read_variable_size<hazelcast::client::local_date_time>(
       field_name, pimpl::field_kind::TIMESTAMP);
 }
 
-boost::optional<hazelcast::client::offset_date_time>
+util::optional<hazelcast::client::offset_date_time>
 compact_reader::read_timestamp_with_timezone(const std::string& field_name)
 {
     return read_variable_size<hazelcast::client::offset_date_time>(
       field_name, pimpl::field_kind::TIMESTAMP_WITH_TIMEZONE);
 }
 
-boost::optional<std::vector<bool>>
+util::optional<std::vector<bool>>
 compact_reader::read_array_of_boolean(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<bool>>(
@@ -802,7 +802,7 @@ compact_reader::read_array_of_boolean(const std::string& field_name)
       "boolean");
 }
 
-boost::optional<std::vector<int8_t>>
+util::optional<std::vector<int8_t>>
 compact_reader::read_array_of_int8(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<int8_t>>(
@@ -812,7 +812,7 @@ compact_reader::read_array_of_int8(const std::string& field_name)
       "int8");
 }
 
-boost::optional<std::vector<int16_t>>
+util::optional<std::vector<int16_t>>
 compact_reader::read_array_of_int16(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<int16_t>>(
@@ -822,7 +822,7 @@ compact_reader::read_array_of_int16(const std::string& field_name)
       "int16");
 }
 
-boost::optional<std::vector<int32_t>>
+util::optional<std::vector<int32_t>>
 compact_reader::read_array_of_int32(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<int32_t>>(
@@ -831,7 +831,7 @@ compact_reader::read_array_of_int32(const std::string& field_name)
       pimpl::ARRAY_OF_NULLABLE_INT32,
       "int32");
 }
-boost::optional<std::vector<int64_t>>
+util::optional<std::vector<int64_t>>
 compact_reader::read_array_of_int64(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<int64_t>>(
@@ -841,7 +841,7 @@ compact_reader::read_array_of_int64(const std::string& field_name)
       "int64");
 }
 
-boost::optional<std::vector<float>>
+util::optional<std::vector<float>>
 compact_reader::read_array_of_float32(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<float>>(
@@ -851,7 +851,7 @@ compact_reader::read_array_of_float32(const std::string& field_name)
       "float32");
 }
 
-boost::optional<std::vector<double>>
+util::optional<std::vector<double>>
 compact_reader::read_array_of_float64(const std::string& field_name)
 {
     return read_array_of_primitive<std::vector<double>>(
@@ -861,7 +861,7 @@ compact_reader::read_array_of_float64(const std::string& field_name)
       "float64");
 }
 
-boost::optional<std::vector<boost::optional<std::string>>>
+util::optional<std::vector<util::optional<std::string>>>
 compact_reader::read_array_of_string(const std::string& field_name)
 {
     const auto& descriptor =
@@ -869,7 +869,7 @@ compact_reader::read_array_of_string(const std::string& field_name)
     return read_array_of_variable_size<std::string>(descriptor);
 }
 
-boost::optional<std::vector<boost::optional<big_decimal>>>
+util::optional<std::vector<util::optional<big_decimal>>>
 compact_reader::read_array_of_decimal(const std::string& field_name)
 {
     const auto& descriptor =
@@ -877,7 +877,7 @@ compact_reader::read_array_of_decimal(const std::string& field_name)
     return read_array_of_variable_size<big_decimal>(descriptor);
 }
 
-boost::optional<std::vector<boost::optional<local_time>>>
+util::optional<std::vector<util::optional<local_time>>>
 compact_reader::read_array_of_time(const std::string& field_name)
 {
     const auto& descriptor =
@@ -885,7 +885,7 @@ compact_reader::read_array_of_time(const std::string& field_name)
     return read_array_of_variable_size<local_time>(descriptor);
 }
 
-boost::optional<std::vector<boost::optional<local_date>>>
+util::optional<std::vector<util::optional<local_date>>>
 compact_reader::read_array_of_date(const std::string& field_name)
 {
     const auto& descriptor =
@@ -893,7 +893,7 @@ compact_reader::read_array_of_date(const std::string& field_name)
     return read_array_of_variable_size<local_date>(descriptor);
 }
 
-boost::optional<std::vector<boost::optional<local_date_time>>>
+util::optional<std::vector<util::optional<local_date_time>>>
 compact_reader::read_array_of_timestamp(const std::string& field_name)
 {
     const auto& descriptor =
@@ -901,7 +901,7 @@ compact_reader::read_array_of_timestamp(const std::string& field_name)
     return read_array_of_variable_size<local_date_time>(descriptor);
 }
 
-boost::optional<std::vector<boost::optional<offset_date_time>>>
+util::optional<std::vector<util::optional<offset_date_time>>>
 compact_reader::read_array_of_timestamp_with_timezone(
   const std::string& field_name)
 {
@@ -910,7 +910,7 @@ compact_reader::read_array_of_timestamp_with_timezone(
     return read_array_of_variable_size<offset_date_time>(descriptor);
 }
 
-boost::optional<bool>
+util::optional<bool>
 compact_reader::read_nullable_boolean(const std::string& field_name)
 {
     return read_nullable_primitive<bool>(field_name,
@@ -918,35 +918,35 @@ compact_reader::read_nullable_boolean(const std::string& field_name)
                                          pimpl::field_kind::NULLABLE_BOOLEAN);
 }
 
-boost::optional<int8_t>
+util::optional<int8_t>
 compact_reader::read_nullable_int8(const std::string& field_name)
 {
     return read_nullable_primitive<int8_t>(
       field_name, pimpl::field_kind::INT8, pimpl::field_kind::NULLABLE_INT8);
 }
 
-boost::optional<int16_t>
+util::optional<int16_t>
 compact_reader::read_nullable_int16(const std::string& field_name)
 {
     return read_nullable_primitive<int16_t>(
       field_name, pimpl::field_kind::INT16, pimpl::field_kind::NULLABLE_INT16);
 }
 
-boost::optional<int32_t>
+util::optional<int32_t>
 compact_reader::read_nullable_int32(const std::string& field_name)
 {
     return read_nullable_primitive<int32_t>(
       field_name, pimpl::field_kind::INT32, pimpl::field_kind::NULLABLE_INT32);
 }
 
-boost::optional<int64_t>
+util::optional<int64_t>
 compact_reader::read_nullable_int64(const std::string& field_name)
 {
     return read_nullable_primitive<int64_t>(
       field_name, pimpl::field_kind::INT64, pimpl::field_kind::NULLABLE_INT64);
 }
 
-boost::optional<float>
+util::optional<float>
 compact_reader::read_nullable_float32(const std::string& field_name)
 {
     return read_nullable_primitive<float>(field_name,
@@ -954,7 +954,7 @@ compact_reader::read_nullable_float32(const std::string& field_name)
                                           pimpl::field_kind::NULLABLE_FLOAT32);
 }
 
-boost::optional<double>
+util::optional<double>
 compact_reader::read_nullable_float64(const std::string& field_name)
 {
     return read_nullable_primitive<double>(field_name,
@@ -962,7 +962,7 @@ compact_reader::read_nullable_float64(const std::string& field_name)
                                            pimpl::field_kind::NULLABLE_FLOAT64);
 }
 
-boost::optional<std::vector<boost::optional<bool>>>
+util::optional<std::vector<util::optional<bool>>>
 compact_reader::read_array_of_nullable_boolean(const std::string& field_name)
 {
     return read_array_of_nullable<bool>(field_name,
@@ -970,7 +970,7 @@ compact_reader::read_array_of_nullable_boolean(const std::string& field_name)
                                         pimpl::ARRAY_OF_NULLABLE_BOOLEAN);
 }
 
-boost::optional<std::vector<boost::optional<int8_t>>>
+util::optional<std::vector<util::optional<int8_t>>>
 compact_reader::read_array_of_nullable_int8(const std::string& field_name)
 {
     return read_array_of_nullable<int8_t>(field_name,
@@ -978,7 +978,7 @@ compact_reader::read_array_of_nullable_int8(const std::string& field_name)
                                           pimpl::ARRAY_OF_NULLABLE_INT8);
 }
 
-boost::optional<std::vector<boost::optional<int16_t>>>
+util::optional<std::vector<util::optional<int16_t>>>
 compact_reader::read_array_of_nullable_int16(const std::string& field_name)
 {
     return read_array_of_nullable<int16_t>(field_name,
@@ -986,7 +986,7 @@ compact_reader::read_array_of_nullable_int16(const std::string& field_name)
                                            pimpl::ARRAY_OF_NULLABLE_INT16);
 }
 
-boost::optional<std::vector<boost::optional<int32_t>>>
+util::optional<std::vector<util::optional<int32_t>>>
 compact_reader::read_array_of_nullable_int32(const std::string& field_name)
 {
     return read_array_of_nullable<int32_t>(field_name,
@@ -994,7 +994,7 @@ compact_reader::read_array_of_nullable_int32(const std::string& field_name)
                                            pimpl::ARRAY_OF_NULLABLE_INT32);
 }
 
-boost::optional<std::vector<boost::optional<int64_t>>>
+util::optional<std::vector<util::optional<int64_t>>>
 compact_reader::read_array_of_nullable_int64(const std::string& field_name)
 {
     return read_array_of_nullable<int64_t>(field_name,
@@ -1002,7 +1002,7 @@ compact_reader::read_array_of_nullable_int64(const std::string& field_name)
                                            pimpl::ARRAY_OF_NULLABLE_INT64);
 }
 
-boost::optional<std::vector<boost::optional<float>>>
+util::optional<std::vector<util::optional<float>>>
 compact_reader::read_array_of_nullable_float32(const std::string& field_name)
 {
     return read_array_of_nullable<float>(field_name,
@@ -1010,7 +1010,7 @@ compact_reader::read_array_of_nullable_float32(const std::string& field_name)
                                          pimpl::ARRAY_OF_NULLABLE_FLOAT32);
 }
 
-boost::optional<std::vector<boost::optional<double>>>
+util::optional<std::vector<util::optional<double>>>
 compact_reader::read_array_of_nullable_float64(const std::string& field_name)
 {
     return read_array_of_nullable<double>(field_name,
@@ -1121,14 +1121,14 @@ default_compact_writer::write_float64(const std::string& field_name,
 
 void
 default_compact_writer::write_string(const std::string& field_name,
-                                     const boost::optional<std::string>& value)
+                                     const util::optional<std::string>& value)
 {
     write_variable_size_field(field_name, field_kind::STRING, value);
 }
 
 void
 default_compact_writer::write_decimal(const std::string& field_name,
-                                      const boost::optional<big_decimal>& value)
+                                      const util::optional<big_decimal>& value)
 {
     write_variable_size_field(field_name, field_kind::DECIMAL, value);
 }
@@ -1136,14 +1136,14 @@ default_compact_writer::write_decimal(const std::string& field_name,
 void
 default_compact_writer::write_time(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::local_time>& value)
+  const util::optional<hazelcast::client::local_time>& value)
 {
     write_variable_size_field(field_name, field_kind::TIME, value);
 }
 void
 default_compact_writer::write_date(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::local_date>& value)
+  const util::optional<hazelcast::client::local_date>& value)
 {
     write_variable_size_field(field_name, field_kind::DATE, value);
 }
@@ -1151,7 +1151,7 @@ default_compact_writer::write_date(
 void
 default_compact_writer::write_timestamp(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::local_date_time>& value)
+  const util::optional<hazelcast::client::local_date_time>& value)
 {
     write_variable_size_field(field_name, field_kind::TIMESTAMP, value);
 }
@@ -1159,7 +1159,7 @@ default_compact_writer::write_timestamp(
 void
 default_compact_writer::write_timestamp_with_timezone(
   const std::string& field_name,
-  const boost::optional<hazelcast::client::offset_date_time>& value)
+  const util::optional<hazelcast::client::offset_date_time>& value)
 {
     write_variable_size_field(
       field_name, field_kind::TIMESTAMP_WITH_TIMEZONE, value);
@@ -1168,7 +1168,7 @@ default_compact_writer::write_timestamp_with_timezone(
 void
 default_compact_writer::write_array_of_boolean(
   const std::string& field_name,
-  const boost::optional<std::vector<bool>>& value)
+  const util::optional<std::vector<bool>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_BOOLEAN, value);
 }
@@ -1176,7 +1176,7 @@ default_compact_writer::write_array_of_boolean(
 void
 default_compact_writer::write_array_of_int8(
   const std::string& field_name,
-  const boost::optional<std::vector<int8_t>>& value)
+  const util::optional<std::vector<int8_t>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_INT8, value);
 }
@@ -1184,7 +1184,7 @@ default_compact_writer::write_array_of_int8(
 void
 default_compact_writer::write_array_of_int16(
   const std::string& field_name,
-  const boost::optional<std::vector<int16_t>>& value)
+  const util::optional<std::vector<int16_t>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_INT16, value);
 }
@@ -1192,7 +1192,7 @@ default_compact_writer::write_array_of_int16(
 void
 default_compact_writer::write_array_of_int32(
   const std::string& field_name,
-  const boost::optional<std::vector<int32_t>>& value)
+  const util::optional<std::vector<int32_t>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_INT32, value);
 }
@@ -1200,7 +1200,7 @@ default_compact_writer::write_array_of_int32(
 void
 default_compact_writer::write_array_of_int64(
   const std::string& field_name,
-  const boost::optional<std::vector<int64_t>>& value)
+  const util::optional<std::vector<int64_t>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_INT64, value);
 }
@@ -1208,7 +1208,7 @@ default_compact_writer::write_array_of_int64(
 void
 default_compact_writer::write_array_of_float32(
   const std::string& field_name,
-  const boost::optional<std::vector<float>>& value)
+  const util::optional<std::vector<float>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_FLOAT32, value);
 }
@@ -1216,7 +1216,7 @@ default_compact_writer::write_array_of_float32(
 void
 default_compact_writer::write_array_of_float64(
   const std::string& field_name,
-  const boost::optional<std::vector<double>>& value)
+  const util::optional<std::vector<double>>& value)
 {
     write_variable_size_field(field_name, field_kind::ARRAY_OF_FLOAT64, value);
 }
@@ -1224,7 +1224,7 @@ default_compact_writer::write_array_of_float64(
 void
 default_compact_writer::write_array_of_string(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<std::string>>>& value)
+  const util::optional<std::vector<util::optional<std::string>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_STRING, value);
@@ -1233,7 +1233,7 @@ default_compact_writer::write_array_of_string(
 void
 default_compact_writer::write_array_of_decimal(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<big_decimal>>>& value)
+  const util::optional<std::vector<util::optional<big_decimal>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_DECIMAL, value);
@@ -1242,7 +1242,7 @@ default_compact_writer::write_array_of_decimal(
 void
 default_compact_writer::write_array_of_time(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<local_time>>>& value)
+  const util::optional<std::vector<util::optional<local_time>>>& value)
 {
     write_array_of_variable_size(field_name, field_kind::ARRAY_OF_TIME, value);
 }
@@ -1250,7 +1250,7 @@ default_compact_writer::write_array_of_time(
 void
 default_compact_writer::write_array_of_date(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<local_date>>>& value)
+  const util::optional<std::vector<util::optional<local_date>>>& value)
 {
     write_array_of_variable_size(field_name, field_kind::ARRAY_OF_DATE, value);
 }
@@ -1258,7 +1258,7 @@ default_compact_writer::write_array_of_date(
 void
 default_compact_writer::write_array_of_timestamp(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<local_date_time>>>& value)
+  const util::optional<std::vector<util::optional<local_date_time>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_TIMESTAMP, value);
@@ -1267,7 +1267,7 @@ default_compact_writer::write_array_of_timestamp(
 void
 default_compact_writer::write_array_of_timestamp_with_timezone(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<offset_date_time>>>& value)
+  const util::optional<std::vector<util::optional<offset_date_time>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_TIMESTAMP_WITH_TIMEZONE, value);
@@ -1276,49 +1276,49 @@ default_compact_writer::write_array_of_timestamp_with_timezone(
 void
 default_compact_writer::write_nullable_boolean(
   const std::string& field_name,
-  const boost::optional<bool>& value)
+  const util::optional<bool>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_BOOLEAN, value);
 }
 void
 default_compact_writer::write_nullable_int8(
   const std::string& field_name,
-  const boost::optional<int8_t>& value)
+  const util::optional<int8_t>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_INT8, value);
 }
 void
 default_compact_writer::write_nullable_int16(
   const std::string& field_name,
-  const boost::optional<int16_t>& value)
+  const util::optional<int16_t>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_INT16, value);
 }
 void
 default_compact_writer::write_nullable_int32(
   const std::string& field_name,
-  const boost::optional<int32_t>& value)
+  const util::optional<int32_t>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_INT32, value);
 }
 void
 default_compact_writer::write_nullable_int64(
   const std::string& field_name,
-  const boost::optional<int64_t>& value)
+  const util::optional<int64_t>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_INT64, value);
 }
 void
 default_compact_writer::write_nullable_float32(
   const std::string& field_name,
-  const boost::optional<float>& value)
+  const util::optional<float>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_FLOAT32, value);
 }
 void
 default_compact_writer::write_nullable_float64(
   const std::string& field_name,
-  const boost::optional<double>& value)
+  const util::optional<double>& value)
 {
     write_variable_size_field(field_name, field_kind::NULLABLE_FLOAT64, value);
 }
@@ -1326,7 +1326,7 @@ default_compact_writer::write_nullable_float64(
 void
 default_compact_writer::write_array_of_nullable_boolean(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<bool>>>& value)
+  const util::optional<std::vector<util::optional<bool>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_BOOLEAN, value);
@@ -1335,7 +1335,7 @@ default_compact_writer::write_array_of_nullable_boolean(
 void
 default_compact_writer::write_array_of_nullable_int8(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int8_t>>>& value)
+  const util::optional<std::vector<util::optional<int8_t>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_INT8, value);
@@ -1344,7 +1344,7 @@ default_compact_writer::write_array_of_nullable_int8(
 void
 default_compact_writer::write_array_of_nullable_int16(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int16_t>>>& value)
+  const util::optional<std::vector<util::optional<int16_t>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_INT16, value);
@@ -1353,7 +1353,7 @@ default_compact_writer::write_array_of_nullable_int16(
 void
 default_compact_writer::write_array_of_nullable_int32(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int32_t>>>& value)
+  const util::optional<std::vector<util::optional<int32_t>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_INT32, value);
@@ -1362,7 +1362,7 @@ default_compact_writer::write_array_of_nullable_int32(
 void
 default_compact_writer::write_array_of_nullable_int64(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<int64_t>>>& value)
+  const util::optional<std::vector<util::optional<int64_t>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_INT64, value);
@@ -1371,7 +1371,7 @@ default_compact_writer::write_array_of_nullable_int64(
 void
 default_compact_writer::write_array_of_nullable_float32(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<float>>>& value)
+  const util::optional<std::vector<util::optional<float>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_FLOAT32, value);
@@ -1380,7 +1380,7 @@ default_compact_writer::write_array_of_nullable_float32(
 void
 default_compact_writer::write_array_of_nullable_float64(
   const std::string& field_name,
-  const boost::optional<std::vector<boost::optional<double>>>& value)
+  const util::optional<std::vector<util::optional<double>>>& value)
 {
     write_array_of_variable_size(
       field_name, field_kind::ARRAY_OF_NULLABLE_FLOAT64, value);

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -1090,7 +1090,7 @@ client_config::get_load_balancer()
         load_balancer_ = load_balancer().next([=](cluster& c) {
             auto members = c.get_members();
             if (members.empty()) {
-                return boost::optional<member>();
+                return util::optional<member>();
             }
             auto i = index->fetch_add(1);
             return boost::make_optional(std::move(members[i % members.size()]));
@@ -1253,7 +1253,7 @@ client_config::set_network_config(
     return *this;
 }
 
-const boost::optional<std::string>&
+const util::optional<std::string>&
 client_config::get_instance_name() const
 {
     return instance_name_;

--- a/hazelcast/src/hazelcast/client/config.cpp
+++ b/hazelcast/src/hazelcast/client/config.cpp
@@ -1093,7 +1093,7 @@ client_config::get_load_balancer()
                 return util::optional<member>();
             }
             auto i = index->fetch_add(1);
-            return boost::make_optional(std::move(members[i % members.size()]));
+            return util::make_optional(std::move(members[i % members.size()]));
         });
     }
     return *load_balancer_;

--- a/hazelcast/src/hazelcast/client/metrics.cpp
+++ b/hazelcast/src/hazelcast/client/metrics.cpp
@@ -170,13 +170,13 @@ metric_descriptor::metric() const
     return metric_;
 }
 
-const boost::optional<std::string>&
+const util::optional<std::string>&
 metric_descriptor::discriminator() const
 {
     return discriminator_;
 }
 
-const boost::optional<std::string>&
+const util::optional<std::string>&
 metric_descriptor::discriminator_value() const
 {
     return discriminator_value_;
@@ -349,7 +349,7 @@ metrics_compressor::calculate_descriptor_mask(
 }
 
 int32_t
-metrics_compressor::get_dictionary_id(const boost::optional<std::string>& word)
+metrics_compressor::get_dictionary_id(const util::optional<std::string>& word)
 {
     if (!word) {
         return NULL_DICTIONARY_ID;

--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -922,8 +922,8 @@ ClientConnectionManagerImpl::translate(const member& m)
 
 std::shared_ptr<connection::Connection>
 ClientConnectionManagerImpl::connection_for_sql(
-  std::function<boost::optional<member>()> member_of_large_same_version_group,
-  std::function<boost::optional<member>(boost::uuids::uuid)> get_cluster_member)
+  std::function<util::optional<member>()> member_of_large_same_version_group,
+  std::function<util::optional<member>(boost::uuids::uuid)> get_cluster_member)
 {
     if (smart_routing_enabled_) {
         // There might be a race - the chosen member might be just connected or
@@ -1131,14 +1131,14 @@ Connection::write(
     socket_->async_write(shared_from_this(), client_invocation);
 }
 
-const boost::optional<address>&
+const util::optional<address>&
 Connection::get_remote_address() const
 {
     return remote_address_;
 }
 
 void
-Connection::set_remote_address(boost::optional<address> endpoint)
+Connection::set_remote_address(util::optional<address> endpoint)
 {
     this->remote_address_ = std::move(endpoint);
 }
@@ -1260,7 +1260,7 @@ Connection::set_connected_server_version(const std::string& connected_server)
     Connection::connected_server_version_string_ = connected_server;
 }
 
-boost::optional<address>
+util::optional<address>
 Connection::get_local_socket_address() const
 {
     return socket_->local_socket_address();

--- a/hazelcast/src/hazelcast/client/protocol.cpp
+++ b/hazelcast/src/hazelcast/client/protocol.cpp
@@ -866,7 +866,7 @@ sql_page_codec::decode_column_values(ClientMessage& msg,
     switch (column_type) {
         case sql::sql_column_type::varchar:
             return to_vector_of_any(
-              msg.get<std::vector<boost::optional<std::string>>>());
+              msg.get<std::vector<util::optional<std::string>>>());
         case sql::sql_column_type::boolean:
             return to_vector_of_any(
               builtin::list_cn_fixed_size_codec::decode<bool>(msg));
@@ -916,7 +916,7 @@ sql_page_codec::decode_column_values(ClientMessage& msg,
         case sql::sql_column_type::object:
             return to_vector_of_any(
               msg.get<std::vector<
-                boost::optional<serialization::pimpl::data>>>());
+                util::optional<serialization::pimpl::data>>>());
         default:
             throw exception::illegal_state(
               "ClientMessage::get<sql::sql_page>",

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -909,19 +909,19 @@ IListImpl::clear()
     return to_void_future(invoke_on_partition(request, partition_id_));
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IListImpl::get_data(int index)
 {
     auto request = protocol::codec::list_get_encode(get_name(), index);
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, partition_id_);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IListImpl::set_data(int index, const serialization::pimpl::data& element)
 {
     auto request = protocol::codec::list_set_encode(get_name(), index, element);
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, partition_id_);
 }
 
@@ -933,12 +933,12 @@ IListImpl::add(int index, const serialization::pimpl::data& element)
     return to_void_future(invoke_on_partition(request, partition_id_));
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IListImpl::remove_data(int index)
 {
     auto request =
       protocol::codec::list_removewithindex_encode(get_name(), index);
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, partition_id_);
 }
 
@@ -1203,13 +1203,13 @@ IQueueImpl::put(const serialization::pimpl::data& element)
     return to_void_future(invoke_on_partition(request, partition_id_));
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IQueueImpl::poll_data(std::chrono::milliseconds timeout)
 {
     auto request = protocol::codec::queue_poll_encode(
       get_name(),
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, partition_id_);
 }
 
@@ -1252,19 +1252,19 @@ IQueueImpl::drain_to_data()
       request, partition_id_);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IQueueImpl::take_data()
 {
     auto request = protocol::codec::queue_take_encode(get_name());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, partition_id_);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IQueueImpl::peek_data()
 {
     auto request = protocol::codec::queue_peek_encode(get_name());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, partition_id_);
 }
 
@@ -1465,7 +1465,7 @@ SerializingProxy::invoke_on_member(protocol::ClientMessage& request,
 }
 
 template<>
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request)
 {
     return decode_optional_var_sized<serialization::pimpl::data>(
@@ -1473,7 +1473,7 @@ SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request)
 }
 
 template<>
-boost::future<boost::optional<map::data_entry_view>>
+boost::future<util::optional<map::data_entry_view>>
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
                                         const serialization::pimpl::data& key)
 {
@@ -1482,7 +1482,7 @@ SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
 }
 
 template<>
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
                                         int partition_id)
 {
@@ -1491,7 +1491,7 @@ SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
 }
 
 template<>
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 SerializingProxy::invoke_and_get_future(protocol::ClientMessage& request,
                                         const serialization::pimpl::data& key)
 {
@@ -1536,21 +1536,21 @@ IMapImpl::contains_value(const serialization::pimpl::data& value)
     return invoke_and_get_future<bool>(request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::get_data(const serialization::pimpl::data& key)
 {
     auto request = protocol::codec::map_get_encode(
       get_name(), key, util::get_current_thread_id());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, key);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::remove_data(const serialization::pimpl::data& key)
 {
     auto request = protocol::codec::map_remove_encode(
       get_name(), key, util::get_current_thread_id());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, key);
 }
 
@@ -1614,7 +1614,7 @@ IMapImpl::try_put(const serialization::pimpl::data& key,
     return invoke_and_get_future<bool>(request, key);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::put_data(const serialization::pimpl::data& key,
                    const serialization::pimpl::data& value,
                    std::chrono::milliseconds ttl)
@@ -1625,7 +1625,7 @@ IMapImpl::put_data(const serialization::pimpl::data& key,
       value,
       util::get_current_thread_id(),
       std::chrono::duration_cast<std::chrono::milliseconds>(ttl).count());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, key);
 }
 
@@ -1643,7 +1643,7 @@ IMapImpl::put_transient(const serialization::pimpl::data& key,
     return invoke_on_partition(request, get_partition_id(key));
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::put_if_absent_data(const serialization::pimpl::data& key,
                              const serialization::pimpl::data& value,
                              std::chrono::milliseconds ttl)
@@ -1654,7 +1654,7 @@ IMapImpl::put_if_absent_data(const serialization::pimpl::data& key,
       value,
       util::get_current_thread_id(),
       std::chrono::duration_cast<std::chrono::milliseconds>(ttl).count());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, key);
 }
 
@@ -1669,14 +1669,14 @@ IMapImpl::replace(const serialization::pimpl::data& key,
     return invoke_and_get_future<bool>(request, key);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::replace_data(const serialization::pimpl::data& key,
                        const serialization::pimpl::data& value)
 {
     auto request = protocol::codec::map_replace_encode(
       get_name(), key, value, util::get_current_thread_id());
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, key);
 }
 
@@ -1815,12 +1815,12 @@ IMapImpl::add_entry_listener(
                              std::move(entry_event_handler));
 }
 
-boost::future<boost::optional<map::data_entry_view>>
+boost::future<util::optional<map::data_entry_view>>
 IMapImpl::get_entry_view_data(const serialization::pimpl::data& key)
 {
     auto request = protocol::codec::map_getentryview_encode(
       get_name(), key, util::get_current_thread_id());
-    return invoke_and_get_future<boost::optional<map::data_entry_view>>(request,
+    return invoke_and_get_future<util::optional<map::data_entry_view>>(request,
                                                                         key);
 }
 
@@ -1972,17 +1972,17 @@ IMapImpl::clear_data()
     return invoke(request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::execute_on_key_data(const serialization::pimpl::data& key,
                               const serialization::pimpl::data& processor)
 {
     auto request = protocol::codec::map_executeonkey_encode(
       get_name(), processor, key, util::get_current_thread_id());
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request, get_partition_id(key));
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 IMapImpl::submit_to_key_data(const serialization::pimpl::data& key,
                              const serialization::pimpl::data& processor)
 {
@@ -2178,7 +2178,7 @@ TransactionalQueueImpl::offer(const serialization::pimpl::data& e,
     return invoke_and_get_future<bool>(request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 TransactionalQueueImpl::poll_data(std::chrono::milliseconds timeout)
 {
     auto request = protocol::codec::transactionalqueue_poll_encode(
@@ -2187,7 +2187,7 @@ TransactionalQueueImpl::poll_data(std::chrono::milliseconds timeout)
       util::get_current_thread_id(),
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count());
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request);
 }
 
@@ -2514,7 +2514,7 @@ ReliableTopicMessage::get_publish_time() const
     return publish_time_;
 }
 
-const boost::optional<address>&
+const util::optional<address>&
 ReliableTopicMessage::get_publisher_address() const
 {
     return publisher_address_;

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -2504,7 +2504,7 @@ ReliableTopicMessage::ReliableTopicMessage(
   , payload_(std::move(payload_data))
 {
     if (address) {
-        publisher_address_ = boost::make_optional(*address);
+        publisher_address_ = util::make_optional(*address);
     }
 }
 

--- a/hazelcast/src/hazelcast/client/serialization.cpp
+++ b/hazelcast/src/hazelcast/client/serialization.cpp
@@ -398,10 +398,10 @@ portable_reader::portable_reader(pimpl::PortableSerializer& portable_ser,
   : is_default_reader_(is_default_reader)
 {
     if (is_default_reader) {
-        default_portable_reader_ = boost::make_optional(
+        default_portable_reader_ = util::make_optional(
           pimpl::DefaultPortableReader(portable_ser, input, cd));
     } else {
-        morphing_portable_reader_ = boost::make_optional(
+        morphing_portable_reader_ = util::make_optional(
           pimpl::MorphingPortableReader(portable_ser, input, cd));
     }
 }

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -832,7 +832,7 @@ DefaultAddressProvider::load_addresses()
     return addresses;
 }
 
-boost::optional<address>
+util::optional<address>
 DefaultAddressProvider::translate(const address& addr)
 {
     return addr;
@@ -871,7 +871,7 @@ ClientClusterServiceImpl::add_membership_listener_without_init(
     return id;
 }
 
-boost::optional<member>
+util::optional<member>
 ClientClusterServiceImpl::get_member(boost::uuids::uuid uuid) const
 {
     assert(!uuid.is_nil());
@@ -2309,7 +2309,7 @@ ClientPartitionServiceImpl::PartitionImpl::get_partition_id() const
     return partition_id_;
 }
 
-boost::optional<member>
+util::optional<member>
 ClientPartitionServiceImpl::PartitionImpl::get_owner() const
 {
     auto owner = partition_service_.get_partition_owner(partition_id_);
@@ -3022,7 +3022,7 @@ remote_address_provider::load_addresses()
     return addresses;
 }
 
-boost::optional<address>
+util::optional<address>
 remote_address_provider::translate(const address& addr)
 {
     // if it is inside cloud, return private address otherwise we need to

--- a/hazelcast/src/hazelcast/client/sql.cpp
+++ b/hazelcast/src/hazelcast/client/sql.cpp
@@ -174,7 +174,7 @@ sql_service::decode_fetch_response(protocol::ClientMessage message)
       message.get_nullable<std::shared_ptr<sql::sql_page>>([](protocol::ClientMessage& msg) {
           return protocol::codec::builtin::sql_page_codec::decode(msg);
       });
-    auto error = message.get<boost::optional<impl::sql_error>>();
+    auto error = message.get<util::optional<impl::sql_error>>();
     return { *std::move(page), std::move(error) };
 }
 
@@ -312,7 +312,7 @@ sql_service::fetch_page(
 }
 
 void
-sql_service::handle_fetch_response_error(boost::optional<impl::sql_error> error)
+sql_service::handle_fetch_response_error(util::optional<impl::sql_error> error)
 {
     if (error) {
         throw hazelcast_sql_exception(
@@ -418,14 +418,14 @@ sql_statement::timeout(std::chrono::milliseconds timeout)
     return *this;
 }
 
-const boost::optional<std::string>&
+const util::optional<std::string>&
 sql_statement::schema() const
 {
     return schema_;
 }
 
 sql_statement&
-sql_statement::schema(boost::optional<std::string> schema)
+sql_statement::schema(util::optional<std::string> schema)
 {
     schema_ = std::move(schema);
     return *this;
@@ -448,8 +448,8 @@ hazelcast_sql_exception::hazelcast_sql_exception(
   std::string source,
   boost::uuids::uuid originating_member_id,
   int32_t code,
-  boost::optional<std::string> message,
-  boost::optional<std::string> suggestion,
+  util::optional<std::string> message,
+  util::optional<std::string> suggestion,
   std::exception_ptr cause)
   : hazelcast_(std::move(source),
                message ? std::move(message).value() : "",
@@ -473,7 +473,7 @@ hazelcast_sql_exception::code() const
     return code_;
 }
 
-const boost::optional<std::string>&
+const util::optional<std::string>&
 hazelcast_sql_exception::suggestion() const
 {
     return suggestion_;
@@ -519,7 +519,7 @@ query_utils::throw_public_exception(std::exception_ptr exc,
     }
 }
 
-boost::optional<member>
+util::optional<member>
 query_utils::member_of_same_larger_version_group(
   const std::vector<member>& members)
 {
@@ -527,8 +527,8 @@ query_utils::member_of_same_larger_version_group(
     // version). Find a random member from the larger same-version group.
 
     // we don't use 2-element array to save on litter
-    boost::optional<member::version> version0;
-    boost::optional<member::version> version1;
+    util::optional<member::version> version0;
+    util::optional<member::version> version1;
     size_t count0 = 0;
     size_t count1 = 0;
 

--- a/hazelcast/src/hazelcast/client/transactions.cpp
+++ b/hazelcast/src/hazelcast/client/transactions.cpp
@@ -339,13 +339,13 @@ TransactionalMapImpl::contains_key_data(const serialization::pimpl::data& key)
     return invoke_and_get_future<bool>(request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 TransactionalMapImpl::get_data(const serialization::pimpl::data& key)
 {
     auto request = protocol::codec::transactionalmap_get_encode(
       get_name(), get_transaction_id(), util::get_current_thread_id(), key);
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request);
 }
 
@@ -367,7 +367,7 @@ TransactionalMapImpl::is_empty()
     return invoke_and_get_future<bool>(request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 TransactionalMapImpl::put_data(const serialization::pimpl::data& key,
                                const serialization::pimpl::data& value)
 {
@@ -381,7 +381,7 @@ TransactionalMapImpl::put_data(const serialization::pimpl::data& key,
       std::chrono::duration_cast<std::chrono::milliseconds>(get_timeout())
         .count());
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request);
 }
 
@@ -399,7 +399,7 @@ TransactionalMapImpl::set_data(const serialization::pimpl::data& key,
     return to_void_future(invoke(request));
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 TransactionalMapImpl::put_if_absent_data(
   const serialization::pimpl::data& key,
   const serialization::pimpl::data& value)
@@ -411,11 +411,11 @@ TransactionalMapImpl::put_if_absent_data(
       key,
       value);
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 TransactionalMapImpl::replace_data(const serialization::pimpl::data& key,
                                    const serialization::pimpl::data& value)
 {
@@ -426,7 +426,7 @@ TransactionalMapImpl::replace_data(const serialization::pimpl::data& key,
       key,
       value);
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request);
 }
 
@@ -446,13 +446,13 @@ TransactionalMapImpl::replace_data(const serialization::pimpl::data& key,
     return invoke_and_get_future<bool>(request);
 }
 
-boost::future<boost::optional<serialization::pimpl::data>>
+boost::future<util::optional<serialization::pimpl::data>>
 TransactionalMapImpl::remove_data(const serialization::pimpl::data& key)
 {
     auto request = protocol::codec::transactionalmap_remove_encode(
       get_name(), get_transaction_id(), util::get_current_thread_id(), key);
 
-    return invoke_and_get_future<boost::optional<serialization::pimpl::data>>(
+    return invoke_and_get_future<util::optional<serialization::pimpl::data>>(
       request);
 }
 

--- a/hazelcast/src/hazelcast/cp/cp.cpp
+++ b/hazelcast/src/hazelcast/cp/cp.cpp
@@ -293,13 +293,13 @@ atomic_long::alter_data(client::serialization::pimpl::data& function_data,
     return invoke_and_get_future<int64_t>(request);
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_long::apply_data(client::serialization::pimpl::data& function_data)
 {
     auto request =
       atomiclong_apply_encode(group_id_, object_name_, function_data);
     return invoke_and_get_future<
-      boost::optional<client::serialization::pimpl::data>>(request);
+      util::optional<client::serialization::pimpl::data>>(request);
 }
 
 atomic_reference::atomic_reference(const std::string& name,
@@ -309,32 +309,32 @@ atomic_reference::atomic_reference(const std::string& name,
   : cp_proxy(SERVICE_NAME, name, &context, group_id, object_name)
 {}
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::get_data()
 {
     auto request = atomicref_get_encode(group_id_, object_name_);
     return invoke_and_get_future<
-      boost::optional<client::serialization::pimpl::data>>(request);
+      util::optional<client::serialization::pimpl::data>>(request);
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::set_data(
   const client::serialization::pimpl::data& new_value_data)
 {
     auto request =
       atomicref_set_encode(group_id_, object_name_, &new_value_data, false);
     return invoke_and_get_future<
-      boost::optional<client::serialization::pimpl::data>>(request);
+      util::optional<client::serialization::pimpl::data>>(request);
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::get_and_set_data(
   const client::serialization::pimpl::data& new_value_data)
 {
     auto request =
       atomicref_set_encode(group_id_, object_name_, &new_value_data, true);
     return invoke_and_get_future<
-      boost::optional<client::serialization::pimpl::data>>(request);
+      util::optional<client::serialization::pimpl::data>>(request);
 }
 
 boost::future<bool>
@@ -364,21 +364,21 @@ atomic_reference::alter_data(
       invoke_apply(function_data, return_value_type::NO_VALUE, true));
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::alter_and_get_data(
   const client::serialization::pimpl::data& function_data)
 {
     return invoke_apply(function_data, return_value_type::NEW, true);
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::get_and_alter_data(
   const client::serialization::pimpl::data& function_data)
 {
     return invoke_apply(function_data, return_value_type::OLD, true);
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::apply_data(
   const client::serialization::pimpl::data& function_data)
 {
@@ -397,7 +397,7 @@ atomic_reference::clear()
     return to_void_future(set(static_cast<byte*>(nullptr)));
 }
 
-boost::future<boost::optional<client::serialization::pimpl::data>>
+boost::future<util::optional<client::serialization::pimpl::data>>
 atomic_reference::invoke_apply(
   const client::serialization::pimpl::data function_data,
   return_value_type return_type,
@@ -409,7 +409,7 @@ atomic_reference::invoke_apply(
                                           static_cast<int32_t>(return_type),
                                           alter);
     return invoke_and_get_future<
-      boost::optional<client::serialization::pimpl::data>>(request);
+      util::optional<client::serialization::pimpl::data>>(request);
 }
 
 latch::latch(const std::string& name,


### PR DESCRIPTION
Currently, C++ version was set to `C++11`. However, repository could be compiled with `C++17` as well even though some features are still taken from `Boost` libraries.

In this PR, I just focus on without breaking backward compability add `C++17` support and replace `Boost::Optional` with `std::optional` which was introduced in `C++17` standards.

Please review my changes and do not hesitate to contact me about your questions. 

Thanks in advance.