### PR TITLE
Update PR builder `hazelcast` membership message

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Report
         shell: bash
-        run: echo "User ${{ github.event.pull_request.head.repo.owner.login }} is a member of the Hazelcast organization"          
+        run: echo "User ${{ github.actor }} is a member of the Hazelcast organization"          
 
 
   # get


### PR DESCRIPTION
The job checks against `github.actor` but logs against `github.event.pull_request.head.repo.owner.login` which aren't the same (e.g. in a non-fork PR) which would really confuse debugging.

We should log what we query.

Added in https://github.com/hazelcast/hazelcast-cpp-client/pull/1173