### PR TITLE
Fix pessimistic-move warning.

### DIFF
--- a/hazelcast/test/src/sql_test.cpp
+++ b/hazelcast/test/src/sql_test.cpp
@@ -828,7 +828,7 @@ TEST_F(SqlTest, sql_result_public_apis_should_throw_after_close)
         ASSERT_TRUE(result->row_set());
 
         it = std::make_shared<sql::sql_result::page_iterator>(
-          std::move(result->iterator()));
+          result->iterator());
 
         result->close().get();
     }


### PR DESCRIPTION
- Pessimistic move warning fixed.

[pessimistic-move.txt](https://github.com/hazelcast/hazelcast-cpp-client/files/10295232/pessimistic-move.txt)
