### PR TITLE
Listener unhandled exception

### DIFF
--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1572,7 +1572,7 @@ ClientInvocation::invoke_on_selection()
         }
     } catch (exception::iexception&) {
         notify_exception(std::current_exception());
-    } catch (std::exception&) {
+    } catch (std::exception& exp) {
         HZ_LOG(
           logger_,
           finest,

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1573,11 +1573,10 @@ ClientInvocation::invoke_on_selection()
     } catch (exception::iexception&) {
         notify_exception(std::current_exception());
     } catch (std::exception&) {
-        HZ_LOG(logger_,
-                   finest,
-                   boost::str(boost::format(
-                                "Unexpected exception. %1%") %
-                              exp.what() ));        
+        HZ_LOG(
+          logger_,
+          finest,
+          boost::str(boost::format("Unexpected exception. %1%") % exp.what()));
         assert(false);
     }
 }
@@ -3010,8 +3009,8 @@ cluster_view_listener::try_register(
               handler->on_listener_register();
               return;
           }
-          
-          f.get(); //get unhandled exception
+
+          f.get(); // get unhandled exception
           // completes with exception, listener needs to be reregistered
           self->try_reregister_to_random_connection(conn_id);
       });

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1573,10 +1573,6 @@ ClientInvocation::invoke_on_selection()
     } catch (exception::iexception&) {
         notify_exception(std::current_exception());
     } catch (std::exception& exp) {
-        HZ_LOG(
-          logger_,
-          finest,
-          boost::str(boost::format("Unexpected exception. %1%") % exp.what()));
         assert(false);
     }
 }
@@ -3013,8 +3009,10 @@ cluster_view_listener::try_register(
           try {
               f.get();
           } catch (exception::hazelcast_client_not_active& e) {
-              /*If client is shutdown, we should not retry for another
-               * connection*/
+              /**
+               * If client is shutdown, we should not retry for another
+               * connection
+               * */
               return;
           }
           // completes with exception, listener needs to be reregistered

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -3010,7 +3010,13 @@ cluster_view_listener::try_register(
               return;
           }
 
-          f.get(); // get unhandled exception
+          try {
+              f.get();
+          } catch (exception::hazelcast_client_not_active& e) {
+              /*If client is shutdown, we should not retry for another
+               * connection*/
+              return;
+          }
           // completes with exception, listener needs to be reregistered
           self->try_reregister_to_random_connection(conn_id);
       });

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1573,6 +1573,11 @@ ClientInvocation::invoke_on_selection()
     } catch (exception::iexception&) {
         notify_exception(std::current_exception());
     } catch (std::exception&) {
+        HZ_LOG(logger_,
+                   finest,
+                   boost::str(boost::format(
+                                "Unexpected exception. %1%") %
+                              exp.what() ));        
         assert(false);
     }
 }
@@ -3005,7 +3010,8 @@ cluster_view_listener::try_register(
               handler->on_listener_register();
               return;
           }
-
+          
+          f.get(); //get unhandled exception
           // completes with exception, listener needs to be reregistered
           self->try_reregister_to_random_connection(conn_id);
       });

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1572,7 +1572,7 @@ ClientInvocation::invoke_on_selection()
         }
     } catch (exception::iexception&) {
         notify_exception(std::current_exception());
-    } catch (std::exception& exp) {
+    } catch (std::exception&) {
         assert(false);
     }
 }


### PR DESCRIPTION
When an exception occurs in invoke_urgent().then, it is not handled with futures's get method. Because of this, assert method may be called in invoke_on_selection and gives error in debug releases.