### PR TITLE
Fix `nightly-windows` action

### DIFF
--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -50,7 +50,7 @@ jobs:
             boost_archive_name: 'boost_1_80_0.tar.gz'
             boost_folder_name: 'boost_1_80_0'
             boost_include_folder: 'C:\Boost\include\boost-1_80'
-        arch: ${{ fromJSON(needs.shared-matrix.outputs.windows-options) }}
+        options: ${{ fromJSON(needs.shared-matrix.outputs.windows-options) }}
         build_type: ${{ fromJSON(needs.shared-matrix.outputs.build-type) }}
         shared_libs: ${{ fromJSON(needs.shared-matrix.outputs.shared-libs) }}
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}


### PR DESCRIPTION
The changes in https://github.com/hazelcast/hazelcast-cpp-client/pull/1284 cause da [build failure](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/15600205707/job/43938577451).

Specifically, [this change](https://github.com/hazelcast/hazelcast-cpp-client/pull/1284#discussion_r2123460558) did not update the key for all matrix jobs.

[Example execution](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/15608983313).