### PR TITLE
De-duplicate version numbers in `CMakeLists.txt` [DI-669]

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,7 @@
 cmake_minimum_required (VERSION 3.10)
 
 project (hazelcast-cpp-client-examples
-         VERSION 5.5.0
+         VERSION ${hazelcast-cpp-client_VERSION}
          DESCRIPTION "Hazelcast C++ Client Code Examples"
          LANGUAGES CXX)
 


### PR DESCRIPTION
Rather than duplicating the version number between client and `examples`, we should simply _inherit_ the version number in `examples` - it's not built on it's own.

This is a _step towards_ having the version number declared _only once_ to make incrementing easier.

_Partially addresses_: [DI-669](https://hazelcast.atlassian.net/browse/DI-669)

[DI-669]: https://hazelcast.atlassian.net/browse/DI-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ