### PR TITLE
Partially automate release - tagging and documentation generation [DI-669]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,13 @@ jobs:
           sudo apt-get install -y doxygen
 
       - name: Generate Doxygen documentation
+        working-directory: repo
         run: |
-          doxygen repo/Doxyfile
+          doxygen
 
       - name: Post-process docs
         run: |
-          mv docs/html ${GH_PAGES_BRANCH}/${{ inputs.BRANCH_NAME }}
+          mv repo/docs/html ${GH_PAGES_BRANCH}/${{ inputs.BRANCH_NAME }}
 
           # doc-index.html
           sed -i \


### PR DESCRIPTION
_Partially_ automates the steps listed in [the `C++ Client Release Process` documentation](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/129810774/C+Client+Release+Process).

Specifically, steps:
- `Git tagging`
- `Doxygen`

By scripting and chaining the steps, the (manual) release work is reduced and consistency is improved. Tagging logic based on [approach in `hazelcast-docker`](https://github.com/hazelcast/hazelcast-docker/blob/master/.github/workflows/retag.yml).

Where possible, I've tried to replicate how it _currently_ works. It's likely there's future scope to improve (e.g. should the documentation updates _really_ raise a PR?).

Of note - the instructions call for an "annotated tag" (`tag -a`). While this [seems more sensible](https://stackoverflow.com/q/4971746), it's not [how we make tags elsewhere](https://github.com/search?q=org%3Ahazelcast%20%22git%20tag%22&type=code) (most notably - [in the release pipeline](https://github.com/hazelcast/hazelcast-pipeline-library/blob/43882a84b3715e2ac74f84c92f3c3d170504f2ab/src/com/hazelcast/qe/pipeline/git/Branch.groovy#L122-L127)), so for consistency I've changed to lightweight tags.

Testing (in my fork):
- [example execution](https://github.com/JackPGreen/hazelcast-cpp-client/actions/runs/19150806835)
- [tag created](https://github.com/JackPGreen/hazelcast-cpp-client/releases/tag/v5.5.3)
- [documentation PR raised](https://github.com/JackPGreen/hazelcast-cpp-client/pull/4)

Post-merge actions:
- [x] update docs

_Partially addresses_: [DI-669](https://hazelcast.atlassian.net/browse/DI-669)

[DI-669]: https://hazelcast.atlassian.net/browse/DI-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ