### PR TITLE
Disable Boost bind pragma deprecated message until Boost version updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ target_link_libraries(
 target_compile_definitions(
         ${PROJECT_NAME}
         PUBLIC BOOST_THREAD_VERSION=5
+        BOOST_BIND_GLOBAL_PLACEHOLDERS
 )
 
 # If building WITH_OPENSSL, add OpenSSL::SSL and OpenSSL::Crypto as dependencies


### PR DESCRIPTION
PR closed by Hazelcast automation as no activity (>3 months). Please reopen with comments, if necessary. Thank you for using Hazelcast and your valuable contributions