### PR TITLE
Improve `curl` failure messages

### DIFF
--- a/scripts/install-boost.sh
+++ b/scripts/install-boost.sh
@@ -12,7 +12,7 @@ fi
 
 TARBALL_NAME=boost_$(echo "$1" | tr . _)
 
-curl --silent --location "https://archives.boost.io/release/${1}/source/${TARBALL_NAME}.tar.gz" | tar xzf -
+curl --fail --silent --show-error --location "https://archives.boost.io/release/${1}/source/${TARBALL_NAME}.tar.gz" | tar xzf -
 pushd "${TARBALL_NAME}"
 ./bootstrap.sh
 ./b2 --with-thread --with-chrono install

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -3,18 +3,18 @@
 # Installs Apache Thrift from source
 # usage ./install-thrift.sh <version>
 
-set -e
+set -o errexit ${RUNNER_DEBUG:+-x}
 
-if [ "$#" -ne 1 ]; then
+if [[ "$#" -ne 1 ]]; then
     echo "usage: $0 <version>"
     exit 1
 fi
 
-curl --silent -Lo thrift-$1.tar.gz https://archive.apache.org/dist/thrift/$1/thrift-$1.tar.gz
-tar xzf thrift-$1.tar.gz
-cd thrift-$1/build
+curl --fail --silent --show-error --location https://archive.apache.org/dist/thrift/$1/thrift-$1.tar.gz  | tar xzf -
+pushd thrift-$1/build
 cmake .. -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON \
          -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF \
          -DBUILD_HASKELL=OFF -DWITH_OPENSSL=OFF -DWITH_LIBEVENT=OFF -DWITH_ZLIB=OFF \
          -DWITH_QT5=OFF
 cmake --build . --target install
+popd


### PR DESCRIPTION
[When the `install-thrift` script fails](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15922496200/job/44912990844), the error is unhelpful:
> Error: Process completed with exit code 28.

Copied the arguments we use elsewhere in the repo (specifically `--show-error`) to give more info.

Also refactored the `install-thrift` script with the changes already applied to `install-boost` in https://github.com/hazelcast/hazelcast-cpp-client/pull/1257