### PR TITLE
Fix build with Boost 1.86.0.

### DIFF
--- a/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
@@ -182,11 +182,11 @@ public:
     {
         check_available(util::Bits::UUID_SIZE_IN_BYTES);
         boost::uuids::uuid u;
-        std::memcpy(&u.data, &buffer_[pos_], util::Bits::UUID_SIZE_IN_BYTES);
+        std::memcpy(&u.data[0], &buffer_[pos_], util::Bits::UUID_SIZE_IN_BYTES);
         pos_ += util::Bits::UUID_SIZE_IN_BYTES;
         if (byte_order_ == boost::endian::order::little) {
             boost::endian::endian_reverse_inplace<int64_t>(
-              *reinterpret_cast<int64_t*>(u.data));
+              *reinterpret_cast<int64_t*>(&u.data[0]));
             boost::endian::endian_reverse_inplace<int64_t>(
               *reinterpret_cast<int64_t*>(
                 &u.data[util::Bits::LONG_SIZE_IN_BYTES]));

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -210,22 +210,7 @@ private:
       const std::string& name,
       int partition = UNASSIGNED_PARTITION,
       const std::shared_ptr<connection::Connection>& conn = nullptr,
-      boost::uuids::uuid uuid = { 0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0 });
+      boost::uuids::uuid uuid = {});
 
     void invoke_on_selection();
 

--- a/hazelcast/src/hazelcast/client/protocol.cpp
+++ b/hazelcast/src/hazelcast/client/protocol.cpp
@@ -376,7 +376,7 @@ operator<<(std::ostream& os, const ClientMessage& msg)
 void
 ClientMessage::set(unsigned char* /* memory */, boost::uuids::uuid uuid)
 {
-    std::memcpy(wr_ptr(uuid.size()), uuid.data, uuid.size());
+    std::memcpy(wr_ptr(uuid.size()), &uuid.data[0], uuid.size());
 }
 
 void

--- a/hazelcast/src/hazelcast/client/serialization.cpp
+++ b/hazelcast/src/hazelcast/client/serialization.cpp
@@ -731,12 +731,12 @@ data_output::write(boost::uuids::uuid v)
     }
     if (byte_order_ == boost::endian::order::little) {
         boost::endian::endian_reverse_inplace<int64_t>(
-          *reinterpret_cast<int64_t*>(v.data));
+          *reinterpret_cast<int64_t*>(&v.data[0]));
         boost::endian::endian_reverse_inplace<int64_t>(
           *reinterpret_cast<int64_t*>(&v.data[util::Bits::LONG_SIZE_IN_BYTES]));
     }
     output_stream_.insert(
-      output_stream_.end(), v.data, v.data + util::Bits::UUID_SIZE_IN_BYTES);
+      output_stream_.end(), &v.data[0], &v.data[util::Bits::LONG_SIZE_IN_BYTES]);
 }
 
 template<>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-cpp-client/issues/1245

`boost::uuid::uuid` is no longer trivial, and `data` is no longer an array, but a type providing overloaded operators that attempt to "look like" an array.

These changes should be safe on previous boost versions.