### PR TITLE
Relocate `hazelcast-remote-controller` [DI-639]

### DIFF
--- a/scripts/start-rc.bat
+++ b/scripts/start-rc.bat
@@ -8,7 +8,7 @@ set HAZELCAST_TEST_VERSION=%HZ_VERSION%
 set HAZELCAST_ENTERPRISE_VERSION=%HZ_VERSION%
 set HAZELCAST_RC_VERSION=0.8-SNAPSHOT
 set SNAPSHOT_REPO=https://oss.sonatype.org/content/repositories/snapshots
-set RELEASE_REPO=http://repo1.maven.apache.org/maven2
+set RELEASE_REPO=https://repo.maven.apache.org/maven2
 set ENTERPRISE_RELEASE_REPO=https://repository.hazelcast.com/release/
 set ENTERPRISE_SNAPSHOT_REPO=https://repository.hazelcast.com/snapshot/
 
@@ -26,7 +26,7 @@ if exist "hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar" (
     echo "hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar already exist, not downloading from maven."
 ) else (
     echo "Downloading: remote-controller jar com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION%"
-    call mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.10:get -Dtransitive=false -DremoteRepositories=%SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION% -Ddest=hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar || (
+    call mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.10:get -Dtransitive=false -DremoteRepositories=%ENTERPRISE_SNAPSHOT_REPO% -Dartifact=com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION% -Ddest=hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar || (
         echo "Failed download remote-controller jar com.hazelcast:hazelcast-remote-controller:%HAZELCAST_RC_VERSION%" 
         exit /b 1
     )

--- a/scripts/start-rc.sh
+++ b/scripts/start-rc.sh
@@ -39,7 +39,7 @@ HAZELCAST_TEST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
 HAZELCAST_RC_VERSION=0.8-SNAPSHOT
 SNAPSHOT_REPO="https://oss.sonatype.org/content/repositories/snapshots"
-RELEASE_REPO="http://repo1.maven.apache.org/maven2"
+RELEASE_REPO="https://repo.maven.apache.org/maven2"
 ENTERPRISE_RELEASE_REPO="https://repository.hazelcast.com/release/"
 ENTERPRISE_SNAPSHOT_REPO="https://repository.hazelcast.com/snapshot/"
 
@@ -55,7 +55,7 @@ fi
 if [ -f "hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar" ]; then
     echo "remote controller already exist, not downloading from maven."
 else
-    downloadFromMaven ${SNAPSHOT_REPO} "com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
+    downloadFromMaven ${ENTERPRISE_SNAPSHOT_REPO} "com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}"
 fi
 
 if [ -f "hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar" ]; then


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-remote-controller/pull/75, `hazelcast-remote-controller` is deployed to a different repository to address build issues. Update the paths to suit.

Also:
- updated Maven central URL as per https://github.com/hazelcast/hazelcast-mono/pull/4897
- updated Maven central URL to use `HTTPS`, as `HTTP` is [no longer supported](https://maven.apache.org/docs/3.8.1/release-notes.html).

Fixes: [DI-639](https://hazelcast.atlassian.net/browse/DI-639)

[DI-639]: https://hazelcast.atlassian.net/browse/DI-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ