### PR TITLE
boost version is updated

### DIFF
--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         boost:
-          - version: 1.71.0
+          - version: 1.73.0
           - version: 1.76.0
 
         build_type:


### PR DESCRIPTION
Boost version is updated for action belonging to Ubuntu x64. (1.71->1.73)
New version is selected according to the oldest compilable version after 1.71.
Fixes #1111 