### PR TITLE
[BACKPORT] Lookup bug fixed. (#1198) DEX-438

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/config/ConfigUtils.h
+++ b/hazelcast/include/hazelcast/client/internal/config/ConfigUtils.h
@@ -44,7 +44,7 @@ public:
         std::vector<std::string> keys(size);
         size_t index = 0;
         for (const auto& e : config_patterns) {
-            keys[index] = e.first;
+            keys[index++] = e.first;
         }
         std::shared_ptr<std::string> configPatternKey =
           config_pattern_matcher.matches(keys, item_name);

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2095,6 +2095,22 @@ TEST_F(IssueTest,TestIssue1005){
 
     c.shutdown().get();
 }
+
+TEST_F(IssueTest, TestIssue1196){
+    client_config conf;
+    hazelcast::client::config::near_cache_config n1;
+    hazelcast::client::config::near_cache_config n2;
+
+    n1.set_name("no-name");
+    n2.set_name("pat*");
+    n2.set_max_idle_seconds(11);
+
+    conf.add_near_cache_config(n1);
+    conf.add_near_cache_config(n2);
+
+    ASSERT_NE(conf.get_near_cache_config("pattern"), nullptr);
+    EXPECT_EQ(conf.get_near_cache_config("pattern")->get_max_idle_seconds(), 11);
+}
 } // namespace test
 } // namespace client
 } // namespace hazelcast


### PR DESCRIPTION
`git cherry-pick f0f253560a2f30578a3e0e5f5196a831900d7fcf`

The `ConfigUtils` lookup bug is fixed. 