### PR TITLE
Support `vcpkg` in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "vcpkg"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
[Dependabot now supports `vcpkg`](https://github.blog/changelog/2025-08-12-dependabot-version-updates-now-support-vcpkg/)