### PR TITLE
Changed the min boost version to 1.88.0 for MacOS [CTT-750] 

### DIFF
--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         boost:
-            - version: 1.73.0
+            - version: 1.88.0 # MacOS issue (https://github.com/boostorg/thread/issues/402) fixed at 1.88.0
             - version: 1.89.0
         build_type: ${{ fromJSON(needs.shared-matrix.outputs.build-type) }}
         shared_libs: ${{ fromJSON(needs.shared-matrix.outputs.shared-libs) }}


### PR DESCRIPTION
Changed the min boost version to 1.88.0 for MacOS due to Boost library bug https://github.com/boostorg/thread/issues/402.

See a sample failing build [here](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/18668934465/job/53225966723)

```
client/hazelcast/include/hazelcast/client/serialization/pimpl/compact/compact.h:22:
2025-10-21T00:34:58.0477540Z /usr/local/include/boost/thread/future.hpp:4672:19: error: no member named 'that' in 'run_it<FutureExecutorContinuationSharedState>'; did you mean 'that_'?
2025-10-21T00:34:58.0478130Z  4672 |           that_=x.that;
2025-10-21T00:34:58.0478870Z       |                   ^~~~
2025-10-21T00:34:58.0479160Z       |                   that_
2025-10-21T00:34:58.0479550Z /usr/local/include/boost/thread/future.hpp:4650:55: note: 'that_' declared here
```