### PR TITLE
Revert "Bump actions/checkout from 1 to 4"

### DIFF
--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -46,7 +46,8 @@ jobs:
       (${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{matrix.boost.version}},${{ matrix.with_openssl.name }})
 
     steps:
-      - uses: actions/checkout@v4
+        # Deliberately uses an old version because i386 is stuck on an outdated version of Javascript
+      - uses: actions/checkout@v1
 
       - uses: ./.github/actions/build-test/ubuntu-x86_64
         with:


### PR DESCRIPTION
_Partially_ reverts hazelcast/hazelcast-cpp-client#1239

Fixes [build failure](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13434825542/job/37534653949).