### PR TITLE
Fix GitHub Actions `certs.jar` download failure

### DIFF
--- a/.github/actions/build-test/unix/action.yml
+++ b/.github/actions/build-test/unix/action.yml
@@ -36,8 +36,9 @@ runs:
   steps:
     - name: Download hazelcast-enterprise-tests.jar
       shell: ${{ env.shell }}
-      run: |
-        curl -H "Authorization: token ${{ inputs.GH_TOKEN }}" https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar > hazelcast-enterprise-${{ env.HAZELCAST_VERSION }}-tests.jar
+        gh api "/repos/hazelcast/private-test-artifacts/contents/certs.jar?ref=data" -H "Accept: application/vnd.github.raw" > hazelcast-enterprise-${{ env.HAZELCAST_VERSION }}-tests.jar
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
 
     - name: Build & Install
       env:

--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -56,12 +56,9 @@ runs:
 
     - name: Download hazelcast-enterprise-tests.jar
       shell: ${{ env.shell }}
-      run: |
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Invoke-WebRequest `
-              https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar `
-              -Headers @{"Authorization"="token ${{ inputs.GH_TOKEN }}"} `
-              -OutFile hazelcast-enterprise-${{ env.HAZELCAST_VERSION }}-tests.jar
+        gh api "/repos/hazelcast/private-test-artifacts/contents/certs.jar?ref=data" -H "Accept: application/vnd.github.raw" > hazelcast-enterprise-${{ env.HAZELCAST_VERSION }}-tests.jar
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
 
     - name: Install SysInternals
       shell: ${{ env.shell }}

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -39,7 +39,9 @@ runs:
     - name: Download hazelcast-enterprise-tests.jar
       shell: ${{ env.shell }}
       run: |
-        curl -H "Authorization: token ${{ inputs.GH_TOKEN }}" https://raw.githubusercontent.com/hazelcast/private-test-artifacts/data/certs.jar > hazelcast-enterprise-${{ env.HAZELCAST_VERSION }}-tests.jar
+        gh api "/repos/hazelcast/private-test-artifacts/contents/certs.jar?ref=data" -H "Accept: application/vnd.github.raw" > hazelcast-enterprise-${{ env.HAZELCAST_VERSION }}-tests.jar
+      env:
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
 
     - name: Install Boost
       shell: ${{ env.shell }}


### PR DESCRIPTION
[Actions are failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13401995252) due to an inability to download `certs.jar`.

Nothing has changed on the source side, but we are accessing it via `raw.githubusercontent.com`. I can only assume that there's been some update to the format of these URLs.

Instead, we can download the file using the GitHub API (via `gh`) which should:
- be more stable long term
- actually work