### PR TITLE
Fix runner-image version for coverage.yml

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     name: Create and upload coverage
     steps:


### PR DESCRIPTION
Due to libssl package version change on ubuntu 22.04 our builds fail so changed runner-image to `20.04` from `ubuntu-latest`.