### PR TITLE
HZC-7235: change-cloud-url

### DIFF
--- a/hazelcast/include/hazelcast/client/client_properties.h
+++ b/hazelcast/include/hazelcast/client/client_properties.h
@@ -264,7 +264,7 @@ public:
      */
     static constexpr const char* CLOUD_URL_BASE = "hazelcast.client.cloud.url";
     static constexpr const char* CLOUD_URL_BASE_DEFAULT =
-      "api.viridian.hazelcast.com";
+      "api.cloud.hazelcast.com";
 
     /**
      * Parametrized SQL queries touching only a single partition benefit from


### PR DESCRIPTION
chore: update cloud url to api.cloud.hazelcast.com to part of deprecation of using viridian