### PR TITLE
Ssl version 3 [API-1872]

### DIFF
--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -16,24 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         boost:
-            - version: 1.71.0
             - version: 1.76.0
 
         build_type:
-          - type: Debug
-            warn_as_err: ON
           - type: Release
             warn_as_err: OFF
 
         shared_libs:
-          - toggle: OFF
-            name: Static
           - toggle: ON
             name: Shared
 
         with_openssl:
-          - toggle: OFF
-            name: 'noSSL'
           - toggle: ON
             name: 'SSL'
 
@@ -68,21 +61,3 @@ jobs:
               -DBUILD_TESTS=ON                                            \
               -DBUILD_EXAMPLES=OFF
 
-      - name: Test
-        if: ${{ inputs.run_tests || github.event_name == 'schedule' }}
-        env:
-          BUILD_DIR: build
-          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
-        run: |
-          ./scripts/test-unix.sh
-
-      - name: Verify Installation
-        env:
-          BUILD_DIR: build-examples
-        run: |
-          ./scripts/verify-installation-unix.sh                          \
-              -DCMAKE_PREFIX_PATH=${{ github.workspace }}/destination    \
-              -DWITH_OPENSSL=${{ matrix.with_openssl.toggle }}

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -16,17 +16,24 @@ jobs:
       fail-fast: false
       matrix:
         boost:
+            - version: 1.71.0
             - version: 1.76.0
 
         build_type:
+          - type: Debug
+            warn_as_err: ON
           - type: Release
             warn_as_err: OFF
 
         shared_libs:
+          - toggle: OFF
+            name: Static
           - toggle: ON
             name: Shared
 
         with_openssl:
+          - toggle: OFF
+            name: 'noSSL'
           - toggle: ON
             name: 'SSL'
 
@@ -61,3 +68,21 @@ jobs:
               -DBUILD_TESTS=ON                                            \
               -DBUILD_EXAMPLES=OFF
 
+      - name: Test
+        if: ${{ inputs.run_tests || github.event_name == 'schedule' }}
+        env:
+          BUILD_DIR: build
+          HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
+        run: |
+          ./scripts/test-unix.sh
+
+      - name: Verify Installation
+        env:
+          BUILD_DIR: build-examples
+        run: |
+          ./scripts/verify-installation-unix.sh                          \
+              -DCMAKE_PREFIX_PATH=${{ github.workspace }}/destination    \
+              -DWITH_OPENSSL=${{ matrix.with_openssl.toggle }}

--- a/hazelcast/src/hazelcast/client/discovery.cpp
+++ b/hazelcast/src/hazelcast/client/discovery.cpp
@@ -268,10 +268,12 @@ ec2_request_signer::hmac_sh_a256_bytes(const void* key_buffer,
     unsigned int len = 32;
     EVP_MD_CTX *mdctx;
     mdctx = EVP_MD_CTX_new();
-    EVP_MD_CTX_init(mdctx);    
-    EVP_DigestInit_ex(mdctx, EVP_sha256(), nullptr);
-    EVP_DigestUpdate(mdctx, data, data_len);
-    EVP_DigestFinal_ex(mdctx, hash, &len);
+    EVP_PKEY *skey = NULL;
+    skey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, (const unsigned char *)key_buffer, key_len);
+    EVP_DigestSignInit(mdctx, NULL, EVP_sha256(), NULL, skey);
+    EVP_DigestSignUpdate(mdctx, data, data_len);
+    EVP_DigestSignFinal(mdctx, hash, (size_t *)&len);
+    EVP_PKEY_free(skey);
     EVP_MD_CTX_free(mdctx);    
 #else
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L

--- a/hazelcast/src/hazelcast/client/discovery.cpp
+++ b/hazelcast/src/hazelcast/client/discovery.cpp
@@ -262,6 +262,18 @@ ec2_request_signer::hmac_sh_a256_bytes(const void* key_buffer,
                                        size_t data_len,
                                        unsigned char* hash) const
 {
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    //https://www.openssl.org/docs/man3.0/man7/migration_guide.html
+    unsigned int len = 32;
+    EVP_MD_CTX *mdctx;
+    mdctx = EVP_MD_CTX_new();
+    EVP_MD_CTX_init(mdctx);    
+    EVP_DigestInit_ex(mdctx, EVP_sha256(), nullptr);
+    EVP_DigestUpdate(mdctx, data, data_len);
+    EVP_DigestFinal_ex(mdctx, hash, &len);
+    EVP_MD_CTX_free(mdctx);    
+#else
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
     HMAC_CTX* hmac = HMAC_CTX_new();
 #else
@@ -279,6 +291,7 @@ ec2_request_signer::hmac_sh_a256_bytes(const void* key_buffer,
 #else
     HMAC_CTX_cleanup(hmac);
     delete hmac;
+#endif
 #endif
 
     return len;

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1569,9 +1569,13 @@ TEST_P(AwsClientTest, testClientAwsMemberWithSecurityGroupDefaultIamRole)
 
 TEST_P(AwsClientTest, testFipsEnabledAwsDiscovery)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    GTEST_SKIP();
+#else  
     if (GetParam() && !std::getenv("INSIDE_AWS")) {
         GTEST_SKIP();
     }
+#endif
 
     client_config clientConfig = get_config();
 

--- a/hazelcast/test/src/HazelcastTests7.cpp
+++ b/hazelcast/test/src/HazelcastTests7.cpp
@@ -1587,8 +1587,13 @@ TEST_P(AwsClientTest, testFipsEnabledAwsDiscovery)
     clientConfig.get_network_config().get_aws_config().set_inside_aws(
       GetParam());
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  // FIPS mode can be enabled over SSL conf
+  //https://wiki.openssl.org/index.php/OpenSSL_3.0
+#else
     // Turn Fips mode on
     FIPS_mode_set(1);
+#endif
 
     auto hazelcastClient = new_client(std::move(clientConfig)).get();
     auto map = hazelcastClient.get_map("myMap").get();


### PR DESCRIPTION
Some methods of OpenSSL is deprecated after V3. This PR makes the cpp-client to be compatible with both versions later than 3 and before version 3.

fixes #1091 
fixes #1092 