### PR TITLE
Fix `codecov-action` [DI-520]

### DIFF
--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -28,4 +28,6 @@ jobs:
       - name: Publish on Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
+          fail_ci_if_error: true


### PR DESCRIPTION
The C++ coverage action has been [silently failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/15610247637/attempts/1).

Updated all usages to:
- supply a token to properly authenticate (the reason for the failure)
- fail the step if the upload fails (to avoid the error going unreported)
- use the latest version (consistency)

Fixes: [DI-520](https://hazelcast.atlassian.net/browse/DI-520)

Post-merge action:
- [ ] re-enable token requirement in [action settings](https://app.codecov.io/account/gh/hazelcast/org-upload-token).