### PR TITLE
Document `b2` parameters

### DIFF
--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -91,7 +91,7 @@ runs:
         rm ${{ inputs.BOOST_ARCHIVE_NAME }}
         cd ${{ inputs.BOOST_FOLDER_NAME }}
         .\bootstrap.bat
-        # Include:
+        # Build the libs for:
         # - Atomic - https://www.boost.org/libs/atomic/
         # - Thread - https://www.boost.org/libs/thread/
         # - Chrono - https://www.boost.org/libs/chrono/

--- a/scripts/install-boost.sh
+++ b/scripts/install-boost.sh
@@ -15,7 +15,7 @@ TARBALL_NAME=boost_$(echo "$1" | tr . _)
 curl --fail --silent --show-error --location "https://archives.boost.io/release/${1}/source/${TARBALL_NAME}.tar.gz" | tar xzf -
 pushd "${TARBALL_NAME}"
 ./bootstrap.sh
-# Include:
+# Build the libs for:
 # - Thread - https://www.boost.org/libs/thread/
 # - Atomic - https://www.boost.org/libs/atomic/
 ./b2 --with-thread --with-chrono install


### PR DESCRIPTION
There was no clear description of what the `b2` parameters did.

[Related discussion](https://github.com/hazelcast/hazelcast-cpp-client/pull/1322#discussion_r2419330300).