### PR TITLE
Compact compiler error on MacOs

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/pimpl/compact/compact.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/compact/compact.h
@@ -70,7 +70,7 @@ namespace compact {
  * @Beta
  * @since 5.1
  */
-struct compact_serializer
+class compact_serializer
 {};
 
 /**

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1423,7 +1423,7 @@ ClientInvocation::invoke()
 
         return replicate_schemas(schemas)
           .then(boost::launch::sync,
-                [this, actual_work, self](boost::future<void> replication) {
+                [actual_work, self](boost::future<void> replication) {
                     replication.get();
 
                     return actual_work();

--- a/hazelcast/test/resources/serialization.xml
+++ b/hazelcast/test/resources/serialization.xml
@@ -1,0 +1,5 @@
+<hazelcast xmlns="http://www.hazelcast.com/schema/config">
+
+    <cluster-name>serialization-dev</cluster-name>
+
+</hazelcast>

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -787,11 +787,11 @@ namespace hazelcast {
 namespace client {
 namespace test {
 
-class serializatation_test_base : public testing::Test
+class serialization_test_base : public testing::Test
 {
 public:
 
-    serializatation_test_base()
+    serialization_test_base()
       : factory_{ "hazelcast/test/resources/serialization.xml" }
       , member_{ factory_ }
       , client_{ new_client(config()).get() }
@@ -821,7 +821,7 @@ private:
     }
 };
 
-class PortableVersionTest : public serializatation_test_base
+class PortableVersionTest : public serialization_test_base
 {
 public:
     class Child
@@ -947,7 +947,7 @@ struct hz_serializer<test::PortableVersionTest::Parent>
 namespace hazelcast {
 namespace client {
 namespace test {
-class PartitionAwareTest : public serializatation_test_base
+class PartitionAwareTest : public serialization_test_base
 {
 public:
     class SimplePartitionAwareObject : public partition_aware<int>
@@ -1023,7 +1023,7 @@ struct hz_serializer<test::PartitionAwareTest::SimplePartitionAwareObject>
 namespace hazelcast {
 namespace client {
 namespace test {
-class JsonValueSerializationTest : public serializatation_test_base
+class JsonValueSerializationTest : public serialization_test_base
 {
 public:
     JsonValueSerializationTest()
@@ -1046,15 +1046,8 @@ TEST_F(JsonValueSerializationTest, testSerializeDeserializeJsonValue)
     ASSERT_EQ(jsonValue, jsonDeserialized.value());
 }
 
-class ClientSerializationTest : public ClientTest
+class ClientSerializationTest : public serialization_test_base
 {
-public:
-    ClientSerializationTest()
-      : member_{ default_server_factory() }
-      , client_{ new_client().get() }
-    {
-    }
-
 protected:
     TestInnerPortable create_inner_portable()
     {
@@ -1115,15 +1108,6 @@ protected:
     }
 
     static const unsigned int LARGE_ARRAY_SIZE;
-
-    serialization::pimpl::default_schema_service& get_schema_service()
-    {
-        return spi::ClientContext{ client_ }.get_schema_service();
-    }
-
-protected:
-    HazelcastServer member_;
-    hazelcast_client client_;
 };
 
 const unsigned int ClientSerializationTest::LARGE_ARRAY_SIZE =
@@ -2203,7 +2187,7 @@ namespace test {
 namespace internal {
 namespace nearcache {
 class NearCacheRecordStoreTest
-  : public serializatation_test_base
+  : public serialization_test_base
   , public ::testing::WithParamInterface<config::in_memory_format>
 {
 public:

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -789,9 +789,11 @@ namespace test {
 class PortableVersionTest : public ClientTest
 {
 public:
-
-    PortableVersionTest(): member_{ default_server_factory() }
-      , client_{ new_client().get() }{}
+    PortableVersionTest()
+      : member_{ default_server_factory() }
+      , client_{ new_client().get() }
+    {
+    }
     class Child
     {
     public:
@@ -836,8 +838,9 @@ public:
     {
         return spi::ClientContext{ client_ }.get_schema_service();
     }
-    protected:
-    HazelcastServer member_;    
+
+protected:
+    HazelcastServer member_;
     hazelcast_client client_;
 };
 
@@ -925,8 +928,11 @@ namespace test {
 class PartitionAwareTest : public ClientTest
 {
 public:
-    PartitionAwareTest():  member_{ default_server_factory() }
-      , client_{ new_client().get() }{}
+    PartitionAwareTest()
+      : member_{ default_server_factory() }
+      , client_{ new_client().get() }
+    {
+    }
     class SimplePartitionAwareObject : public partition_aware<int>
     {
     public:
@@ -946,10 +952,11 @@ public:
     {
         return spi::ClientContext{ client_ }.get_schema_service();
     }
-    protected:
-    HazelcastServer member_;    
-    hazelcast_client client_;    
-}; 
+
+protected:
+    HazelcastServer member_;
+    hazelcast_client client_;
+};
 
 TEST_F(PartitionAwareTest, testSimplePartitionAwareObjectSerialisation)
 {
@@ -1020,8 +1027,8 @@ public:
     serialization::pimpl::default_schema_service& get_schema_service()
     {
         return spi::ClientContext{ client_ }.get_schema_service();
-    }    
-    
+    }
+
 protected:
     HazelcastServer member_;
     hazelcast_client client_;
@@ -1043,8 +1050,12 @@ TEST_F(JsonValueSerializationTest, testSerializeDeserializeJsonValue)
 class ClientSerializationTest : public ClientTest
 {
 public:
-    ClientSerializationTest(): member_{ default_server_factory() }
-      , client_{ new_client().get() }{}
+    ClientSerializationTest()
+      : member_{ default_server_factory() }
+      , client_{ new_client().get() }
+    {
+    }
+
 protected:
     TestInnerPortable create_inner_portable()
     {
@@ -1110,9 +1121,10 @@ protected:
     {
         return spi::ClientContext{ client_ }.get_schema_service();
     }
-    protected:
-    HazelcastServer member_;    
-    hazelcast_client client_;    
+
+protected:
+    HazelcastServer member_;
+    hazelcast_client client_;
 };
 
 const unsigned int ClientSerializationTest::LARGE_ARRAY_SIZE =
@@ -2196,12 +2208,13 @@ class NearCacheRecordStoreTest
   , public ::testing::WithParamInterface<config::in_memory_format>
 {
 public:
-    NearCacheRecordStoreTest(): member_{ default_server_factory() }
+    NearCacheRecordStoreTest()
+      : member_{ default_server_factory() }
       , client_{ new_client().get() }
     {
         ss_ = std::unique_ptr<serialization::pimpl::SerializationService>(
-          new serialization::pimpl::SerializationService(
-            serialization_config_, get_schema_service()));
+          new serialization::pimpl::SerializationService(serialization_config_,
+                                                         get_schema_service()));
     }
 
 protected:
@@ -2550,9 +2563,9 @@ protected:
     serialization::pimpl::default_schema_service& get_schema_service()
     {
         return spi::ClientContext{ client_ }.get_schema_service();
-    }    
+    }
 
-    HazelcastServer member_;    
+    HazelcastServer member_;
     hazelcast_client client_;
     std::unique_ptr<serialization::pimpl::SerializationService> ss_;
     serialization_config serialization_config_;

--- a/hazelcast/test/src/HazelcastTests2.cpp
+++ b/hazelcast/test/src/HazelcastTests2.cpp
@@ -790,7 +790,6 @@ namespace test {
 class serialization_test_base : public testing::Test
 {
 public:
-
     serialization_test_base()
       : factory_{ "hazelcast/test/resources/serialization.xml" }
       , member_{ factory_ }
@@ -802,10 +801,9 @@ public:
     serialization::pimpl::default_schema_service& get_schema_service()
     {
         return spi::ClientContext{ client_ }.get_schema_service();
-    }    
+    }
 
 protected:
-
     HazelcastServerFactory factory_;
     HazelcastServer member_;
     hazelcast_client client_;
@@ -863,7 +861,6 @@ public:
     private:
         Child child_;
     };
-
 };
 
 // Test for issue https://github.com/hazelcast/hazelcast/issues/12733

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2044,10 +2044,13 @@ TEST(ClientMessageTest, testFragmentedMessageHandling)
     ASSERT_TRUE(datas_opt);
     auto& datas = datas_opt.value();
     ASSERT_EQ(10, datas.size());
+    HazelcastServerFactory factory("hazelcast/test/resources/hazelcast.xml");
+    HazelcastServer member(factory);    
+    auto client = new_client().get();
 
     serialization_config serializationConfig;
     serialization::pimpl::SerializationService ss{ serializationConfig,
-                                                   null_schema_service() };
+                                                   spi::ClientContext{ client }.get_schema_service() };
     for (int32_t i = 0; i < 10; ++i) {
         ASSERT_EQ(i, ss.to_object<int32_t>(&datas[i].first));
         ASSERT_EQ(i, ss.to_object<int32_t>(&datas[i].second));

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2044,9 +2044,12 @@ TEST(ClientMessageTest, testFragmentedMessageHandling)
     ASSERT_TRUE(datas_opt);
     auto& datas = datas_opt.value();
     ASSERT_EQ(10, datas.size());
-    HazelcastServerFactory factory("hazelcast/test/resources/hazelcast.xml");
+    HazelcastServerFactory factory("hazelcast/test/resources/serialization.xml");
     HazelcastServer member(factory);
-    auto client = new_client().get();
+    client_config conf;
+    conf.set_cluster_name("serialization-dev");
+    auto client = new_client(std::move(conf)).get();
+    remote_controller_client().ping();
 
     serialization_config serializationConfig;
     serialization::pimpl::SerializationService ss{

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2045,12 +2045,13 @@ TEST(ClientMessageTest, testFragmentedMessageHandling)
     auto& datas = datas_opt.value();
     ASSERT_EQ(10, datas.size());
     HazelcastServerFactory factory("hazelcast/test/resources/hazelcast.xml");
-    HazelcastServer member(factory);    
+    HazelcastServer member(factory);
     auto client = new_client().get();
 
     serialization_config serializationConfig;
-    serialization::pimpl::SerializationService ss{ serializationConfig,
-                                                   spi::ClientContext{ client }.get_schema_service() };
+    serialization::pimpl::SerializationService ss{
+        serializationConfig, spi::ClientContext{ client }.get_schema_service()
+    };
     for (int32_t i = 0; i < 10; ++i) {
         ASSERT_EQ(i, ss.to_object<int32_t>(&datas[i].first));
         ASSERT_EQ(i, ss.to_object<int32_t>(&datas[i].second));

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2044,7 +2044,8 @@ TEST(ClientMessageTest, testFragmentedMessageHandling)
     ASSERT_TRUE(datas_opt);
     auto& datas = datas_opt.value();
     ASSERT_EQ(10, datas.size());
-    HazelcastServerFactory factory("hazelcast/test/resources/serialization.xml");
+    HazelcastServerFactory factory(
+      "hazelcast/test/resources/serialization.xml");
     HazelcastServer member(factory);
     client_config conf;
     conf.set_cluster_name("serialization-dev");

--- a/hazelcast/test/src/TestHelperFunctions.h
+++ b/hazelcast/test/src/TestHelperFunctions.h
@@ -23,7 +23,6 @@
 
 #include "hazelcast/client/spi/ClientContext.h"
 
-
 inline std::string
 random_string()
 {

--- a/hazelcast/test/src/TestHelperFunctions.h
+++ b/hazelcast/test/src/TestHelperFunctions.h
@@ -23,13 +23,6 @@
 
 #include "hazelcast/client/spi/ClientContext.h"
 
-inline hazelcast::client::serialization::pimpl::default_schema_service&
-null_schema_service()
-{
-    return *static_cast<
-      hazelcast::client::serialization::pimpl::default_schema_service*>(
-      nullptr);
-}
 
 inline std::string
 random_string()

--- a/hazelcast/test/src/compact/compact_rabin_fingerprint_test.h
+++ b/hazelcast/test/src/compact/compact_rabin_fingerprint_test.h
@@ -28,9 +28,6 @@ struct CompactRabinFingerprintTest : public ::testing::Test
     template<typename T>
     using entry_t = std::tuple<int64_t, T, int64_t>;
 
-    static constexpr int int32_min = std::numeric_limits<int>::min();
-    static constexpr int64_t int64_min = std::numeric_limits<int64_t>::min();
-
     template<typename T>
     void check_each(std::vector<entry_t<T>> entries)
     {
@@ -52,7 +49,7 @@ TEST_F(CompactRabinFingerprintTest, test_i8_fingerprint)
     check_each(std::vector<entry_t<byte>>{
       // Before               Val   After(Expected)
       { 100, -5, -6165936963810616235 },
-      { int64_min, 0, 36028797018963968 },
+      { INT64_MIN, 0, 36028797018963968 },
       { 9223372036854775807, 113, -3588673659009074035 },
       { -13, -13, 72057594037927935 },
       { 42, 42, 0 },
@@ -68,8 +65,8 @@ TEST_F(CompactRabinFingerprintTest, test_i32_fingerprint)
 {
     check_each(std::vector<entry_t<int>>{
       // Before               Val            After(Expected)
-      { int64_min, 2147483647, 6066553457199370002 },
-      { 9223372036854775807, int32_min, 6066553459773452525 },
+      { INT64_MIN, 2147483647, 6066553457199370002 },
+      { 9223372036854775807, INT32_MIN, 6066553459773452525 },
       { 9223372036854707, 42, -961937498224213201 },
       { -42, -42, 4294967295 },
       { 42, 42, 0 },
@@ -77,7 +74,7 @@ TEST_F(CompactRabinFingerprintTest, test_i32_fingerprint)
       { 0, 0, 0 },
       { -123456789, 0, -565582369564281851 },
       { 123456786669, 42127, 7157681543413310373 },
-      { 2147483647, int32_min, -7679311364898232185 } });
+      { 2147483647, INT32_MIN, -7679311364898232185 } });
 }
 
 TEST_F(CompactRabinFingerprintTest, test_str_fingerprint)


### PR DESCRIPTION
After compact merge, client was not able to compile on Macos. This PR contains changes to compile it on MacOs.