### PR TITLE
Windows GitHub cache [API-1890]

### DIFF
--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -140,7 +140,7 @@ jobs:
           path: C:\Thrift
           key: ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}-
+            ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}
             
       - if: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
         name: Install Thrift

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -108,8 +108,6 @@ jobs:
       - name: Cache Boost Version
         id: cache-boost
         uses: actions/cache@v3
-        env:
-          cache-name: cache-boost-version
         with:          
           path: C:\Boost
           key: ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type }}
@@ -134,8 +132,6 @@ jobs:
       - name: Cache Thrift Version
         id: cache-thrift
         uses: actions/cache@v3
-        env:
-          cache-name: cache-thrift-version
         with:          
           path: C:\Thrift
           key: ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type }}

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -111,10 +111,10 @@ jobs:
         env:
           cache-name: cache-boost-version
         with:          
-          path: ${{ matrix.vc_boost.boost_include_folder }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-${{ matrix.vc_boost.boost_archive_name }}
+          path: C:\Boost
+          key: ${{ runner.os }}-${{ matrix.arch.address_model }}-build-${{ matrix.vc_boost.boost_archive_name }}-${{ matrix.build_type }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-${{ matrix.vc_boost.boost_archive_name }}
+            ${{ runner.os }}-${{ matrix.arch.address_model }}-build-${{ matrix.vc_boost.boost_archive_name }}-${{ matrix.build_type }}
             
       - if: ${{ steps.cache-boost.outputs.cache-hit != 'true' }}
         name: Install Boost
@@ -138,9 +138,9 @@ jobs:
           cache-name: cache-thrift-version
         with:          
           path: C:\Thrift
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-thrift-0.13
+          key: ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-thrift-0.13
+            ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}-
             
       - if: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
         name: Install Thrift

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -112,9 +112,9 @@ jobs:
           cache-name: cache-boost-version
         with:          
           path: C:\Boost
-          key: ${{ runner.os }}-${{ matrix.arch.address_model }}-build-${{ matrix.vc_boost.boost_archive_name }}-${{ matrix.build_type }}
+          key: ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch.address_model }}-build-${{ matrix.vc_boost.boost_archive_name }}-${{ matrix.build_type }}
+            ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type }}
             
       - if: ${{ steps.cache-boost.outputs.cache-hit != 'true' }}
         name: Install Boost
@@ -138,9 +138,9 @@ jobs:
           cache-name: cache-thrift-version
         with:          
           path: C:\Thrift
-          key: ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}
+          key: ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch.address_model }}-build-thrift-0.13-${{ matrix.build_type }}
+            ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type }}
             
       - if: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
         name: Install Thrift

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -105,7 +105,19 @@ jobs:
                 "https://curl.se/ca/cacert.pem" `
                 -OutFile "C:\cacert.pem"
 
-      - name: Install Boost
+      - name: Cache Boost Version
+        id: cache-boost
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-boost-version
+        with:          
+          path: ${{ matrix.vc_boost.boost_include_folder }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-${{ matrix.vc_boost.boost_archive_name }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-${{ matrix.vc_boost.boost_archive_name }}
+            
+      - if: ${{ steps.cache-boost.outputs.cache-hit != 'true' }}
+        name: Install Boost
         run: |
           Invoke-WebRequest `
               "${{ matrix.vc_boost.boost_url }}" `
@@ -119,7 +131,19 @@ jobs:
           cd ..
           Remove-Item ${{ matrix.vc_boost.boost_folder_name }} -Recurse -Force
 
-      - name: Install Thrift
+      - name: Cache Thrift Version
+        id: cache-thrift
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-thrift-version
+        with:          
+          path: C:\Thrift
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-thrift-0.13
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch.address_model }}-thrift-0.13
+            
+      - if: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
+        name: Install Thrift
         run: |
           Invoke-WebRequest `
               "https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz" `


### PR DESCRIPTION
For windows github actions, boost and thrift directories are cached. They are used from cache after first run. We had 5-6 minutes advantage after doing this.