### PR TITLE
Simplify `Debug`/`Release` options

### DIFF
--- a/.github/actions/build-test/macos-x86_64/action.yml
+++ b/.github/actions/build-test/macos-x86_64/action.yml
@@ -5,8 +5,6 @@ inputs:
     required: true
   BOOST_VERSION:
     required: true
-  WARN_AS_ERR:
-    required: true
   BUILD_TYPE:
     required: true
   SHARED_LIBS_TOGGLE:
@@ -53,7 +51,6 @@ runs:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         BOOST_VERSION: ${{ inputs.BOOST_VERSION }}
         THRIFT_VERSION: ${{ inputs.THRIFT_VERSION }}
-        WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
         SHARED_LIBS_TOGGLE: ${{ inputs.SHARED_LIBS_TOGGLE }}
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}

--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -7,8 +7,6 @@ inputs:
     required: true
   THRIFT_VERSION:
     required: true
-  WARN_AS_ERR:
-    required: true
   BUILD_TYPE:
     required: true
   SHARED_LIBS_TOGGLE:
@@ -112,7 +110,6 @@ runs:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         BOOST_VERSION: ${{ inputs.BOOST_VERSION }}
         THRIFT_VERSION: ${{ inputs.THRIFT_VERSION }}
-        WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
         SHARED_LIBS_TOGGLE: ${{ inputs.SHARED_LIBS_TOGGLE }}
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}

--- a/.github/actions/build-test/ubuntu-x86_64/action.yml
+++ b/.github/actions/build-test/ubuntu-x86_64/action.yml
@@ -7,8 +7,6 @@ inputs:
     required: true
   THRIFT_VERSION:
     required: true
-  WARN_AS_ERR:
-    required: true
   BUILD_TYPE:
     required: true
   SHARED_LIBS_TOGGLE:
@@ -74,7 +72,6 @@ runs:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         BOOST_VERSION: ${{ inputs.BOOST_VERSION }}
         THRIFT_VERSION: ${{ inputs.THRIFT_VERSION }}
-        WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
         SHARED_LIBS_TOGGLE: ${{ inputs.SHARED_LIBS_TOGGLE }}
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}

--- a/.github/actions/build-test/unix/action.yml
+++ b/.github/actions/build-test/unix/action.yml
@@ -7,8 +7,6 @@ inputs:
     required: true
   THRIFT_VERSION:
     required: true
-  WARN_AS_ERR:
-    required: true
   BUILD_TYPE:
     required: true
   SHARED_LIBS_TOGGLE:
@@ -45,11 +43,10 @@ runs:
       env:
         BUILD_DIR: build
         INSTALL: ON
-        WARN_AS_ERR: ${{ inputs.WARN_AS_ERR }}
+        BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
       shell: ${{ env.shell }}
       run: |
         ./scripts/build-unix.sh                                          \
-            -DCMAKE_BUILD_TYPE=${{ inputs.BUILD_TYPE }}                  \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/destination   \
             -DBUILD_SHARED_LIBS=${{ inputs.SHARED_LIBS_TOGGLE }}         \
             -DWITH_OPENSSL=${{ inputs.OPENSSL_TOGGLE }}                  \

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -63,10 +63,10 @@ runs:
       env:
         BUILD_DIR: build
         COVERAGE: ON
+        BUILD_TYPE: Debug
       shell: ${{ env.shell }}
       run: |
         ./scripts/build-unix.sh        \
-            -DCMAKE_BUILD_TYPE=Debug   \
             -DBUILD_SHARED_LIBS=ON     \
             -DWITH_OPENSSL=ON          \
             -DBUILD_TESTS=ON           \

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -121,10 +121,8 @@ jobs:
       fail-fast: false
       matrix:
         build_type:
-          - type: Debug
-            warn_as_err: ON
-          - type: Release
-            warn_as_err: OFF
+          - Debug
+          - Release
             
         shared_libs:
           - toggle: OFF
@@ -143,7 +141,7 @@ jobs:
       image: i386/ubuntu
       options: --privileged
 
-    name: ubuntu-i386-(${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
+    name: ubuntu-i386-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
 
     steps:
         # Deliberately uses an old version because i386 is stuck on an outdated version of Javascript
@@ -158,8 +156,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ env.boost_version }}
           THRIFT_VERSION: ${{ env.thrift_version }}
-          WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.run_tests }}
@@ -176,10 +173,8 @@ jobs:
       matrix:
 
         build_type:
-          - type: Debug
-            warn_as_err: ON
-          - type: Release
-            warn_as_err: OFF
+          - Debug
+          - Release
 
         shared_libs:
           - toggle: OFF
@@ -195,7 +190,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    name: ubuntu-x64-(${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
+    name: ubuntu-x64-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     steps:
 
       - uses: actions/checkout@v4
@@ -208,8 +203,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ env.boost_version }}
           THRIFT_VERSION: ${{ env.thrift_version }}
-          WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.run_tests }}
@@ -283,10 +277,8 @@ jobs:
       fail-fast: false
       matrix:
         build_type:
-          - type: Debug
-            warn_as_err: ON
-          - type: Release
-            warn_as_err: OFF
+          - Debug
+          - Release
 
         shared_libs:
           - toggle: OFF
@@ -302,7 +294,7 @@ jobs:
 
     runs-on: macos-latest
 
-    name: macOS-(${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
+    name: macOS-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     env:
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl/
 
@@ -316,8 +308,7 @@ jobs:
         with:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ env.boost_version }}
-          WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.run_tests }}

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -20,10 +20,8 @@ jobs:
             - version: 1.76.0
 
         build_type:
-          - type: Debug
-            warn_as_err: ON
-          - type: Release
-            warn_as_err: OFF
+          - Debug
+          - Release
 
         shared_libs:
           - toggle: OFF
@@ -41,7 +39,7 @@ jobs:
 
     name: >-
       macOS-x86_64
-      (${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }}, ${{matrix.boost.version}})
+      (${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }}, ${{matrix.boost.version}})
 
     env:
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl/
@@ -53,8 +51,7 @@ jobs:
         with:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ matrix.boost.version }}
-          WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.run_tests || github.event_name == 'schedule' }}

--- a/.github/workflows/nightly-ubuntu-i386.yml
+++ b/.github/workflows/nightly-ubuntu-i386.yml
@@ -19,10 +19,8 @@ jobs:
           - version: 1.71.0
           - version: 1.76.0
         build_type:
-          - type: Debug
-            warn_as_err: ON
-          - type: Release
-            warn_as_err: OFF
+          - Debug
+          - Release
 
         shared_libs:
           - toggle: OFF
@@ -43,7 +41,7 @@ jobs:
 
     name: >-
       Ubuntu-i386
-      (${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{matrix.boost.version}},${{ matrix.with_openssl.name }})
+      (${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{matrix.boost.version}},${{ matrix.with_openssl.name }})
 
     steps:
         # Deliberately uses an old version because i386 is stuck on an outdated version of Javascript
@@ -54,8 +52,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ matrix.boost.version }}
           THRIFT_VERSION: 0.13.0
-          WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.run_tests || github.event_name == 'schedule' }}

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -20,10 +20,8 @@ jobs:
           - version: 1.76.0
 
         build_type:
-          - type: Debug
-            warn_as_err: ON
-          - type: Release
-            warn_as_err: OFF
+          - Debug
+          - Release
 
         shared_libs:
           - toggle: OFF
@@ -41,7 +39,7 @@ jobs:
 
     name: >-
       Ubuntu-x86_64
-      (${{ matrix.build_type.type }}, ${{ matrix.shared_libs.name }}, ${{matrix.boost.version}}, ${{ matrix.with_openssl.name }})
+      (${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{matrix.boost.version}}, ${{ matrix.with_openssl.name }})
 
     steps:
       - uses: actions/checkout@v4
@@ -51,8 +49,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BOOST_VERSION: ${{ matrix.boost.version }}
           THRIFT_VERSION: 0.13.0
-          WARN_AS_ERR: ${{ matrix.build_type.warn_as_err }}
-          BUILD_TYPE: ${{ matrix.build_type.type }}
+          BUILD_TYPE: ${{ matrix.build_type }}
           SHARED_LIBS_TOGGLE: ${{ matrix.shared_libs.toggle }}
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.run_tests || github.event_name == 'schedule' }}

--- a/scripts/build-unix.sh
+++ b/scripts/build-unix.sh
@@ -8,8 +8,8 @@
 # - BIT_VERSION : target platform architecture (32 or 64)
 # - COVERAGE : add compiler flags necessary for test coverage (set to ON)
 # - INSTALL : install after the build finishes (set to ON)
-# - WARN_AS_ERR : treat compiler warnings as errors (set to ON)
 # - CXXFLAGS : additional compiler flags
+# - BUILD_TYPE : config to use when building (Release, Debug, etc.)
 #
 # Command line arguments are forwarded to CMake.
 #
@@ -30,7 +30,8 @@ fi
 # enable all compiler warnings
 CXXFLAGS="$CXXFLAGS -Wall"
 
-if [ "$WARN_AS_ERR" = "ON" ]; then
+if [ "${BUILD_TYPE}" = "Debug" ]; then
+  # treat compiler warnings as errors when the build type is Debug
   CXXFLAGS="$CXXFLAGS -Werror"
 fi
 
@@ -46,6 +47,7 @@ echo "BIT_VERSION     = $BIT_VERSION"
 echo "COVERAGE        = $COVERAGE"
 echo "INSTALL         = $INSTALL"
 echo "CXXFLAGS        = $CXXFLAGS"
+echo "BUILD_TYPE      = $BUILD_TYPE"
 echo "CMake arguments = $@"
 
 # export flags variable to be used by CMake
@@ -57,7 +59,7 @@ mkdir $BUILD_DIR
 cd $BUILD_DIR
 
 echo "Configuring..."
-cmake $SOURCE_DIR "$@"
+cmake $SOURCE_DIR -DCMAKE_BUILD_TYPE=${BUILD_TYPE} "$@"
 
 echo "Building..."
 VERBOSE=1 cmake --build .

--- a/scripts/do-all-unix.sh
+++ b/scripts/do-all-unix.sh
@@ -17,11 +17,6 @@ set -e
 export BUILD_DIR=build
 export INSTALL=ON
 
-# treat compiler warnings as errors when the build type is Debug
-if [ "$BUILD_TYPE" == "Debug" ]; then
-  export WARN_AS_ERR=ON
-fi
-
 DESTINATION=$(pwd)/destination
 
 # set BUILD_SHARED_LIBS depending on LIBRARY_TYPE
@@ -31,7 +26,6 @@ if [ "$LIBRARY_TYPE" == "STATIC" ]; then
 fi
 
 ./scripts/build-unix.sh                      \
-    -DCMAKE_BUILD_TYPE=$BUILD_TYPE           \
     -DCMAKE_INSTALL_PREFIX=$DESTINATION      \
     -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS   \
     -DWITH_OPENSSL=$WITH_OPENSSL             \


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-cpp-client/pull/1279 made it obvious that adding configuration for `Debug` builds (e.g. "add an extra compilation argument") was very tedious as it needs to be declared in _each_ workflow and then passed all the way down to the actual scripts that build the code.

Instead, it'd be much cleaner if the jobs _only_ declare a release type, and the build scripts react to that with the appropriate actions (e.g. adding some extra debug or whatever).

Changes:
- migrate the _implementation_ of the `DEBUG` builds into the `build-` scripts
   - e.g. `WARN_AS_ERROR` can be assumed when `DEBUG` is enabled, rather than being duplicated in each job configuration
   - remove the architecture to pass these redundant params down
- pass `BUILD_TYPE` into the `build-` scripts as an environment variable, as already used for other parameters and for the Windows equivalent (`BUILD_CONFIGURATION`)

This PR is the refactor-half of https://github.com/hazelcast/hazelcast-cpp-client/pull/1279, split out separately to make that PR smaller.