### PR TITLE
Reference type is changed to pointer.

### DIFF
--- a/hazelcast/include/hazelcast/client/sql/sql_result.h
+++ b/hazelcast/include/hazelcast/client/sql/sql_result.h
@@ -91,10 +91,11 @@ public:
         bool has_next() const;
 
     private:
+
         std::shared_ptr<std::atomic<bool>> in_progress_;
         std::shared_ptr<std::atomic<bool>> last_;
         std::shared_ptr<sql_row_metadata> row_metadata_;
-        serialization::pimpl::SerializationService& serialization_;
+        serialization::pimpl::SerializationService* serialization_;
         std::shared_ptr<sql_result> result_;
         std::shared_ptr<sql_page> first_page_;
     };

--- a/hazelcast/src/hazelcast/client/sql.cpp
+++ b/hazelcast/src/hazelcast/client/sql.cpp
@@ -744,7 +744,7 @@ sql_result::page_iterator::page_iterator(std::shared_ptr<sql_result> result,
   : in_progress_{ std::make_shared<std::atomic<bool>>(false) }
   , last_{ std::make_shared<std::atomic<bool>>(false) }
   , row_metadata_{ result->row_metadata_ }
-  , serialization_(result->client_context_->get_serialization_service())
+  , serialization_(&result->client_context_->get_serialization_service())
   , result_{ move(result) }
   , first_page_(move(first_page))
 {
@@ -758,7 +758,7 @@ sql_result::page_iterator::next()
     if (first_page_) {
         auto page = move(first_page_);
 
-        page->serialization_service(&serialization_);
+        page->serialization_service(serialization_);
         page->row_metadata(row_metadata_);
         *last_ = page->last();
 
@@ -786,7 +786,7 @@ sql_result::page_iterator::next()
     std::weak_ptr<std::atomic<bool>> in_progress_w{ in_progress_ };
     std::shared_ptr<sql_row_metadata> row_metadata{ row_metadata_ };
     auto result = result_;
-    auto serialization_service = &serialization_;
+    auto serialization_service = serialization_;
 
     return page_future.then(
       boost::launch::sync,


### PR DESCRIPTION
Due to this warning [MacOs Jobs](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/3764987609) fails because library is not compiled.

So reference member changed to pointer.

[move-assignment-error-macos.txt](https://github.com/hazelcast/hazelcast-cpp-client/files/10294786/move-assignment-error-macos.txt)
