### PR TITLE
Group `boost` `vcpkg` ports in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      boost:
+        patterns:
+          - "boost-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot updates each port _individually_ which is annoying:
- https://github.com/hazelcast/hazelcast-cpp-client/pull/1355
- https://github.com/hazelcast/hazelcast-cpp-client/pull/1356
- https://github.com/hazelcast/hazelcast-cpp-client/pull/1357

Instead, [configure Dependabot to group them](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--). It would be preferable to remove the version specification in the `vcpkg` file itself, but this isn't possible.

I'm not able to (easily) test this change until it's merged.