### PR TITLE
Compact test failures

### DIFF
--- a/hazelcast/src/hazelcast/client/compact.cpp
+++ b/hazelcast/src/hazelcast/client/compact.cpp
@@ -1489,6 +1489,8 @@ field_descriptor::field_descriptor(enum field_kind f,
 std::array<uint64_t, 256>
 init_fp_table()
 {
+    std::mutex tmp_mutex;
+    std::lock_guard<std::mutex> lg(tmp_mutex);
     static std::array<uint64_t, 256> FP_TABLE;
     for (int i = 0; i < 256; ++i) {
         uint64_t fp = i;
@@ -1500,12 +1502,12 @@ init_fp_table()
     return FP_TABLE;
 }
 
-static std::array<uint64_t, 256> FP_TABLE = init_fp_table();
 constexpr uint64_t rabin_finger_print::INIT;
 
 uint64_t
 rabin_finger_print::fingerprint64(uint64_t fp, byte b)
-{
+{    
+    static std::array<uint64_t, 256> FP_TABLE = init_fp_table();
     return (fp >> 8) ^ FP_TABLE[(int)(fp ^ b) & 0xff];
 }
 

--- a/hazelcast/src/hazelcast/client/compact.cpp
+++ b/hazelcast/src/hazelcast/client/compact.cpp
@@ -1506,7 +1506,7 @@ constexpr uint64_t rabin_finger_print::INIT;
 
 uint64_t
 rabin_finger_print::fingerprint64(uint64_t fp, byte b)
-{    
+{
     static std::array<uint64_t, 256> FP_TABLE = init_fp_table();
     return (fp >> 8) ^ FP_TABLE[(int)(fp ^ b) & 0xff];
 }

--- a/hazelcast/src/hazelcast/client/compact.cpp
+++ b/hazelcast/src/hazelcast/client/compact.cpp
@@ -1489,9 +1489,7 @@ field_descriptor::field_descriptor(enum field_kind f,
 std::array<uint64_t, 256>
 init_fp_table()
 {
-    std::mutex tmp_mutex;
-    std::lock_guard<std::mutex> lg(tmp_mutex);
-    static std::array<uint64_t, 256> FP_TABLE;
+    std::array<uint64_t, 256> FP_TABLE;
     for (int i = 0; i < 256; ++i) {
         uint64_t fp = i;
         for (int j = 0; j < 8; ++j) {


### PR DESCRIPTION
Fixes #1090 
As I observed, the problem occurs in static library. It does not occur in dynamic library.
The problem is occured because of the static member initialization order. As there are template schemas, the build_schema function is called at startup. As finger print table is also initialized at startup, the schemas are built with empty table. 