### PR TITLE
Update `apache.org` download links to use `closer.lua`

### DIFF
--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -100,7 +100,7 @@ runs:
       shell: pwsh
       run: |
         Invoke-WebRequest `
-            "https://archive.apache.org/dist/thrift/${{ inputs.THRIFT_VERSION }}/thrift-${{ inputs.THRIFT_VERSION }}.tar.gz" `
+            "https://www.apache.org/dyn/closer.lua/thrift/${{ inputs.THRIFT_VERSION }}/thrift-${{ inputs.THRIFT_VERSION }}.tar.gz?action=download" `
             -OutFile "thrift-${{ inputs.THRIFT_VERSION }}.tar.gz"
         tar xzf thrift-${{ inputs.THRIFT_VERSION }}.tar.gz
         rm thrift-${{ inputs.THRIFT_VERSION }}.tar.gz

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -10,7 +10,7 @@ if [[ "$#" -ne 1 ]]; then
     exit 1
 fi
 
-curl --fail --silent --show-error --location https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download  | tar xzf -
+curl --fail --silent --show-error --location "https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download" | tar xzf -
 pushd thrift-$1/build
 cmake .. -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON \
          -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF \

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -10,7 +10,7 @@ if [[ "$#" -ne 1 ]]; then
     exit 1
 fi
 
-curl --fail --silent --show-error --location https://archive.apache.org/dist/thrift/$1/thrift-$1.tar.gz  | tar xzf -
+curl --fail --silent --show-error --location https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download  | tar xzf -
 pushd thrift-$1/build
 cmake .. -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON \
          -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF \


### PR DESCRIPTION
[We have seen instability downloading from `archive.apache.org`](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15973338298/job/45050422979).

Update links to use `closer.lua` instead, as mentioned in [Apache's documentation](https://infra.apache.org/release-download-pages.html).