### PR TITLE
Remove top-level `env` from GitHub composite actions

### DIFF
--- a/.github/actions/build-test/macos-x86_64/action.yml
+++ b/.github/actions/build-test/macos-x86_64/action.yml
@@ -22,20 +22,15 @@ inputs:
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: bash
-
 runs:
   using: composite
   steps:
     - name: Read Config
-      shell: ${{ env.shell }}
+      shell: bash
       run: cat .github/config.env >> $GITHUB_ENV
 
     - name: Install Dependencies
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo ./scripts/install-boost.sh ${{ inputs.BOOST_VERSION }}
         brew install openssl@1.1 thrift curl

--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -24,16 +24,11 @@ inputs:
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: bash
-
 runs:
   using: composite
   steps:
     - name: Read Config
-      shell: ${{ env.shell }}
+      shell: bash
       run: cat .github/config.env >> $GITHUB_ENV
 
     # Install Java via `apt`, can't use the `setup-java` action on this image
@@ -41,13 +36,13 @@ runs:
     # Newest available version for this image is Node 8, which is too old for any version to run against
     # https://github.com/actions/setup-node/issues/922
     - name: Install Necessary Packages
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         apt-get update
         apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-${{ env.JAVA_VERSION }}-jre-headless gdb curl
 
     - name: Make sure the target architecture is 32 bit
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         echo 'int main() { return sizeof(void*) != 4; }' > test.c
         gcc test.c -oa
@@ -56,7 +51,7 @@ runs:
 
     # `apt-get` brings in `3.6` which is too old to be compatible with Java 17
     - name: Install Maven
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         install_dir="/opt/maven"
         mkdir ${install_dir}
@@ -74,7 +69,7 @@ runs:
         echo "${install_dir}/bin" >> $GITHUB_PATH
 
     - name: Install `gh` CLI
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         # https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
         (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
@@ -87,18 +82,18 @@ runs:
           && apt install gh -y
 
     - name: Install Boost
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ./scripts/install-boost.sh ${{ inputs.BOOST_VERSION }}
 
     - name: Install Thrift
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ./scripts/install-thrift.sh ${{ inputs.THRIFT_VERSION }}
 
     - name: Configure Resources
       if: ${{ inputs.run_tests }}
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ulimit -c unlimited
 

--- a/.github/actions/build-test/ubuntu-x86_64/action.yml
+++ b/.github/actions/build-test/ubuntu-x86_64/action.yml
@@ -24,22 +24,17 @@ inputs:
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: bash
-
 runs:
   using: composite
   steps:
     - name: Install Necessary Packages
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y net-tools libssl-dev gdb curl
 
     - name: Read Config
-      shell: ${{ env.shell }}
+      shell: bash
       run: cat .github/config.env >> $GITHUB_ENV
 
     - name: Setup JDK
@@ -49,18 +44,18 @@ runs:
         distribution: ${{ env.JAVA_DISTRIBUTION }}
 
     - name: Install Boost
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo ./scripts/install-boost.sh ${{ inputs.BOOST_VERSION }}
 
     - name: Install Thrift
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo ./scripts/install-thrift.sh ${{ inputs.THRIFT_VERSION }}
 
     - name: Configure Resources
       if: ${{ inputs.run_tests }}
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ulimit -c unlimited
 

--- a/.github/actions/build-test/unix/action.yml
+++ b/.github/actions/build-test/unix/action.yml
@@ -24,16 +24,11 @@ inputs:
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: bash
-
 runs:
   using: composite
   steps:
     - name: Download hazelcast-enterprise-tests.jar
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         gh api "/repos/hazelcast/private-test-artifacts/contents/certs.jar?ref=data" -H "Accept: application/vnd.github.raw" > hazelcast-enterprise-${{ env.HZ_VERSION }}-tests.jar
       env:
@@ -44,7 +39,7 @@ runs:
         BUILD_DIR: build
         INSTALL: ON
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ./scripts/build-unix.sh                                          \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/destination   \
@@ -62,6 +57,6 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ./scripts/test-unix.sh

--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -42,11 +42,6 @@ inputs:
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: pwsh
-
 runs:
   using: composite
   steps:
@@ -55,14 +50,14 @@ runs:
       run: cat .github/config.env >> $GITHUB_ENV
 
     - name: Download hazelcast-enterprise-tests.jar
-      shell: ${{ env.shell }}
+      shell: pwsh
       run: |
         gh api "/repos/hazelcast/private-test-artifacts/contents/certs.jar?ref=data" -H "Accept: application/vnd.github.raw" > hazelcast-enterprise-${{ env.HZ_VERSION }}-tests.jar
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
 
     - name: Install SysInternals
-      shell: ${{ env.shell }}
+      shell: pwsh
       run: |
           Invoke-WebRequest `
               "https://download.sysinternals.com/files/SysinternalsSuite.zip" `
@@ -77,7 +72,7 @@ runs:
         timeout_minutes: 10
         max_attempts : 4
         retry_on: error
-        shell: ${{ env.shell }}
+        shell: pwsh
         command: |
           choco install openssl ${{ inputs.ARCH_CHOCO_OPTIONS }}
           Invoke-WebRequest `
@@ -86,7 +81,7 @@ runs:
 
     - if: ${{ inputs.INSTALL_BOOST != 'false' }}
       name: Install Boost
-      shell: ${{ env.shell }}
+      shell: pwsh
       run: |
         Invoke-WebRequest `
             "${{ inputs.BOOST_URL }}" `
@@ -102,7 +97,7 @@ runs:
 
     - if: ${{ inputs.INSTALL_THRIFT != 'false' }}
       name: Install Thrift
-      shell: ${{ env.shell }}
+      shell: pwsh
       run: |
         Invoke-WebRequest `
             "https://archive.apache.org/dist/thrift/${{ inputs.THRIFT_VERSION }}/thrift-${{ inputs.THRIFT_VERSION }}.tar.gz" `
@@ -133,7 +128,7 @@ runs:
         BIT_VERSION: ${{ inputs.ARCH_ADDRESS_MODEL }}
         INSTALL: ON
         CXXFLAGS: '/I C:\Thrift\include\'
-      shell: ${{ env.shell }}
+      shell: pwsh
       run: |
         .\scripts\build-windows.bat `
             -DCMAKE_PREFIX_PATH="C:\Boost;C:\Thrift" `
@@ -153,7 +148,7 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         SSL_CERT_FILE: 'C:\cacert.pem'
-      shell: ${{ env.shell }}
+      shell: pwsh
       run: |
         $dump = start-process -NoNewWindow sys-internals\procdump.exe {-accepteula -e -ma -w client_test.exe crash.dmp}
         .\scripts\test-windows.bat

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -18,39 +18,37 @@ inputs:
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
 
-env:
-  # Not possible to set this as a default
-  # https://github.com/orgs/community/discussions/46670
-  shell: bash
-  BUILD_TYPE: Debug
-
 runs:
   using: composite
   steps:
     - name: Read Config
-      shell: ${{ env.shell }}
+      shell: bash
       run: cat .github/config.env >> $GITHUB_ENV
 
+    - shell: bash
+      run: |
+        echo "BUILD_TYPE=Debug" >> ${GITHUB_ENV}
+
     - name: Install Necessary Packages
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y net-tools libssl-dev gdb gcovr lcov curl
 
     - name: Download hazelcast-enterprise-tests.jar
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         gh api "/repos/hazelcast/private-test-artifacts/contents/certs.jar?ref=data" -H "Accept: application/vnd.github.raw" > hazelcast-enterprise-${{ env.HZ_VERSION }}-tests.jar
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
 
     - name: Install Boost
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo ./scripts/install-boost.sh ${{ inputs.BOOST_VERSION }}
 
     - name: Install Thrift
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         sudo ./scripts/install-thrift.sh ${{ inputs.THRIFT_VERSION }}
 
@@ -65,7 +63,7 @@ runs:
         BUILD_DIR: build
         COVERAGE: ON
         BUILD_TYPE: ${{ env.BUILD_TYPE }}
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ./scripts/build-unix.sh        \
             -DBUILD_SHARED_LIBS=ON     \
@@ -82,7 +80,7 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         BUILD_TYPE: ${{ env.BUILD_TYPE }}
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         ulimit -c unlimited
         sudo sh -c "echo 'core' > /proc/sys/kernel/core_pattern"
@@ -90,7 +88,7 @@ runs:
         ./scripts/test-unix.sh
 
     - name: Collect coverage info
-      shell: ${{ env.shell }}
+      shell: bash
       run: |
         # collect and list coverage info
         lcov --capture --directory . --no-external -o coverage.info \


### PR DESCRIPTION
tl;dr - it doesn't work

In composite actions, a `shell` _must_ be specified. To avoid duplication, this was centralised to an `env` variable.

However, GitHub [doesn't support this](https://github.com/orgs/community/discussions/51280) - for example, in [this job](https://github.com/hazelcast/hazelcast-go-client/actions/runs/15848149662/job/44674983175) the output of `${{ env.shell }}` is blank.

It _appeared_ to work because if the specified `shell` is empty, it uses the default shell of the executing runner - and all of our executions were setting `bash` on Linux/Mac or `pwsh` on Windows anyway so the net effect is the same.

This bug appeared when a `bash` composite action failed to resolve `bash` commands on a Windows runner - because it was actually running in an (implicit) `pwsh` shell.