### PR TITLE
[Windows] The choco package manager no more supports 32-bit OpenSSL version

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -343,7 +343,7 @@ jobs:
       matrix:
         arch:
           - cmake: Win32
-            choco_options: '--x86'
+            choco_options: '--forceX86 --x86 --version 1.1.1.2100 -y'
             address_model: 32
           - cmake: x64
             choco_options: ''

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -48,7 +48,7 @@ jobs:
             boost_include_folder: 'C:\Boost\include\boost-1_80'
         arch:
           - cmake: Win32
-            choco_options: '--x86'
+            choco_options: '--forceX86 --x86 --version 1.1.1.2100 -y'
             address_model: 32
           - cmake: x64
             choco_options: ''


### PR DESCRIPTION
The choco package manager no more supports 32-bit OpenSSL version. Hence, we have to use OpenSSL 1.1.1.2100 version and force 32-bit usage.