### PR TITLE
Fix `install-thrift` download errors on GitHub Runners

### DIFF
--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -99,8 +99,11 @@ runs:
       name: Install Thrift
       shell: pwsh
       run: |
+        # Ideally we would download directly from Apache:
+        # https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download
+        # But this has intermittent failures in GitHub Actions
         Invoke-WebRequest `
-            "https://www.apache.org/dyn/closer.lua/thrift/${{ inputs.THRIFT_VERSION }}/thrift-${{ inputs.THRIFT_VERSION }}.tar.gz?action=download" `
+            "http://deb.debian.org/debian/pool/main/t/thrift/thrift_${{ inputs.THRIFT_VERSION }}.orig.tar.gz" `
             -OutFile "thrift-${{ inputs.THRIFT_VERSION }}.tar.gz"
         tar xzf thrift-${{ inputs.THRIFT_VERSION }}.tar.gz
         rm thrift-${{ inputs.THRIFT_VERSION }}.tar.gz

--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -103,7 +103,7 @@ runs:
         # https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download
         # But this has intermittent failures in GitHub Actions
         Invoke-WebRequest `
-            "http://deb.debian.org/debian/pool/main/t/thrift/thrift_${{ inputs.THRIFT_VERSION }}.orig.tar.gz" `
+            "https://deb.debian.org/debian/pool/main/t/thrift/thrift_${{ inputs.THRIFT_VERSION }}.orig.tar.gz" `
             -OutFile "thrift-${{ inputs.THRIFT_VERSION }}.tar.gz"
         tar xzf thrift-${{ inputs.THRIFT_VERSION }}.tar.gz
         rm thrift-${{ inputs.THRIFT_VERSION }}.tar.gz

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -13,7 +13,7 @@ fi
 # Ideally we would download directly from Apache:
 # https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download
 # But this has intermittent failures in GitHub Actions
-curl --fail --silent --show-error --location "http://deb.debian.org/debian/pool/main/t/thrift/thrift_$1.orig.tar.gz" | tar xzf -
+curl --fail --silent --show-error --location "https://deb.debian.org/debian/pool/main/t/thrift/thrift_$1.orig.tar.gz" | tar xzf -
 pushd thrift-$1/build
 cmake .. -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON \
          -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF \

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -10,7 +10,10 @@ if [[ "$#" -ne 1 ]]; then
     exit 1
 fi
 
-curl --fail --silent --show-error --location "https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download" | tar xzf -
+# Ideally we would download directly from Apache:
+# https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download
+# But this has intermittent failures in GitHub Actions
+curl --fail --silent --show-error --location "http://deb.debian.org/debian/pool/main/t/thrift/thrift_$1.orig.tar.gz" | tar xzf -
 pushd thrift-$1/build
 cmake .. -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON \
          -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF \


### PR DESCRIPTION
Despite the changes in https://github.com/hazelcast/hazelcast-cpp-client/pull/1315, the downloads are [still failing](https://github.com/hazelcast/client-compatibility-suites/actions/runs/16020766406/job/45197809787) on GitHub Runners.

Specifically, the [mirror service doesn't _have_ a mirror of the specific version of `thrift` we want](https://www.apache.org/dyn/closer.cgi?path=/thrift/0.13.0/thrift-0.13.0.tar.gz):
> The requested file or directory is not on the mirrors.
The object is in our archive : https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz

And it just redirects to `archive.apache.org` - which is what it was using originally.

Updated to use an alternative mirror (Debian) and checked the checksums match (`38a27d391a2b03214b444cb13d5664f1`).