### PR TITLE
Add `AddressSanitizer` to `DEBUG` builds

### DIFF
--- a/.github/actions/build-test/macos-x86_64/action.yml
+++ b/.github/actions/build-test/macos-x86_64/action.yml
@@ -9,6 +9,8 @@ inputs:
     required: true
   BUILD_TYPE:
     required: true
+  CXX_FLAGS:
+    required: true
   SHARED_LIBS_TOGGLE:
     required: true
   OPENSSL_TOGGLE:
@@ -55,6 +57,7 @@ runs:
         THRIFT_VERSION: ${{ inputs.THRIFT_VERSION }}
         WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
+        CXX_FLAGS: ${{ inputs.CXX_FLAGS }}
         SHARED_LIBS_TOGGLE: ${{ inputs.SHARED_LIBS_TOGGLE }}
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}
         RUN_TESTS: ${{ inputs.RUN_TESTS }}

--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   BUILD_TYPE:
     required: true
+  CXX_FLAGS:
+    required: true
   SHARED_LIBS_TOGGLE:
     required: true
   OPENSSL_TOGGLE:
@@ -114,6 +116,7 @@ runs:
         THRIFT_VERSION: ${{ inputs.THRIFT_VERSION }}
         WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
+        CXX_FLAGS: ${{ inputs.CXX_FLAGS }}
         SHARED_LIBS_TOGGLE: ${{ inputs.SHARED_LIBS_TOGGLE }}
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}
         RUN_TESTS: ${{ inputs.RUN_TESTS }}

--- a/.github/actions/build-test/ubuntu-x86_64/action.yml
+++ b/.github/actions/build-test/ubuntu-x86_64/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   BUILD_TYPE:
     required: true
+  CXX_FLAGS:
+    required: true
   SHARED_LIBS_TOGGLE:
     required: true
   OPENSSL_TOGGLE:
@@ -76,6 +78,7 @@ runs:
         THRIFT_VERSION: ${{ inputs.THRIFT_VERSION }}
         WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
+        CXX_FLAGS: ${{ inputs.CXX_FLAGS }}
         SHARED_LIBS_TOGGLE: ${{ inputs.SHARED_LIBS_TOGGLE }}
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}
         RUN_TESTS: ${{ inputs.RUN_TESTS }}

--- a/.github/actions/build-test/unix/action.yml
+++ b/.github/actions/build-test/unix/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   BUILD_TYPE:
     required: true
+  CXX_FLAGS:
+    required: true
   SHARED_LIBS_TOGGLE:
     required: true
   OPENSSL_TOGGLE:
@@ -45,6 +47,7 @@ runs:
       env:
         BUILD_DIR: build
         INSTALL: ON
+        CXXFLAGS: '${{ inputs.CXX_FLAGS}}'
         WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
       shell: ${{ env.shell }}
       run: |

--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -9,6 +9,8 @@ inputs:
     required: true
   BUILD_TYPE:
     required: true
+  CXX_FLAGS:
+    required: true
   SHARED_LIBS_TOGGLE:
     required: true
   OPENSSL_TOGGLE:
@@ -132,7 +134,7 @@ runs:
         BUILD_CONFIGURATION: ${{ inputs.BUILD_TYPE }}
         BIT_VERSION: ${{ inputs.ARCH_ADDRESS_MODEL }}
         INSTALL: ON
-        CXXFLAGS: '/I C:\Thrift\include\'
+        CXXFLAGS: '/I C:\Thrift\include\ ${{ inputs.CXX_FLAGS}}'
       shell: ${{ env.shell }}
       run: |
         .\scripts\build-windows.bat `

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -123,8 +123,10 @@ jobs:
         build_type:
           - type: Debug
             warn_as_err: ON
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
           - type: Release
             warn_as_err: OFF
+            cxx_flags: ''
             
         shared_libs:
           - toggle: OFF
@@ -160,6 +162,7 @@ jobs:
           THRIFT_VERSION: ${{ env.thrift_version }}
           WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
           BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.run_tests }}
@@ -178,8 +181,10 @@ jobs:
         build_type:
           - type: Debug
             warn_as_err: ON
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
           - type: Release
             warn_as_err: OFF
+            cxx_flags: ''
 
         shared_libs:
           - toggle: OFF
@@ -210,6 +215,7 @@ jobs:
           THRIFT_VERSION: ${{ env.thrift_version }}
           WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
           BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.run_tests }}
@@ -231,8 +237,10 @@ jobs:
             choco_options: ''
             address_model: 64
         build_type:
-          - Debug
-          - Release
+          - type: Debug
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
+          - type: Release
+            cxx_flags: ''
         shared_libs:
           - toggle: OFF
             name: Static
@@ -246,7 +254,7 @@ jobs:
 
     runs-on: 'windows-latest'
     env:
-      JOB_NAME: win_${{ matrix.arch.address_model }}_${{ matrix.build_type.short }}_${{ matrix.shared_libs.name }}_${{ matrix.with_openssl.name }}
+      JOB_NAME: win_${{ matrix.arch.address_model }}_${{ matrix.build_type.type }}_${{ matrix.shared_libs.name }}_${{ matrix.with_openssl.name }}
     name: win-${{ matrix.arch.address_model }}_${{ matrix.shared_libs.name }}_${{ matrix.with_openssl.name }}
     steps:
       - uses: actions/checkout@v4
@@ -259,7 +267,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ env.boost_version }}
           THRIFT_VERSION: ${{ env.thrift_version }}
-          BUILD_TYPE: ${{ matrix.build_type }}
+          BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           ARCH_CHOCO_OPTIONS: ${{ matrix.arch.choco_options }}
@@ -285,8 +294,10 @@ jobs:
         build_type:
           - type: Debug
             warn_as_err: ON
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
           - type: Release
             warn_as_err: OFF
+            cxx_flags: ''
 
         shared_libs:
           - toggle: OFF
@@ -318,6 +329,7 @@ jobs:
           BOOST_VERSION: ${{ env.boost_version }}
           WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
           BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.run_tests }}

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -22,8 +22,10 @@ jobs:
         build_type:
           - type: Debug
             warn_as_err: ON
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
           - type: Release
             warn_as_err: OFF
+            cxx_flags: ''
 
         shared_libs:
           - toggle: OFF
@@ -55,6 +57,7 @@ jobs:
           BOOST_VERSION: ${{ matrix.boost.version }}
           WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
           BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.run_tests || github.event_name == 'schedule' }}

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -21,8 +21,10 @@ jobs:
         build_type:
           - type: Debug
             warn_as_err: ON
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
           - type: Release
             warn_as_err: OFF
+            cxx_flags: ''
 
         shared_libs:
           - toggle: OFF
@@ -56,6 +58,7 @@ jobs:
           THRIFT_VERSION: 0.13.0
           WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
           BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.run_tests || github.event_name == 'schedule' }}

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -22,8 +22,10 @@ jobs:
         build_type:
           - type: Debug
             warn_as_err: ON
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
           - type: Release
             warn_as_err: OFF
+            cxx_flags: ''
 
         shared_libs:
           - toggle: OFF
@@ -53,6 +55,7 @@ jobs:
           THRIFT_VERSION: 0.13.0
           WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
           BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.run_tests || github.event_name == 'schedule' }}

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -54,8 +54,10 @@ jobs:
             choco_options: ''
             address_model: 64
         build_type:
-          - Debug
-          - Release
+          - type: Debug
+            cxx_flags: '-fsanitize=address -fno-omit-frame-pointer'
+          - type: Release
+            cxx_flags: ''
         shared_libs:
           - toggle: OFF
             name: Static
@@ -69,10 +71,10 @@ jobs:
 
     runs-on: ${{ matrix.vc_boost.image }}
     env:
-      JOB_NAME: Windows_(${{ matrix.vc_boost.name }},${{ matrix.arch.address_model }},${{ matrix.build_type }},${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
+      JOB_NAME: Windows_(${{ matrix.vc_boost.name }},${{ matrix.arch.address_model }},${{ matrix.build_type.type }},${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     name: >-
       Windows
-      (${{ matrix.vc_boost.name }}, ${{ matrix.arch.address_model }}, ${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
+      (${{ matrix.vc_boost.name }}, ${{ matrix.arch.address_model }}, ${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
 
     steps:
       - uses: actions/checkout@v4
@@ -82,25 +84,26 @@ jobs:
         uses: actions/cache@v4
         with:          
           path: C:\Boost
-          key: ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type }}
+          key: ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type.type }}
           restore-keys: |
-            ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type }}
+            ${{ matrix.vc_boost.name }}-${{ matrix.arch.address_model }}-${{ matrix.build_type.type }}
 
       - name: Cache Thrift Version
         id: cache-thrift
         uses: actions/cache@v4
         with:          
           path: C:\Thrift
-          key: ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type }}
+          key: ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type.type }}
           restore-keys: |
-            ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type }}
+            ${{ matrix.vc_boost.image }}-${{ matrix.arch.address_model }}-thrift-0.13-${{ matrix.build_type.type }}
 
       - uses: ./.github/actions/build-test/windows
         with:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ matrix.boost.version }}
           THRIFT_VERSION: 0.13.0
-          BUILD_TYPE: ${{ matrix.build_type }}
+          BUILD_TYPE: ${{ matrix.build_type.type }}
+          CXX_FLAGS: ${{ matrix.build_type.cxx_flags }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           ARCH_CHOCO_OPTIONS: ${{ matrix.arch.choco_options }}


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-cpp-client/pull/1276 addressed a `Segementation fault`, but from the error alone, the root cause was not obvious:
```
31168 Segmentation fault: 11  build/cpp_client
```

By adding [`asan`](https://learn.microsoft.com/en-us/cpp/sanitizers/asan) to the `DEBUG` builds, the CI job would've failed with a much more helpful error message:
```
=================================================================
==37978==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000040 (pc 0x7eff21446d48 bp 0x7efeff67fce0 sp 0x7efeff67fcd0 T22)
==37978==The signal is caused by a READ memory access.
==37978==Hint: address points to the zero page.

    #0 0x7eff21446d48 in hazelcast::logger::enabled(hazelcast::logger::level) /home/runner/work/hazelcast-cpp-client/hazelcast-cpp-client/hazelcast/src/hazelcast/logger.cpp:71
    #1 0x7eff20a05b1d in hazelcast::client::protocol::codec::client_addclusterviewlistener_handler::handle(hazelcast::client::protocol::ClientMessage&) /home/runner/work/hazelcast-cpp-client/hazelcast-cpp-client/hazelcast/generated-sources/src/hazelcast/client/protocol/codec/codecs.cpp:145

{...}

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/runner/work/hazelcast-cpp-client/hazelcast-cpp-client/hazelcast/src/hazelcast/logger.cpp:71 in hazelcast::logger::enabled(hazelcast::logger::level)
```

An _alternative_ implementation would've been to hardcode the flags in the `build-unix`/`build-windows` instead.