### PR TITLE
Fix test coverage

### DIFF
--- a/scripts/build-unix.sh
+++ b/scripts/build-unix.sh
@@ -19,7 +19,7 @@ set -e
 
 # add compiler flags necessary for test coverage
 if [ "$COVERAGE" = "ON" ]; then
-  CXXFLAGS="$CXXFLAGS -fprofile-arcs -ftest-coverage -fPIC -O0"
+  CXXFLAGS="$CXXFLAGS -fprofile-arcs -fprofile-update=atomic -ftest-coverage -fPIC -O0"
 fi
 
 # set -m32 or -m64 if a BIT_VERSION is given


### PR DESCRIPTION
[Test coverage action is failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/workflows/coverage-report.yaml) due to:
```
geninfo: ERROR: Unexpected negative count '-1' for /home/runner/work/hazelcast-cpp-client/hazelcast-cpp-client/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp:145.
Perhaps you need to compile with '-fprofile-update=atomic
(use "geninfo --ignore-errors negative ..." to bypass this error)
```

Added suggested compilation flag.

✅ Tested [here](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/13517945070/job/37770555102).