### PR TITLE
Discovery token is filtered out in exception message [API-1738].

### DIFF
--- a/hazelcast/include/hazelcast/util/SyncHttpsClient.h
+++ b/hazelcast/include/hazelcast/util/SyncHttpsClient.h
@@ -37,7 +37,8 @@ class HAZELCAST_API SyncHttpsClient
 public:
     SyncHttpsClient(const std::string& server_ip,
                     const std::string& uri_path,
-                    std::chrono::steady_clock::duration timeout);
+                    std::chrono::steady_clock::duration timeout,
+                    const std::string& secret_removal = std::string{});
 
     std::istream& connect_and_get_response();
 
@@ -45,6 +46,7 @@ private:
     std::string server_;
     std::string uri_path_;
     std::chrono::steady_clock::duration timeout_;
+    std::string secret_removal_;
 
     boost::asio::io_service io_service_;
     boost::asio::ip::tcp::resolver resolver_;

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -3072,7 +3072,7 @@ std::unordered_map<address, address>
 cloud_discovery::get_addresses()
 {
 #ifdef HZ_BUILD_WITH_SSL
-    std::string discovery_token {cloud_config_.discovery_token};
+    std::string discovery_token{ cloud_config_.discovery_token };
     try {
 
         util::SyncHttpsClient httpsConnection(cloud_base_url_,
@@ -3082,8 +3082,8 @@ cloud_discovery::get_addresses()
         auto& conn_stream = httpsConnection.connect_and_get_response();
         return parse_json_response(conn_stream);
     } catch (std::exception& e) {
-        std::string message {e.what()};
-        boost::replace_all(message, discovery_token,"<DISCOVERY_TOKEN>");
+        std::string message{ e.what() };
+        boost::replace_all(message, discovery_token, "<DISCOVERY_TOKEN>");
         std::throw_with_nested(
           boost::enable_current_exception(exception::illegal_state(
             "cloud_discovery::get_addresses", move(message))));

--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -286,12 +286,15 @@ SyncHttpsClient::connect_and_get_response()
 
     } catch (std::exception& e) {
         close();
-        throw client::exception::io(
-          "SyncHttpsClient::openConnection",
-          (boost::format(
+        auto message = (boost::format(
              "Could not retrieve response from https://%1%%2%. Error:%3%") %
            server_ % uri_path_ % e.what())
-            .str());
+            .str();
+
+        throw client::exception::io(
+          "SyncHttpsClient::openConnection",
+          move(message)
+          );
     }
     return response_stream_;
 }

--- a/hazelcast/src/hazelcast/util/util.cpp
+++ b/hazelcast/src/hazelcast/util/util.cpp
@@ -286,15 +286,12 @@ SyncHttpsClient::connect_and_get_response()
 
     } catch (std::exception& e) {
         close();
-        auto message = (boost::format(
-             "Could not retrieve response from https://%1%%2%. Error:%3%") %
-           server_ % uri_path_ % e.what())
-            .str();
-
         throw client::exception::io(
           "SyncHttpsClient::openConnection",
-          move(message)
-          );
+          (boost::format(
+             "Could not retrieve response from https://%1%%2%. Error:%3%") %
+           server_ % uri_path_ % e.what())
+            .str());
     }
     return response_stream_;
 }

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1857,13 +1857,10 @@ TEST_F(cloud_discovery_test, token_should_not_be_leaked)
 
     auto discovery_token = cloudConfig.discovery_token;
 
-    try
-    {
+    try {
         hazelcast::new_client(std::move(config)).get();
         FAIL();
-    }
-    catch (const exception::illegal_state& e)
-    {
+    } catch (const exception::illegal_state& e) {
         std::string message = e.what();
         ASSERT_EQ(message.find(discovery_token), std::string::npos);
     }


### PR DESCRIPTION
- Discovery token is filtered out at the source of exception.
- `token_should_not_be_leaked` test is added for this case.