### PR TITLE
Revert back PR #1335

### DIFF
--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -93,7 +93,9 @@ runs:
         .\bootstrap.bat
         # Build the libs for:
         # - Thread - https://www.boost.org/libs/thread/
-        .\b2 address-model=${{ inputs.ARCH_ADDRESS_MODEL }} --with-thread install
+        # - Chrono - https://www.boost.org/libs/chrono/
+        # - Atomic - https://www.boost.org/libs/atomic/
+        .\b2 address-model=${{ inputs.ARCH_ADDRESS_MODEL }} --with-thread --with-chrono --with-atomic install
         cd ..
         Remove-Item ${{ inputs.BOOST_FOLDER_NAME }} -Recurse -Force
 

--- a/scripts/install-boost.sh
+++ b/scripts/install-boost.sh
@@ -17,6 +17,8 @@ pushd "${TARBALL_NAME}"
 ./bootstrap.sh
 # Build the libs for:
 # - Thread - https://www.boost.org/libs/thread/
+# - Chrono - https://www.boost.org/libs/chrono/
+# - Atomic - https://www.boost.org/libs/atomic/
 # Used the c++11 language level intentionally to support old boost versions.
-./b2 cxxflags="-std=c++11 -Wno-enum-constexpr-conversion" --with-thread install
+./b2 cxxflags="-std=c++11 -Wno-enum-constexpr-conversion" --with-thread --with-chrono --with-atomic install
 popd


### PR DESCRIPTION
Revert back PR #1335. Add the boost lib dependencies explicitly.

see [comment](https://github.com/hazelcast/hazelcast-cpp-client/pull/1335#issuecomment-3436779439) for details.