### PR TITLE
Fix `README.md` logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://hazelcast.com">
-        <img class="center" src="https://hazelcast.com/files/brand-images/logo/hazelcast-logo.svg" alt="logo">
+        <img class="center" src="https://hazelcast.com/files/brand-images/logo/hazelcast-logo.svg" alt="Hazelcast logo">
     </a>
     <h2 align="center">Hazelcast C++ Client</h2>
 </p>


### PR DESCRIPTION
Was fixed in https://github.com/hazelcast/hazelcast-cpp-client/pull/1268 but has moved again.

Also fixed (duplicated) `alt` test on license badge.