### PR TITLE
Fixed build problems with latest Boost library versions [DEX-431]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,6 @@ project(hazelcast-cpp-client
         DESCRIPTION "Hazelcast C++ Client"
         LANGUAGES CXX)
 
-# Set the C++ standard
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Generate the Reference_Manual.md file using the latest project version.
@@ -89,15 +87,27 @@ find_package(Threads REQUIRED)
 
 # find Boost
 if (WIN32)
-	find_package(Boost 1.73 REQUIRED COMPONENTS thread chrono)
+	find_package(Boost 1.73 CONFIG REQUIRED COMPONENTS thread chrono)
 else()
-	find_package(Boost 1.71 REQUIRED COMPONENTS thread chrono)
+	find_package(Boost 1.71 CONFIG REQUIRED COMPONENTS thread chrono)
 endif()
 
 if (Boost_FOUND)
     message(STATUS "Boost version: ${Boost_VERSION}")
     message(STATUS "Boost include directory: ${Boost_INCLUDE_DIRS}")
     message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
+
+    # Check Boost version and set C++ standard accordingly
+    # Our library can not use a lower C++ standard than the one required by Boost.
+    if (Boost_VERSION VERSION_LESS 1.70)
+        set(CMAKE_CXX_STANDARD 11)
+    elseif (Boost_VERSION VERSION_LESS 1.77)
+        set(CMAKE_CXX_STANDARD 14)
+    else()
+        set(CMAKE_CXX_STANDARD 17)  # Boost.JSON, Boost.Process, etc.
+    endif()
+
+    message(STATUS "Required C++ standard: ${CMAKE_CXX_STANDARD}")
 else()
     message(FATAL_ERROR "Boost not found!")
 endif()
@@ -263,8 +273,12 @@ install(
 )
 
 if (BUILD_TESTS)
+    message(STATUS "BUILD_TESTS is enabled. Ensure the 'build-tests' feature is enabled in vcpkg.json.")
+    find_package(GTest REQUIRED)
     add_subdirectory(hazelcast/test)
-endif ()
+else()
+    message(STATUS "BUILD_TESTS is disabled.")
+endif()
 
 if (BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,14 @@ else()
 	find_package(Boost 1.71 REQUIRED COMPONENTS thread chrono)
 endif()
 
+if (Boost_FOUND)
+    message(STATUS "Boost version: ${Boost_VERSION}")
+    message(STATUS "Boost include directory: ${Boost_INCLUDE_DIRS}")
+    message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
+else()
+    message(FATAL_ERROR "Boost not found!")
+endif()
+
 # find OpenSSL if building WITH_OPENSSL
 if (WITH_OPENSSL)
     if (APPLE)
@@ -104,6 +112,14 @@ if (WITH_OPENSSL)
     endif ()
 
     find_package(OpenSSL REQUIRED)
+
+    if (OpenSSL_FOUND)
+        message(STATUS "OpenSSL version: ${OpenSSL_VERSION}")
+        message(STATUS "OpenSSL include directory: ${OPENSSL_INCLUDE_DIR}")
+        message(STATUS "OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+    else()
+        message(FATAL_ERROR "OpenSSL not found!")
+    endif()
 endif ()
 
 # add the library target

--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -347,6 +347,27 @@ For example:
 g++ -DHZ_BUILD_WITH_SSL -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_VERSION=5 -I/var/git/hazelcast-cpp-client/build/include -std=gnu++11 -c main.cpp
 ```
 
+##### 1.1.3.5.2. Building the hazelcast-cpp-client library with vcpkg toolchain
+If you want to build the `hazelcast-cpp-client` library with vcpkg toolchain, you can use the following command:
+```sh
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=<path to vcpkg folder>/scripts/buildsystems/vcpkg.cmake
+cmake --build build --config Release
+```
+
+if you want to build the project with tests and examples enabled, then you can use the following command:
+```sh
+cmake -b build \
+-DBUILD_TESTS=ON \
+-DBUILD_EXAMPLES=ON \
+-DWITH_OPENSSL=ON \
+-DCMAKE_VERBOSE_MAKEFILE=ON \
+-DCMAKE_TOOLCHAIN_FILE=<path to vcpkg folder>/scripts/buildsystems/vcpkg.cmake \
+-DVCPKG_MANIFEST_FEATURES='build-tests' \
+
+cmake --build build
+```
+
+
 ## 1.2. Starting a Hazelcast Cluster
 
 The Hazelcast C++ client requires a working Hazelcast cluster to run. This cluster handles storage and manipulation of the user data. Clients are a way to connect to the Hazelcast cluster and access such data.

--- a/Reference_Manual.md.in
+++ b/Reference_Manual.md.in
@@ -199,7 +199,7 @@ Please see [getting started](https://github.com/microsoft/vcpkg#getting-started)
 If you use Linux or Mac:
 
 ```sh
-git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
+git clone https://github.com/microsoft/vcpkg
 ./vcpkg/bootstrap-vcpkg.sh
 ./vcpkg/vcpkg install "hazelcast-cpp-client[openssl]" --recurse
 ``` 
@@ -207,7 +207,7 @@ git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
 If you use Windows:
 
 ```bat
-git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
+git clone https://github.com/microsoft/vcpkg
 .\vcpkg\bootstrap-vcpkg.bat
 .\vcpkg\vcpkg install "hazelcast-cpp-client[openssl]:x64-windows" --recurse
 ``` 
@@ -242,7 +242,7 @@ This generates the `conanbuildinfo.cmake` file to be included in your CMakeLists
 ### 1.1.3. Install From Source Code Using CMake
 #### 1.1.3.1. Requirements
 1. Linux, macOS or Windows
-2. A compiler that supports C++11
+2. A compiler that supports C++11 or above: The project detects the minimum C++ standard supported by the Boost library and uses the same language level for compilation.
 3. [CMake](https://cmake.org) 3.10 or above
 4. [Boost](https://www.boost.org) 1.71 or above. Minimum boost version is upgraded to 1.73 for Windows due to [this](https://github.com/chriskohlhoff/asio/issues/431) bug.
 5. [OpenSSL](https://www.openssl.org) (optional)
@@ -346,6 +346,27 @@ For example:
 ```sh
 g++ -DHZ_BUILD_WITH_SSL -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_VERSION=5 -I/var/git/hazelcast-cpp-client/build/include -std=gnu++11 -c main.cpp
 ```
+
+##### 1.1.3.5.2. Building the hazelcast-cpp-client library with vcpkg toolchain
+If you want to build the `hazelcast-cpp-client` library with vcpkg toolchain, you can use the following command:
+```sh
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=<path to vcpkg folder>/scripts/buildsystems/vcpkg.cmake
+cmake --build build --config Release
+```
+
+if you want to build the project with tests and examples enabled, then you can use the following command:
+```sh
+cmake -b build \
+-DBUILD_TESTS=ON \
+-DBUILD_EXAMPLES=ON \
+-DWITH_OPENSSL=ON \
+-DCMAKE_VERBOSE_MAKEFILE=ON \
+-DCMAKE_TOOLCHAIN_FILE=<path to vcpkg folder>/scripts/buildsystems/vcpkg.cmake \
+-DVCPKG_MANIFEST_FEATURES='build-tests' \
+
+cmake --build build
+```
+
 
 ## 1.2. Starting a Hazelcast Cluster
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,9 +21,6 @@ project (hazelcast-cpp-client-examples
          DESCRIPTION "Hazelcast C++ Client Code Examples"
          LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if (NOT TARGET hazelcast-cpp-client)
     message(STATUS "hazelcast-cpp-client is not a valid target, using find_package to find it.")
     find_package(hazelcast-cpp-client REQUIRED)

--- a/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
+++ b/hazelcast/include/hazelcast/client/connection/ClientConnectionManagerImpl.h
@@ -295,7 +295,9 @@ private:
     std::unique_ptr<internal::socket::SocketFactory> socket_factory_;
     HeartbeatManager heartbeat_;
     std::thread io_thread_;
-    std::unique_ptr<boost::asio::io_context::work> io_guard_;
+    std::unique_ptr<
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>
+      io_guard_;
     const bool async_start_;
     const config::client_connection_strategy_config::reconnect_mode
       reconnect_mode_;

--- a/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
+++ b/hazelcast/include/hazelcast/client/internal/nearcache/impl/DefaultNearCache.h
@@ -124,8 +124,7 @@ public:
     {
         expiration_cancelled_.store(true);
         if (expiration_timer_) {
-            boost::system::error_code ignored;
-            expiration_timer_->cancel(ignored);
+            expiration_timer_->cancel();
         }
         near_cache_record_store_->destroy();
     }

--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -76,7 +76,7 @@ public:
       const std::shared_ptr<connection::Connection> connection) override
     {
         boost::asio::steady_timer connectTimer(io_);
-        connectTimer.expires_from_now(connect_timeout_);
+        connectTimer.expires_after(connect_timeout_);
         connectTimer.async_wait([=](const boost::system::error_code& ec) {
             if (ec == boost::asio::error::operation_aborted) {
                 return;
@@ -117,7 +117,7 @@ public:
     {
         check_connection(connection, invocation);
         auto message = invocation->get_client_message();
-        socket_strand_.post([connection, invocation, message, this]() mutable {
+        boost::asio::post(socket_strand_, [connection, invocation, message, this]() mutable {
             if (!check_connection(connection, invocation)) {
                 return;
             }

--- a/hazelcast/include/hazelcast/client/proxy/flake_id_generator_impl.h
+++ b/hazelcast/include/hazelcast/client/proxy/flake_id_generator_impl.h
@@ -91,19 +91,20 @@ private:
         int32_t get_batch_size() const;
 
         class IdIterator
-          : public std::iterator<std::input_iterator_tag, int64_t>
         {
         public:
-            IdIterator();
+            using iterator_category = std::input_iterator_tag;
+            using value_type = int64_t;
+            using difference_type = std::ptrdiff_t;
+            using pointer = int64_t*;
+            using reference = int64_t&;
 
+            IdIterator();
             IdIterator(int64_t base2, int64_t increment, int32_t remaining);
 
             IdIterator& operator++();
-
             bool operator==(const IdIterator& rhs) const;
-
             bool operator!=(const IdIterator& rhs) const;
-
             const int64_t& operator*() { return base2_; }
 
         private:
@@ -111,7 +112,6 @@ private:
             const int64_t increment_;
             int32_t remaining_;
         };
-
         IdIterator iterator();
 
         static IdIterator& end();

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/data_input.h
@@ -182,11 +182,11 @@ public:
     {
         check_available(util::Bits::UUID_SIZE_IN_BYTES);
         boost::uuids::uuid u;
-        std::memcpy(&u.data, &buffer_[pos_], util::Bits::UUID_SIZE_IN_BYTES);
+        std::memcpy(&u.data[0], &buffer_[pos_], util::Bits::UUID_SIZE_IN_BYTES);
         pos_ += util::Bits::UUID_SIZE_IN_BYTES;
         if (byte_order_ == boost::endian::order::little) {
             boost::endian::endian_reverse_inplace<int64_t>(
-              *reinterpret_cast<int64_t*>(u.data));
+              *reinterpret_cast<int64_t*>(&u.data[0]));
             boost::endian::endian_reverse_inplace<int64_t>(
               *reinterpret_cast<int64_t*>(
                 &u.data[util::Bits::LONG_SIZE_IN_BYTES]));

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientExecutionServiceImpl.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientExecutionServiceImpl.h
@@ -96,9 +96,9 @@ private:
       std::shared_ptr<boost::asio::steady_timer> timer)
     {
         if (delay.count() > 0) {
-            timer->expires_from_now(delay);
+            timer->expires_after(delay);
         } else {
-            timer->expires_from_now(period);
+            timer->expires_after(period);
         }
 
         timer->async_wait([=](boost::system::error_code ec) {

--- a/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
+++ b/hazelcast/include/hazelcast/client/spi/impl/ClientInvocation.h
@@ -210,22 +210,7 @@ private:
       const std::string& name,
       int partition = UNASSIGNED_PARTITION,
       const std::shared_ptr<connection::Connection>& conn = nullptr,
-      boost::uuids::uuid uuid = { 0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0,
-                                  0x0 });
+      boost::uuids::uuid uuid = {});
 
     void invoke_on_selection();
 

--- a/hazelcast/include/hazelcast/util/SyncHttpClient.h
+++ b/hazelcast/include/hazelcast/util/SyncHttpClient.h
@@ -39,7 +39,7 @@ public:
 private:
     std::string server_;
     std::string uri_path_;
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     boost::asio::ip::tcp::socket socket_;
     boost::asio::streambuf response_;
     std::istream response_stream_;

--- a/hazelcast/include/hazelcast/util/SyncHttpsClient.h
+++ b/hazelcast/include/hazelcast/util/SyncHttpsClient.h
@@ -48,7 +48,7 @@ private:
     std::chrono::steady_clock::duration timeout_;
     std::string secret_removal_;
 
-    boost::asio::io_service io_service_;
+    boost::asio::io_context io_service_;
     boost::asio::ip::tcp::resolver resolver_;
 
     boost::asio::ssl::context ssl_context_;

--- a/hazelcast/src/hazelcast/client/protocol.cpp
+++ b/hazelcast/src/hazelcast/client/protocol.cpp
@@ -376,7 +376,7 @@ operator<<(std::ostream& os, const ClientMessage& msg)
 void
 ClientMessage::set(unsigned char* /* memory */, boost::uuids::uuid uuid)
 {
-    std::memcpy(wr_ptr(uuid.size()), uuid.data, uuid.size());
+    std::memcpy(wr_ptr(uuid.size()), &uuid.data[0], uuid.size());
 }
 
 void

--- a/hazelcast/src/hazelcast/client/serialization.cpp
+++ b/hazelcast/src/hazelcast/client/serialization.cpp
@@ -731,12 +731,12 @@ data_output::write(boost::uuids::uuid v)
     }
     if (byte_order_ == boost::endian::order::little) {
         boost::endian::endian_reverse_inplace<int64_t>(
-          *reinterpret_cast<int64_t*>(v.data));
+          *reinterpret_cast<int64_t*>(&v.data[0]));
         boost::endian::endian_reverse_inplace<int64_t>(
           *reinterpret_cast<int64_t*>(&v.data[util::Bits::LONG_SIZE_IN_BYTES]));
     }
     output_stream_.insert(
-      output_stream_.end(), v.data, v.data + util::Bits::UUID_SIZE_IN_BYTES);
+      output_stream_.end(), &v.data[0], &v.data[util::Bits::LONG_SIZE_IN_BYTES]);
 }
 
 template<>

--- a/hazelcast/src/hazelcast/client/stats.cpp
+++ b/hazelcast/src/hazelcast/client/stats.cpp
@@ -96,8 +96,7 @@ void
 Statistics::shutdown()
 {
     if (send_task_timer_) {
-        boost::system::error_code ignored;
-        send_task_timer_->cancel(ignored);
+        send_task_timer_->cancel();
     }
 }
 

--- a/hazelcast/test/CMakeLists.txt
+++ b/hazelcast/test/CMakeLists.txt
@@ -7,11 +7,18 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-maybe-uninitialized")
 endif ()
 
-find_package(GTest 1.10)
+find_package(GTest)
 
 if (GTest_FOUND)
+    message(STATUS "GTest package found!")
+    get_target_property(GTEST_INCLUDES GTest::gtest INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "GTest include directory: ${GTEST_INCLUDES}")
+    message(STATUS "GTest libraries: ${GTEST_LIBRARIES}")
+
     set(GTEST_TARGETS GTest::gtest GTest::gtest_main)
 else()
+    message(STATUS "GTest package not found!")
+
     message(STATUS "Downloading googletest from Github")
 
     configure_file(CMakeLists.googletest.in googletest-download/CMakeLists.txt)

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2360,11 +2360,11 @@ TEST(ClientMessageTest, test_encode_sql_query_id)
 
     protocol::ClientMessage msg;
 
-    boost::uuids::uuid server_uuid{ 1, 2,  3,  4,  5,  6,  7,  8,
-                                    9, 10, 11, 12, 13, 14, 15, 16 };
-    boost::uuids::uuid client_uuid{ 21, 22, 23, 24, 25, 26, 27, 28,
-                                    29, 30, 31, 32, 33, 34, 35, 36 };
-    msg.set(sql::impl::query_id{ server_uuid, client_uuid });
+boost::uuids::uuid server_uuid = boost::uuids::uuid{{ 1, 2,  3,  4,  5,  6,  7,  8,
+                                                      9, 10, 11, 12, 13, 14, 15, 16 }};
+boost::uuids::uuid client_uuid = boost::uuids::uuid{{ 21, 22, 23, 24, 25, 26, 27, 28,
+                                                      29, 30, 31, 32, 33, 34, 35, 36 }};
+msg.set(sql::impl::query_id{ server_uuid, client_uuid });
 
     const std::vector<unsigned char> expected_bytes{
         6,  0,  0,  0,  0,  16, // begin frame

--- a/hazelcast/test/src/sql_test.cpp
+++ b/hazelcast/test/src/sql_test.cpp
@@ -2269,10 +2269,10 @@ public:
 protected:
     query_id get_query_id() const
     {
-        boost::uuids::uuid server_uuid{ 1, 2,  3,  4,  5,  6,  7,  8,
-                                        9, 10, 11, 12, 13, 14, 15, 16 };
-        boost::uuids::uuid client_uuid{ 21, 22, 23, 24, 25, 26, 27, 28,
-                                        29, 30, 31, 32, 33, 34, 35, 36 };
+        boost::uuids::uuid server_uuid{ {1, 2,  3,  4,  5,  6,  7,  8,
+                                        9, 10, 11, 12, 13, 14, 15, 16} };
+        boost::uuids::uuid client_uuid{ {21, 22, 23, 24, 25, 26, 27, 28,
+                                        29, 30, 31, 32, 33, 34, 35, 36} };
         return { server_uuid, client_uuid };
     }
 };

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,15 @@
     "boost-property-tree",
     "boost-system",
     "boost-thread",
-    "boost-uuid"
-  ]
+    "boost-uuid",
+    "boost-multiprecision"
+  ],
+  "features": {
+    "build-tests": {
+      "description": "Enable GTest for building tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "hazelcast-cpp-client",
+  "version": "5.5.0",
+  "dependencies": [
+    "boost-any",
+    "boost-asio",
+    "boost-chrono",
+    "boost-format",
+    "boost-optional",
+    "boost-property-tree",
+    "boost-system",
+    "boost-thread",
+    "boost-uuid"
+  ]
+}


### PR DESCRIPTION
Fixed build problems with latest Boost library versions.
Updated the project to use the minimum C++ standard to be the same as the one required by the Boost library. This means if a user is using an older Boost version we use C++11 but if newer Boost version is used we change level to C++ 14 or C++ 17. the algorithm is like this:
```
    # Check Boost version and set C++ standard accordingly
    # Our library can not use a lower C++ standard than the one required by Boost.
    if (Boost_VERSION VERSION_LESS 1.70)
        set(CMAKE_CXX_STANDARD 11)
    elseif (Boost_VERSION VERSION_LESS 1.77)
        set(CMAKE_CXX_STANDARD 14)
    else()
        set(CMAKE_CXX_STANDARD 17)  # Boost.JSON, Boost.Process, etc.
    endif()
```

fixes #1253 
fixes https://hazelcast.atlassian.net/browse/DEX-431