### PR TITLE
Allow PR builder on `dependabot` PRs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Report
         shell: bash
-        run: echo "User ${{ github.actor }} is trusted for PR execution"          
+        run: echo "User ${{ github.actor }} is trusted for test execution"          
 
 
   # get


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-cpp-client/pull/1360 is blocked by lack of PR builder execution.

[Fixed in a _similar_ way to `hazelcast-code-samples`](https://github.com/hazelcast/hazelcast-code-samples/blob/94133f7b918259f0e89cc9ddc8bc16050ce77bc0/.github/workflows/builder.yaml#L24-L28).