### PR TITLE
`connection_manager_translate` tests are fixed.

### DIFF
--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2476,7 +2476,7 @@ protected:
 HazelcastServer* connection_manager_translate::instance_ = nullptr;
 const address connection_manager_translate::private_address{ "localhost",
                                                              5701 };
-const address connection_manager_translate::public_address{ "192.168.0.1",
+const address connection_manager_translate::public_address{ "245.245.245.245",
                                                             5701 };
 
 TEST_F(connection_manager_translate, test_translate_is_used)


### PR DESCRIPTION
IP used in translate tests were `192.168.0.1` but I observed that sometimes it connects to it, probably other github runners hosted in the `192.168.0.1` network. So I changed the url to some reserved multicast ip blocks.