### PR TITLE
Partially automate release - release branch creation and version updates [DI-669]

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -30,7 +30,7 @@ jobs:
           git push origin ${{ steps.project_version.outputs.version }}
 
   update-version:
-    name: Update version in `${{ inputs.BRANCH_NAME }}` to `${{ inputs.NEXT_VERSION }}`
+    name: Update next version in `${{ inputs.BRANCH_NAME }}` to `${{ inputs.NEXT_VERSION }}`
     runs-on: ubuntu-latest
     env:
         NEW_VERSION: ${{ inputs.NEXT_VERSION }}


### PR DESCRIPTION
_Partially_ automates the steps listed in [the `C++ Client Release Process` documentation](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/129810774/C+Client+Release+Process).

Specifically, steps:
- `Create branch`
- `Update next version`

By scripting and chaining the steps, the (manual) release work is reduced and consistency is improved.

Testing (in my fork):
- [example execution](https://github.com/JackPGreen/hazelcast-cpp-client/actions/runs/19166496611)
- [branch created](https://github.com/JackPGreen/hazelcast-cpp-client/tree/5.5.0)
- [version update PR raised](https://github.com/JackPGreen/hazelcast-cpp-client/pull/5) - (note, action is included in PR as I've since reset my forks' `master`, it's not _actually_ in the PR)

Post-merge actions:
- [x] update docs

_Partially addresses_: [DI-669](https://hazelcast.atlassian.net/browse/DI-669)

[DI-669]: https://hazelcast.atlassian.net/browse/DI-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ