### PR TITLE
Update `vcpkg` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please see [getting started](https://github.com/microsoft/vcpkg#getting-started)
 If you use Linux or Mac:
 
 ```sh
-git clone https://github.com/microsoft/vcpkg
+git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
 ./vcpkg/bootstrap-vcpkg.sh
 ./vcpkg/vcpkg install "hazelcast-cpp-client[openssl]" --recurse
 ``` 
@@ -83,7 +83,7 @@ git clone https://github.com/microsoft/vcpkg
 If you use Windows:
 
 ```bat
-git clone https://github.com/microsoft/vcpkg
+git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
 .\vcpkg\bootstrap-vcpkg.bat
 .\vcpkg\vcpkg install "hazelcast-cpp-client[openssl]:x64-windows" --recurse
 ``` 

--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -192,7 +192,7 @@ Please see [getting started](https://github.com/microsoft/vcpkg#getting-started)
 If you use Linux or Mac:
 
 ```sh
-git clone https://github.com/microsoft/vcpkg
+git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
 ./vcpkg/bootstrap-vcpkg.sh
 ./vcpkg/vcpkg install "hazelcast-cpp-client[openssl]" --recurse
 ``` 
@@ -200,7 +200,7 @@ git clone https://github.com/microsoft/vcpkg
 If you use Windows:
 
 ```bat
-git clone https://github.com/microsoft/vcpkg
+git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
 .\vcpkg\bootstrap-vcpkg.bat
 .\vcpkg\vcpkg install "hazelcast-cpp-client[openssl]:x64-windows" --recurse
 ``` 


### PR DESCRIPTION
[A community user raised that the `vcpkg` instructions no longer work](https://hazelcastcommunity.slack.com/archives/C015Q2TUBKL/p1743010446548399).

Specifically, `vcpkg` delisted Hazelcast when upgrading to Boost `1.87` - https://github.com/microsoft/vcpkg/pull/42678.

As such an version of `vcpkg` must be used that _does_ contain Hazelcast.

Tested locally on a fresh environment via Docker:
```
docker run --interactive --tty --rm --platform linux/amd64 ubuntu:latest bash -c "apt-get -y update && apt-get install -y curl git build-essential zip unzip tar pkg-config && git clone https://github.com/microsoft/vcpkg --branch 2025.02.14 && ./vcpkg/bootstrap-vcpkg.sh && ./vcpkg/vcpkg install hazelcast-cpp-client[openssl] --recurse"
```
> Successfully downloaded hazelcast-hazelcast-cpp-client-v5.3.0.tar.gz

This is a _workaround_ until the client can be relisted.