### PR TITLE
Fix Ubuntu i386 nightly tests

### DIFF
--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -48,9 +48,6 @@ runs:
         apt-get update
         apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-${{ env.JAVA_VERSION }}-jre-headless gdb curl
 
-      # v1.0.2 - https://github.com/actions4gh/setup-gh/releases/tag/v1.0.2
-    - uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de
-
     - name: Make sure the target architecture is 32 bit
       shell: ${{ env.shell }}
       run: |
@@ -77,6 +74,20 @@ runs:
           --strip-components=1 \
           --directory ${install_dir}
         echo "${install_dir}/bin" >> $GITHUB_PATH
+
+    - name: Install `gh` CLI
+      shell: ${{ env.shell }}
+      run: |
+        # https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
+        (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+          && mkdir -p -m 755 /etc/apt/keyrings \
+                && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+                && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+          && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && apt update \
+          && apt install gh -y
+
 
     - name: Install Boost
       shell: ${{ env.shell }}

--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -88,7 +88,6 @@ runs:
           && apt update \
           && apt install gh -y
 
-
     - name: Install Boost
       shell: ${{ env.shell }}
       run: |

--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -48,6 +48,9 @@ runs:
         apt-get update
         apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-${{ env.JAVA_VERSION }}-jre-headless gdb curl
 
+      # v1.0.2 - https://github.com/actions4gh/setup-gh/releases/tag/v1.0.2
+    - uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de
+
     - name: Make sure the target architecture is 32 bit
       shell: ${{ env.shell }}
       run: |

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -49,7 +49,7 @@ jobs:
         # Deliberately uses an old version because i386 is stuck on an outdated version of Javascript
       - uses: actions/checkout@v1
 
-      - uses: ./.github/actions/build-test/ubuntu-x86_64
+      - uses: ./.github/actions/build-test/ubuntu-i386
         with:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ matrix.boost.version }}

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -46,7 +46,8 @@ jobs:
       (${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{matrix.boost.version}},${{ matrix.with_openssl.name }})
 
     steps:
-      - uses: actions/checkout@v4
+        # Deliberately uses an old version because i386 is stuck on an outdated version of Javascript
+      - uses: actions/checkout@v1
 
       - uses: ./.github/actions/build-test/ubuntu-x86_64
         with:


### PR DESCRIPTION
The action [has been failing for a while](https://github.com/hazelcast/hazelcast-cpp-client/actions/workflows/nightly-ubuntu-i386.yml) and I have identified a couple of issues:

- https://github.com/hazelcast/hazelcast-cpp-client/pull/1239 introduced an implicit dependency on Node 20 - incompatible with Ubuntu i386
- https://github.com/hazelcast/hazelcast-cpp-client/pull/1260 introduced a dependency on `gh` which is pre-installed on GitHub Actions runner images... but the `ubuntu-i386` variant doesn't _use_ the runner image and instead runs on a vanilla Docker image and as such we must explicitly install `gh` as a prerequisite.
- https://github.com/hazelcast/hazelcast-cpp-client/pull/1243 erroneously updated the i386 nightly build to use the **x64** variant

Tested [here](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13507682122) ✅.

