### PR TITLE
[API-1809]: Executor Lifecycle is extended for reliable_topic async continuation

### DIFF
--- a/hazelcast/include/hazelcast/client/reliable_topic.h
+++ b/hazelcast/include/hazelcast/client/reliable_topic.h
@@ -159,7 +159,7 @@ private:
           , cancelled_(false)
           , logger_(lg)
           , name_(topic_name)
-          , execution_service_(execution_service)
+          , execution_service_(std::move(execution_service))
           , executor_(executor)
           , serialization_service_(service)
           , batch_size_(batch_size)

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -41,7 +41,7 @@ reliable_topic::reliable_topic(const std::string& instance_name,
   : proxy::ProxyImpl(reliable_topic::SERVICE_NAME, instance_name, context)
   , execution_service_(
       context->get_client_execution_service().shared_from_this())  
-  , executor_(context->get_client_execution_service().get_user_executor())
+  , executor_(execution_service_->get_user_executor())
   , logger_(context->get_logger())
 {
     auto reliable_config =

--- a/hazelcast/src/hazelcast/client/proxy.cpp
+++ b/hazelcast/src/hazelcast/client/proxy.cpp
@@ -39,6 +39,8 @@ const std::chrono::milliseconds imap::UNSET{ -1 };
 reliable_topic::reliable_topic(const std::string& instance_name,
                                spi::ClientContext* context)
   : proxy::ProxyImpl(reliable_topic::SERVICE_NAME, instance_name, context)
+  , execution_service_(
+      context->get_client_execution_service().shared_from_this())  
   , executor_(context->get_client_execution_service().get_user_executor())
   , logger_(context->get_logger())
 {


### PR DESCRIPTION
For reliable_topic, in MessageRunner class, the next function is using boost async continuation with executor. When the client is destroyed, the executor object is destroyed too. If an async call is done and in the meanwhile the client is destroyed, an invalid executor is being used by boost and segfault is occured. To solve this problem, the lifecycle of executor is extended with passing the execution service as a parameter of async call.

To test the fix, first the test case is changed. testConfig test case is done for multiple times, as it destroys the client. When we add 10 test cases with testConfig, the error started to occur nearly every run. After the fix, we did not see the problem for more than 10 test cases. There is an example of test results in the attached file.

Fixes #1079, #1071 

[reliable_topic_test.txt](https://github.com/hazelcast/hazelcast-cpp-client/files/10566242/reliable_topic_test.txt)
