### PR TITLE
Fix failing `nightly-windows.yml`

### DIFF
--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -100,7 +100,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ matrix.boost.version }}
           THRIFT_VERSION: 0.13.0
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           ARCH_CHOCO_OPTIONS: ${{ matrix.arch.choco_options }}


### PR DESCRIPTION
This action has been [failing for a while](https://github.com/hazelcast/hazelcast-cpp-client/actions/workflows/nightly-windows.yml?query=is%3Afailure), see the [most recent failure](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13434821788).

The most recent error seems to have been introduced in https://github.com/hazelcast/hazelcast-cpp-client/pull/1243 where a copy-paste error referenced the nested `build_type.type` element of the matrix which does not exist for the Windows jobs due to a difference in configuration.

Testing blocked by https://github.com/hazelcast/hazelcast-cpp-client/pull/1262.