### PR TITLE
sql_test comptibility test failure fix.

### DIFF
--- a/hazelcast/test/src/remote_controller_client.cpp
+++ b/hazelcast/test/src/remote_controller_client.cpp
@@ -79,7 +79,12 @@ cluster_version()
 
     version.major = std::stoi(major_minor_patch.at(0));
     version.minor = std::stoi(major_minor_patch.at(1));
-    version.patch = std::stoi(major_minor_patch.at(2));
+
+    if (major_minor_patch.size() > 2) {
+      version.patch = std::stoi(major_minor_patch.at(2));
+    } else {
+      version.patch = 0;
+    }
 
     return version;
 }

--- a/hazelcast/test/src/sql_test.cpp
+++ b/hazelcast/test/src/sql_test.cpp
@@ -1551,6 +1551,10 @@ TEST_F(SqlTest, find_with_page_sync_iterator)
 
 TEST_F(SqlTest, timeout_for_page_iterator_sync)
 {
+    // `TABLE` clause is not supported before 5.0.0
+    if (cluster_version() < member::version{ 5, 0, 0 })
+        GTEST_SKIP();
+
     // `generate_stream(1)` generates a row per seconds, so it will guaranteed
     // that it will timeout
     auto result =


### PR DESCRIPTION
- `TABLE` keyword is not supported before `5.0.0`