### PR TITLE
[API-1886] Download hazelcast-enterprise-tests.jar step has been added.

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -17,7 +17,11 @@ jobs:
       - name: Install Necessary Packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y net-tools libssl-dev gdb gcovr
+          sudo apt-get install -y net-tools libssl-dev gdb gcovr curl
+
+      - name: Download hazelcast-enterprise-tests.jar
+        run: |
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN }}" https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar > hazelcast-enterprise-5.2.0-tests.jar
 
       - name: Install Boost
         run: |

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -51,8 +51,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install openssl@1.1 thrift
+          brew install openssl@1.1 thrift curl
           ./scripts/install-boost.sh ${{matrix.boost.version}}
+
+      - name: Download hazelcast-enterprise-tests.jar
+        run: |
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN }}" https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar > hazelcast-enterprise-5.2.0-tests.jar
 
       - name: Build & Install
         env:

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Necessary Packages
         run: |
           apt-get update
-          apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-11-jre-headless gdb
+          apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-11-jre-headless gdb curl
 
       - name: Make sure the target architecture is 32 bit
         run: |
@@ -59,6 +59,10 @@ jobs:
           rm a test.c
 
       - uses: actions/checkout@v1
+
+      - name: Download hazelcast-enterprise-tests.jar
+        run: |
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN }}" https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar > hazelcast-enterprise-5.2.0-tests.jar
 
       - name: Install Boost
         run: |

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -47,9 +47,13 @@ jobs:
       - name: Install Necessary Packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y net-tools libssl-dev gdb
+          sudo apt-get install -y net-tools libssl-dev gdb curl
 
       - uses: actions/checkout@v2
+
+      - name: Download hazelcast-enterprise-tests.jar
+        run: |
+          curl -H "Authorization: token ${{ secrets.GH_TOKEN }}" https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar > hazelcast-enterprise-5.2.0-tests.jar
 
       - name: Install Boost
         run: |

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -75,6 +75,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Download hazelcast-enterprise-tests.jar
+        shell: pwsh
+        run: |
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          Invoke-WebRequest https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar -Headers @{"Authorization"="token ${{ secrets.GH_TOKEN }}"} -OutFile hazelcast-enterprise-5.2.0-tests.jar
+
       - uses: nick-fields/retry@v2
         name: Install OpenSSL
         if: matrix.with_openssl.toggle == 'ON'


### PR DESCRIPTION
Github actions fail because server version is upgraded to `5.2.0`. `hazelcast-enterprise-tests.jar` is not shared publicly anymore with `5.2.0`. So it needs to be downloaded before testing step. All workflows are updated according to it.