### PR TITLE
Compatibility tests are fixed.

### DIFF
--- a/hazelcast/test/src/compact/compact_generic_record_builder_test.h
+++ b/hazelcast/test/src/compact/compact_generic_record_builder_test.h
@@ -31,7 +31,7 @@ class CompactGenericRecordBuilderTest : public compact_test_base
 protected:
     SerializationService& serialization_service()
     {
-        return spi::ClientContext{ client }.get_serialization_service();
+        return spi::ClientContext{ *client }.get_serialization_service();
     }
 };
 
@@ -129,7 +129,7 @@ TEST_F(CompactGenericRecordBuilderTest,
     }
 
     // Ensure that schema is distributed
-    client.get_map(random_string())
+    client->get_map(random_string())
       .get()
       ->put(random_string(), list.front())
       .get();

--- a/hazelcast/test/src/compact/compact_generic_record_integration_test.h
+++ b/hazelcast/test/src/compact/compact_generic_record_integration_test.h
@@ -39,7 +39,7 @@ protected:
 
         remote_controller_client().executeOnController(
           response,
-          factory_.get_cluster_id(),
+          factory_->get_cluster_id(),
           (boost::format(
              R"(
                         var clusterMap = instance_0.getMap("%1%");
@@ -71,7 +71,7 @@ protected:
 
         remote_controller_client().executeOnController(
           response,
-          factory_.get_cluster_id(),
+          factory_->get_cluster_id(),
           (boost::format(
              R"(
                 var map = instance_0.getMap("%1%");
@@ -143,9 +143,9 @@ protected:
                     record.getFieldKind("date") === com.hazelcast.nio.serialization.FieldKind.DATE &&
                     record.getDate("date").getYear() == 2023 &&
                     record.getDate("date").getMonthValue() == 2 &&)"
-            // Splitted into two chunks
-            // Because MSVC complains about it !!!
-            R"(
+             // Splitted into two chunks
+             // Because MSVC complains about it !!!
+             R"(
                     record.getDate("date").getDayOfMonth() == 6 &&
                     record.getFieldKind("date_null") === com.hazelcast.nio.serialization.FieldKind.DATE &&
                     record.getDate("date_null") === null &&
@@ -302,7 +302,7 @@ TEST_F(CompactGenericRecordIntegrationTest, test_put_generic_record_back)
     // Counterpart is 'test' but using random string is
     // better to prevent name clashes.
     auto map_name = random_string();
-    auto map = client.get_map(map_name).get();
+    auto map = client->get_map(map_name).get();
 
     named_compact expected{ "foo", 900 };
 
@@ -319,7 +319,7 @@ TEST_F(CompactGenericRecordIntegrationTest, test_put_generic_record_back)
 
 TEST_F(CompactGenericRecordIntegrationTest, test_put_get)
 {
-    auto map = client.get_map(random_string()).get();
+    auto map = client->get_map(random_string()).get();
 
     map->put(1, create_generic_record()).get();
     boost::optional<generic_record> record =
@@ -618,7 +618,7 @@ TEST_F(CompactGenericRecordIntegrationTest,
     auto record = create_generic_record();
 
     auto map_name = random_string();
-    client.get_map(map_name).get()->put(1, record).get();
+    client->get_map(map_name).get()->put(1, record).get();
 
     validate_record(map_name);
 }
@@ -629,9 +629,9 @@ TEST_F(CompactGenericRecordIntegrationTest, test_put_and_read_with_sql)
     auto record = create_generic_record(type_name);
 
     auto map_name = random_string();
-    client.get_map(map_name).get()->put(1, record).get();
+    client->get_map(map_name).get()->put(1, record).get();
 
-    (void)client.get_sql()
+    (void)client->get_sql()
       .execute(boost::str(boost::format(
                             R"(
                     CREATE MAPPING "%1%" (
@@ -649,7 +649,7 @@ TEST_F(CompactGenericRecordIntegrationTest, test_put_and_read_with_sql)
       .get();
 
     auto result =
-      client.get_sql()
+      client->get_sql()
         .execute(boost::str(boost::format("SELECT * FROM %1%") % map_name))
         .get();
 

--- a/hazelcast/test/src/compact/compact_generic_record_test.h
+++ b/hazelcast/test/src/compact/compact_generic_record_test.h
@@ -37,7 +37,7 @@ protected:
 
     SerializationService& serialization_service()
     {
-        return spi::ClientContext{ client }.get_serialization_service();
+        return spi::ClientContext{ *client }.get_serialization_service();
     }
 
     void assert_setter_throws(generic_record_builder& builder,
@@ -113,7 +113,7 @@ TEST_F(CompactGenericRecordTest, test_get_field_kind)
     auto data = service.to_data(record);
 
     // Ensure that schema is distributed
-    client.get_map(random_string()).get()->put(random_string(), record).get();
+    client->get_map(random_string()).get()->put(random_string(), record).get();
     auto internal_generic_record = service.to_object<generic_record>(data);
 
     ASSERT_TRUE(internal_generic_record.has_value());
@@ -150,7 +150,7 @@ TEST_F(CompactGenericRecordTest,
     auto data = ss.to_data(record);
 
     // Ensure that schema is distributed
-    client.get_map(random_string()).get()->put(random_string(), record).get();
+    client->get_map(random_string()).get()->put(random_string(), record).get();
     boost::optional<generic_record> internal_generic_record =
       ss.to_object<generic_record>(data);
 
@@ -183,7 +183,7 @@ TEST_F(CompactGenericRecordTest,
     auto data = ss.to_data(record);
 
     // Ensure that schema is distributed
-    client.get_map(random_string()).get()->put(random_string(), record).get();
+    client->get_map(random_string()).get()->put(random_string(), record).get();
     boost::optional<generic_record> internal_generic_record =
       ss.to_object<generic_record>(data);
 

--- a/hazelcast/test/src/compact/compact_nullable_primitive_interoperability_test.h
+++ b/hazelcast/test/src/compact/compact_nullable_primitive_interoperability_test.h
@@ -54,7 +54,7 @@ class CompactNullablePrimitiveInteroperabilityTest : public compact_test_base
 protected:
     SerializationService& serialization_service()
     {
-        return spi::ClientContext{ client }.get_serialization_service();
+        return spi::ClientContext{ *client }.get_serialization_service();
     }
 };
 

--- a/hazelcast/test/src/compact/compact_read_write_integration_test.h
+++ b/hazelcast/test/src/compact/compact_read_write_integration_test.h
@@ -41,7 +41,7 @@ TEST_F(CompactReadWriteIntegrationTest, map_put_get)
     auto map_name = random_string();
     auto key = random_string();
 
-    auto map = client.get_map(map_name).get();
+    auto map = client->get_map(map_name).get();
 
     map->put(key, dto).get();
     auto actual = map->get<std::string, main_dto>(key).get();
@@ -57,7 +57,7 @@ TEST_F(CompactReadWriteIntegrationTest, write_read_sql)
     auto key = random_string();
     auto type_name = serialization::hz_serializer<sample_compact_type>::type_name();
 
-    auto map = client.get_map(map_name).get();
+    auto map = client->get_map(map_name).get();
 
     map->put(key, value).get();
 
@@ -74,9 +74,9 @@ TEST_F(CompactReadWriteIntegrationTest, write_read_sql)
                          map_name % type_name)
                           .str();
 
-    (void)client.get_sql().execute(query).get();
+    (void)client->get_sql().execute(query).get();
 
-    auto result = client.get_sql()
+    auto result = client->get_sql()
                     .execute(str(boost::format("SELECT * FROM %1%") % map_name))
                     .get();
 

--- a/hazelcast/test/src/compact/compact_schema_replication_on_cluster_restart_test.h
+++ b/hazelcast/test/src/compact/compact_schema_replication_on_cluster_restart_test.h
@@ -43,7 +43,7 @@ protected:
 
         remote_controller_client().executeOnController(
           response,
-          factory_.get_cluster_id(),
+          factory_->get_cluster_id(),
           R"(
               var length = instance_0.getOriginal().node.getSchemaService().getAllSchemas().size();
               result = "" + length;
@@ -63,18 +63,18 @@ TEST_F(CompactSchemaReplicationOnClusterRestart, on_cluster_restart)
     auto schema_parent = get_schema<sample_compact_type>();
     auto schema_child = get_schema<nested_type>();
 
-    auto map = client.get_map(random_string()).get();
+    auto map = client->get_map(random_string()).get();
 
     map->put(random_string(), sample_compact_type{}).get();
 
-    member_.shutdown();
+    member_->shutdown();
 
     boost::latch connected_latch(1);
 
-    client.add_lifecycle_listener(lifecycle_listener().on_connected(
+    client->add_lifecycle_listener(lifecycle_listener().on_connected(
       [&connected_latch]() { connected_latch.try_count_down(); }));
 
-    HazelcastServer another_member{ factory_ };
+    HazelcastServer another_member{ *factory_ };
 
     ASSERT_OPEN_EVENTUALLY(connected_latch);
     ASSERT_TRUE_EVENTUALLY(check_schema_on_backend(schema_parent) &&
@@ -88,14 +88,14 @@ TEST_F(CompactSchemaReplicationOnClusterRestart,
 
     ASSERT_TRUE_EVENTUALLY(condition());
 
-    member_.shutdown();
+    member_->shutdown();
 
     boost::latch connected_latch(1);
 
-    client.add_lifecycle_listener(lifecycle_listener().on_connected(
+    client->add_lifecycle_listener(lifecycle_listener().on_connected(
       [&connected_latch]() { connected_latch.try_count_down(); }));
 
-    HazelcastServer another_member{ factory_ };
+    HazelcastServer another_member{ *factory_ };
 
     ASSERT_OPEN_EVENTUALLY(connected_latch);
     ASSERT_TRUE_ALL_THE_TIME(condition(), 1);

--- a/hazelcast/test/src/compact/compact_schema_replication_on_write_test.h
+++ b/hazelcast/test/src/compact/compact_schema_replication_on_write_test.h
@@ -45,7 +45,7 @@ TEST_F(CompactSchemaReplicationOnWrite, imap_put)
     ASSERT_EQ(check_schema_on_backend(schema_parent), false);
     ASSERT_EQ(check_schema_on_backend(schema_child), false);
 
-    auto map = client.get_map(random_string()).get();
+    auto map = client->get_map(random_string()).get();
 
     map->put(random_string(), sample_compact_type{}).get();
 

--- a/hazelcast/test/src/compact/compact_schema_replication_stress_test.h
+++ b/hazelcast/test/src/compact/compact_schema_replication_stress_test.h
@@ -68,7 +68,7 @@ TEST_F(CompactSchemaReplicationStress, test)
 {
     using replication_work_t =
       boost::future<std::vector<serialization::pimpl::schema>>;
-    auto map = client.get_map(random_string()).get();
+    auto map = client->get_map(random_string()).get();
 
     replication_work_t replication_works[] = {
         boost::async(boost::launch::async, replicate_schemas<0, 10>, map),

--- a/hazelcast/test/src/compact/compact_schema_validation_test.h
+++ b/hazelcast/test/src/compact/compact_schema_validation_test.h
@@ -49,7 +49,7 @@ protected:
 
         remote_controller_client().executeOnController(
           response,
-          factory_.get_cluster_id(),
+          factory_->get_cluster_id(),
           (boost::format(
              R"(
                         var schemas = instance_0.getOriginal().node.getSchemaService().getAllSchemas();

--- a/hazelcast/test/src/compact/compact_serialization_test.h
+++ b/hazelcast/test/src/compact/compact_serialization_test.h
@@ -41,7 +41,7 @@ class CompactSerializationTest : public compact_test_base
 public:
     SerializationService& serialization_service()
     {
-        return spi::ClientContext{ client }.get_serialization_service();
+        return spi::ClientContext{ *client }.get_serialization_service();
     }
 
     template<typename T>

--- a/hazelcast/test/src/compact/compact_test_base.h
+++ b/hazelcast/test/src/compact/compact_test_base.h
@@ -33,21 +33,20 @@ class compact_test_base : public testing::Test
 public:
     using schema_t = serialization::pimpl::schema;
 
-    compact_test_base()
-      : factory_{ "hazelcast/test/resources/compact.xml" }
-      , member_{ factory_ }
-      , client{ new_client(config()).get() }
-    {
-        remote_controller_client().ping();
-    }
+    compact_test_base() {}
 
 protected:
     void SetUp() override
     {
-        auto version = client.get_cluster().get_members().front().get_version();
-
-        if (version < member::version{ 5, 2, 0 })
+        if (cluster_version() < member::version{ 5, 2, 0 })
             GTEST_SKIP();
+
+        factory_.reset(
+          new HazelcastServerFactory{ "hazelcast/test/resources/compact.xml" });
+        member_.reset(new HazelcastServer{ *factory_ });
+        client.reset(new hazelcast_client{ new_client(config()).get() });
+
+        remote_controller_client().ping();
     }
 
     template<typename T>
@@ -55,7 +54,7 @@ protected:
     {
         auto schema = get_schema<T>();
 
-        spi::ClientContext context{ client };
+        spi::ClientContext context{ *client };
 
         ASSERT_NO_THROW(
           context.get_schema_service().replicate_schema_in_cluster(schema));
@@ -67,7 +66,7 @@ protected:
 
         remote_controller_client().executeOnController(
           response,
-          factory_.get_cluster_id(),
+          factory_->get_cluster_id(),
           (boost::format(
              R"(
                         var schemas = instance_0.getOriginal().node.getSchemaService().getAllSchemas();
@@ -98,9 +97,9 @@ protected:
         return compact_stream_serializer::build_schema(T{});
     }
 
-    HazelcastServerFactory factory_;
-    HazelcastServer member_;
-    hazelcast_client client;
+    std::unique_ptr<HazelcastServerFactory> factory_;
+    std::unique_ptr<HazelcastServer> member_;
+    std::unique_ptr<hazelcast_client> client;
 
 private:
     static client_config config()

--- a/hazelcast/test/src/sql_test.cpp
+++ b/hazelcast/test/src/sql_test.cpp
@@ -1358,6 +1358,9 @@ TEST_F(SqlTest, test_streaming_sql_query)
 
 TEST_F(SqlTest, test_date)
 {
+    if (cluster_version() < member::version{ 5, 0, 0 })
+        GTEST_SKIP();
+
     create_mapping("DATE");
 
     auto expecteds = populate_map_via_rc<local_date>(
@@ -1378,6 +1381,9 @@ TEST_F(SqlTest, test_date)
 
 TEST_F(SqlTest, test_time)
 {
+    if (cluster_version() < member::version{ 5, 0, 0 })
+        GTEST_SKIP();
+
     create_mapping("TIME");
 
     auto expecteds = populate_map_via_rc<local_time>(
@@ -1399,6 +1405,9 @@ TEST_F(SqlTest, test_time)
 
 TEST_F(SqlTest, test_timestamp)
 {
+    if (cluster_version() < member::version{ 5, 0, 0 })
+        GTEST_SKIP();
+
     create_mapping("TIMESTAMP");
 
     auto expecteds = populate_map_via_rc<local_date_time>(
@@ -1422,6 +1431,9 @@ TEST_F(SqlTest, test_timestamp)
 
 TEST_F(SqlTest, test_timestamp_with_timezone)
 {
+    if (cluster_version() < member::version{ 5, 0, 0 })
+        GTEST_SKIP();
+
     create_mapping("TIMESTAMP WITH TIME ZONE");
 
     auto expecteds = populate_map_via_rc<offset_date_time>(


### PR DESCRIPTION
- Clusters on compact tests made disabled if the version is lower than 5.2.0
- `test_date`, `test_time`, `test_timestamp`, `test_timestamp_with_timezone` are skipped before `5.0.0`