### PR TITLE
Cyclic dependency shared block

### DIFF
--- a/hazelcast/test/src/sql_test.cpp
+++ b/hazelcast/test/src/sql_test.cpp
@@ -416,9 +416,9 @@ protected:
                             Fns&&... fn)
     {
         for (auto itr = result->iterator(); itr.has_next();) {
-            auto page = itr.next();
+            auto page = itr.next().get();
 
-            for (auto const& row : page.get()->rows()) {
+            for (auto const& row : page->rows()) {
                 int _[] = { 0, ((void)fn(row), 0)... };
                 (void)_;
 


### PR DESCRIPTION
There is memory leak because `sql_page` self reference is passed to `sql_row` but those `sql_row`s are stored in `std::vector<T>` of `sql_page` so it creates cyclic dependency. So neither `sql_page` nor `sql_row`s gets destroyed.

- This problem is solved by creating a 3rd subject which is `shared_block` and both `sql_page` and `sql_row`s are holds a reference to it. It doesn't create additional cost. Just expresses the flow differently.

- Range for loop is fixed. Longer than one temporary expressions are not allowed in range-for.