### PR TITLE
Unused `this` capture is removed.

### DIFF
--- a/hazelcast/src/hazelcast/client/network.cpp
+++ b/hazelcast/src/hazelcast/client/network.cpp
@@ -841,7 +841,7 @@ ClientConnectionManagerImpl::on_authenticated(
                 client_state_ = client_state::CONNECTED_TO_CLUSTER;
                 auto self = shared_from_this();
                 boost::asio::post(
-                  executor_->get_executor(), [self, new_cluster_id, this]() {
+                  executor_->get_executor(), [self, new_cluster_id]() {
                       self->initialize_client_on_cluster(new_cluster_id);
                   });
             } else {


### PR DESCRIPTION
Removes unused `this` capture from lambda object.

[macos-compile-error.txt](https://github.com/hazelcast/hazelcast-cpp-client/files/10867976/macos-compile-error.txt)
