### PR TITLE
Fix `boost` installation script

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,8 +1,6 @@
 name: Code coverage report to Codecov
 
 on:
-  # TODO REMOVE
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -1,6 +1,8 @@
 name: Code coverage report to Codecov
 
 on:
+  # TODO REMOVE
+  pull_request:
   push:
     branches:
       - master

--- a/scripts/install-boost.sh
+++ b/scripts/install-boost.sh
@@ -3,18 +3,17 @@
 # Installs Boost from source
 # usage: ./install-boost.sh <version>
 
-set -e
+set -o errexit ${RUNNER_DEBUG:+-x}
 
-if [ "$#" -ne 1 ]; then
+if [[ "$#" -ne 1 ]]; then
     echo "usage: $0 <version>"
     exit 1
 fi
 
 TARBALL_NAME=boost_$(echo "$1" | tr . _)
 
-curl --silent -Lo $TARBALL_NAME.tar.gz https://boostorg.jfrog.io/artifactory/main/release/$1/source/$TARBALL_NAME.tar.gz
-tar xzf $TARBALL_NAME.tar.gz
-cd $TARBALL_NAME
+curl --silent --location "https://archives.boost.io/release/${1}/source/${TARBALL_NAME}.tar.gz" | tar xzf -
+pushd "${TARBALL_NAME}"
 ./bootstrap.sh
 ./b2 --with-thread --with-chrono install
-cd ..
+popd


### PR DESCRIPTION
The [coverage action is failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13248710933/job/36981292995) because the `boost` installation mirror [is dead](https://landing.jfrog.com/reactivate-server/boostorg).

Changes:
- update installation link to use `boost` archive
- refactored script
   - use long-form command names
   - fix shellcheck warnings
   - avoid writing temporary download files to disk

Example action [showing `boost` installation success](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13249150779/job/36982695856).