### PR TITLE
Executor pool size

### DIFF
--- a/hazelcast/include/hazelcast/client/spi/impl/ClientExecutionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientExecutionServiceImpl.h
@@ -42,7 +42,7 @@ class HAZELCAST_API ClientExecutionServiceImpl
 public:
     ClientExecutionServiceImpl(const std::string& name,
                                const client_properties& properties,
-                               int32_t pool_size,
+                               int32_t user_pool_size,
                                spi::lifecycle_service& service);
 
     void start();
@@ -83,6 +83,7 @@ private:
     std::unique_ptr<util::hz_thread_pool> user_executor_;
     spi::lifecycle_service& lifecycle_service_;
     const client_properties& client_properties_;
+    int32_t user_pool_size_;
 
     template<typename CompletionToken>
     std::shared_ptr<boost::asio::steady_timer>

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1291,10 +1291,11 @@ ClientInvocationServiceImpl::fail_on_indeterminate_state() const
 ClientExecutionServiceImpl::ClientExecutionServiceImpl(
   const std::string& name,
   const client_properties& properties,
-  int32_t pool_size,
+  int32_t user_pool_size,
   spi::lifecycle_service& service)
   : lifecycle_service_(service)
   , client_properties_(properties)
+  , user_pool_size_(user_pool_size)
 {}
 
 void
@@ -1310,7 +1311,11 @@ ClientExecutionServiceImpl::start()
     internal_executor_.reset(
       new hazelcast::util::hz_thread_pool(internalPoolSize));
 
-    user_executor_.reset(new hazelcast::util::hz_thread_pool());
+    if (user_pool_size_ <= 0){
+        user_executor_.reset(new hazelcast::util::hz_thread_pool());
+    } else{
+        user_executor_.reset(new hazelcast::util::hz_thread_pool(user_pool_size_));
+    }
 }
 
 void

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1311,10 +1311,11 @@ ClientExecutionServiceImpl::start()
     internal_executor_.reset(
       new hazelcast::util::hz_thread_pool(internalPoolSize));
 
-    if (user_pool_size_ <= 0){
+    if (user_pool_size_ <= 0) {
         user_executor_.reset(new hazelcast::util::hz_thread_pool());
-    } else{
-        user_executor_.reset(new hazelcast::util::hz_thread_pool(user_pool_size_));
+    } else {
+        user_executor_.reset(
+          new hazelcast::util::hz_thread_pool(user_pool_size_));
     }
 }
 

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2349,7 +2349,9 @@ namespace client {
 namespace test {
 namespace thread_pool {
 
-class ThreadPoolTest : public ClientTest, public testing::WithParamInterface<int32_t>
+class ThreadPoolTest
+  : public ClientTest
+  , public testing::WithParamInterface<int32_t>
 {
 protected:
     struct ThreadState
@@ -2400,17 +2402,18 @@ TEST_P(ThreadPoolTest, testEqualThreadAndJobs)
 
     ASSERT_EQ(0, state->thread_ids.size());
     for (int i = 0; i < num_of_jobs; i++) {
-        ctx.get_client_execution_service().get_user_executor().submit([state, &mutex_for_thread_id]() {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            {
-                std::lock_guard<std::mutex> lg(mutex_for_thread_id);
-                state->thread_ids.insert( boost::this_thread::get_id() );
-            }
-            state->latch1.count_down();
-        });
+        ctx.get_client_execution_service().get_user_executor().submit(
+          [state, &mutex_for_thread_id]() {
+              std::this_thread::sleep_for(std::chrono::seconds(1));
+              {
+                  std::lock_guard<std::mutex> lg(mutex_for_thread_id);
+                  state->thread_ids.insert(boost::this_thread::get_id());
+              }
+              state->latch1.count_down();
+          });
     }
     ASSERT_OPEN_EVENTUALLY(state->latch1);
-    ASSERT_EQ( std::min(num_of_jobs, num_of_thread), state->thread_ids.size());
+    ASSERT_EQ(std::min(num_of_jobs, num_of_thread), state->thread_ids.size());
 }
 
 INSTANTIATE_TEST_SUITE_P(ThreadPoolTestSuite,

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2344,6 +2344,84 @@ TEST_F(
 } // namespace client
 } // namespace hazelcast
 
+namespace hazelcast {
+namespace client {
+namespace test {
+namespace thread_pool {
+
+class ThreadPoolTest : public ClientTest, public testing::WithParamInterface<int32_t>
+{
+protected:
+    struct ThreadState
+    {
+        explicit ThreadState(int latch_count)
+          : latch1(latch_count)
+        {
+        }
+
+        boost::latch latch1;
+        std::set<boost::thread::id> thread_ids;
+    };
+
+protected:
+    static void SetUpTestCase()
+    {
+        instance = new HazelcastServer(default_server_factory());
+    }
+
+    static void TearDownTestCase()
+    {
+        delete client;
+        delete instance;
+
+        client = nullptr;
+        instance = nullptr;
+    }
+
+    static HazelcastServer* instance;
+    static hazelcast_client* client;
+};
+
+HazelcastServer* ThreadPoolTest::instance = nullptr;
+hazelcast_client* ThreadPoolTest::client = nullptr;
+
+TEST_P(ThreadPoolTest, testEqualThreadAndJobs)
+{
+    int32_t num_of_thread = 5;
+    int32_t num_of_jobs = GetParam();
+    client_config config;
+    config.set_executor_pool_size(num_of_thread);
+
+    client = new hazelcast_client{ new_client(std::move(config)).get() };
+
+    spi::ClientContext ctx(*client);
+    auto state = std::make_shared<ThreadState>(num_of_jobs);
+    std::mutex mutex_for_thread_id;
+
+    ASSERT_EQ(0, state->thread_ids.size());
+    for (int i = 0; i < num_of_jobs; i++) {
+        ctx.get_client_execution_service().get_user_executor().submit([state, &mutex_for_thread_id]() {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            {
+                std::lock_guard<std::mutex> lg(mutex_for_thread_id);
+                state->thread_ids.insert( boost::this_thread::get_id() );
+            }
+            state->latch1.count_down();
+        });
+    }
+    ASSERT_OPEN_EVENTUALLY(state->latch1);
+    ASSERT_EQ( std::min(num_of_jobs, num_of_thread), state->thread_ids.size());
+}
+
+INSTANTIATE_TEST_SUITE_P(ThreadPoolTestSuite,
+                         ThreadPoolTest,
+                         ::testing::Values(5, 10, 2));
+
+} // namespace thread_pool
+} // namespace test
+} // namespace client
+} // namespace hazelcast
+
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
set_executor_pool_size has no effect in the code. It justs sets a variable and this variable is never used anywhere. In this PR, user thread pool size can be set with set_executor_pool_size function. The PR is tested with written test cases.