### PR TITLE
Refactor for gcc 4-8-5.

### DIFF
--- a/hazelcast/include/hazelcast/client/sql/sql_service.h
+++ b/hazelcast/include/hazelcast/client/sql/sql_service.h
@@ -153,8 +153,8 @@ private:
 
     std::shared_ptr<connection::Connection> query_connection();
 
-    void rethrow(const std::exception_ptr& exc_ptr);
-    void rethrow(std::exception_ptr cause_ptr,
+    void rethrow(const std::exception& exc_ptr);
+    void rethrow(const std::exception& cause_ptr,
                  const std::shared_ptr<connection::Connection>& connection);
 
     boost::uuids::uuid client_id();

--- a/hazelcast/src/hazelcast/client/sql.cpp
+++ b/hazelcast/src/hazelcast/client/sql.cpp
@@ -84,8 +84,8 @@ sql_service::execute(const sql_statement& statement)
               auto response = response_fut.get();
               return handle_execute_response(
                 response, query_conn, qid, cursor_buffer_size);
-          } catch (...) {
-              rethrow(std::current_exception(), query_conn);
+          } catch (const std::exception& e) {
+              rethrow(e, query_conn);
           }
           assert(0);
           return std::shared_ptr<sql_result>();
@@ -104,8 +104,8 @@ sql_service::close(const std::shared_ptr<connection::Connection>& connection,
       [this, connection](boost::future<protocol::ClientMessage> f) {
           try {
               f.get();
-          } catch (exception::iexception&) {
-              rethrow(std::current_exception(), connection);
+          } catch (const exception::iexception& e) {
+              rethrow(e, connection);
           }
 
           return;
@@ -224,22 +224,22 @@ sql_service::query_connection()
             exception::query e(
               static_cast<int32_t>(impl::sql_error_code::CONNECTION_PROBLEM),
               "Client is not connected");
-            rethrow(std::make_exception_ptr(e));
+            rethrow(e);
         }
 
-    } catch (...) {
-        rethrow(std::current_exception());
+    } catch (const std::exception& e) {
+        rethrow(e);
     }
 
     return connection;
 }
 
 void
-sql_service::rethrow(const std::exception_ptr& exc_ptr)
+sql_service::rethrow(const std::exception& e)
 {
     // Make sure that access_control is thrown as a top-level exception
     try {
-        std::rethrow_if_nested(exc_ptr);
+        std::rethrow_if_nested(e);
     } catch (exception::access_control&) {
         throw;
     } catch (...) {
@@ -247,11 +247,12 @@ sql_service::rethrow(const std::exception_ptr& exc_ptr)
                                                   client_id());
     }
 
-    impl::query_utils::throw_public_exception(exc_ptr, client_id());
+    impl::query_utils::throw_public_exception(std::make_exception_ptr(e),
+                                              client_id());
 }
 
 void
-sql_service::rethrow(std::exception_ptr cause_ptr,
+sql_service::rethrow(const std::exception& cause,
                      const std::shared_ptr<connection::Connection>& connection)
 {
     if (!connection->is_alive()) {
@@ -263,11 +264,11 @@ sql_service::rethrow(std::exception_ptr cause_ptr,
           std::make_exception_ptr(exception::query(
             static_cast<int32_t>(impl::sql_error_code::CONNECTION_PROBLEM),
             msg,
-            std::move(cause_ptr))),
+            std::make_exception_ptr(cause))),
           client_id());
     }
 
-    return rethrow(cause_ptr);
+    return rethrow(cause);
 }
 
 boost::uuids::uuid
@@ -335,9 +336,8 @@ sql_statement::sql_statement(hazelcast_client& client, std::string query)
   , timeout_{ TIMEOUT_NOT_SET }
   , expected_result_type_{ sql_expected_result_type::any }
   , schema_{}
-  , serialization_service_{
-      spi::ClientContext(client).get_serialization_service()
-  }
+  , serialization_service_(
+      spi::ClientContext(client).get_serialization_service())
 {
     sql(std::move(query));
 }
@@ -349,7 +349,7 @@ sql_statement::sql_statement(spi::ClientContext& client_context,
   , timeout_{ TIMEOUT_NOT_SET }
   , expected_result_type_{ sql_expected_result_type::any }
   , schema_{}
-  , serialization_service_{ client_context.get_serialization_service() }
+  , serialization_service_(client_context.get_serialization_service())
 {
     sql(std::move(query));
 }
@@ -690,12 +690,10 @@ sql_result::close()
         release_resources();
 
         return f;
-    }
-    catch (...)
-    {
+    } catch (const std::exception& e) {
         release_resources();
 
-        service_->rethrow(std::current_exception());
+        service_->rethrow(e);
     }
 
     // This should not be reached.
@@ -742,9 +740,9 @@ sql_result::page_iterator::page_iterator(std::shared_ptr<sql_result> result,
   : in_progress_{ std::make_shared<std::atomic<bool>>(false) }
   , last_{ std::make_shared<std::atomic<bool>>(false) }
   , row_metadata_{ result->row_metadata_ }
-  , serialization_{ result->client_context_->get_serialization_service() }
+  , serialization_(result->client_context_->get_serialization_service())
   , result_{ move(result) }
-  , first_page_{ move(first_page) }
+  , first_page_(move(first_page))
 {
 }
 

--- a/hazelcast/src/hazelcast/client/sql.cpp
+++ b/hazelcast/src/hazelcast/client/sql.cpp
@@ -221,10 +221,14 @@ sql_service::query_connection()
             [&](boost::uuids::uuid id) { return cs.get_member(id); });
 
         if (!connection) {
-            exception::query e(
-              static_cast<int32_t>(impl::sql_error_code::CONNECTION_PROBLEM),
-              "Client is not connected");
-            rethrow(e);
+            try {
+                throw exception::query(
+                  static_cast<int32_t>(
+                    impl::sql_error_code::CONNECTION_PROBLEM),
+                  "Client is not connected");
+            } catch (const exception::query& e) {
+                rethrow(e);
+            }
         }
 
     } catch (const std::exception& e) {
@@ -247,7 +251,7 @@ sql_service::rethrow(const std::exception& e)
                                                   client_id());
     }
 
-    impl::query_utils::throw_public_exception(std::make_exception_ptr(e),
+    impl::query_utils::throw_public_exception(std::current_exception(),
                                               client_id());
 }
 

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1899,7 +1899,7 @@ TEST_F(cloud_discovery_test, parse_json)
       config,
       client_properties::CLOUD_URL_BASE_DEFAULT,
       std::chrono::seconds(1));
-    auto test_stream = std::istringstream(
+    std::istringstream test_stream (
       R"([{"private-address":"100.103.97.89","public-address":"3.92.127.167:30964"},{"private-address":"100.97.31.19","public-address":"54.227.206.253:30964"},{"private-address":"100.127.33.250","public-address":"54.80.210.250:30964"}])");
     auto addresses = d.parse_json_response(test_stream);
     ASSERT_EQ(3, addresses.size());

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1899,7 +1899,7 @@ TEST_F(cloud_discovery_test, parse_json)
       config,
       client_properties::CLOUD_URL_BASE_DEFAULT,
       std::chrono::seconds(1));
-    std::istringstream test_stream (
+    std::istringstream test_stream(
       R"([{"private-address":"100.103.97.89","public-address":"3.92.127.167:30964"},{"private-address":"100.97.31.19","public-address":"54.227.206.253:30964"},{"private-address":"100.127.33.250","public-address":"54.80.210.250:30964"}])");
     auto addresses = d.parse_json_response(test_stream);
     ASSERT_EQ(3, addresses.size());


### PR DESCRIPTION
- There is bug in `libstdc++` which comes with `gcc-4-8-5` which requires `T` of `std::throw_with_nested(T)` to be polymorphic but it contradicts with the standard. See [here](https://stackoverflow.com/questions/26217260/libstdc-stdthrow-with-nested-requires-polymorphic-types) but anyway due to our customer base `sql_service::rethrow` method is refactored to prevent this compile-error.
- `{}` brace initializers changed to `()` while initializing `serialization_service_` reference because otherwise it is not allowed by GCC 4.8.5.
- `std::istringstream` constructor is called directly rather than creating an rvalue instance and copy beacuse `std::istringstream` doesn't have copy constructor.

Successfully compiled on lab-116
![gcc-4-8-5](https://user-images.githubusercontent.com/35337781/209136211-dea2cde5-c411-4c13-aa4f-406a6bb1b3f3.png)

