### PR TITLE
Remove duplicated `curl` installation from `i386` setup action

### DIFF
--- a/.github/actions/build-test/ubuntu-i386/action.yml
+++ b/.github/actions/build-test/ubuntu-i386/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: |
         apt-get update
-        apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-${{ env.JAVA_VERSION }}-jre-headless gdb curl
+        apt-get install -y build-essential cmake curl git libssl-dev maven net-tools openjdk-${{ env.JAVA_VERSION }}-jre-headless gdb
 
     - name: Make sure the target architecture is 32 bit
       shell: bash


### PR DESCRIPTION
It doesn't cause any problems (it's only installed once), it's just more confusing to read.