### PR TITLE
Remove the `Beta` annotation from the compact serialization [HZ-5298]

### DIFF
--- a/Reference_Manual.md
+++ b/Reference_Manual.md
@@ -388,7 +388,7 @@ The underlying format of the compact serialized objects is platform and language
 
 Refer to [documentation](https://docs.hazelcast.com/hazelcast/latest/compact-binary-specification) for more details about compact binary serialization.
 ### 4.3.1. Compact Serializer
-Another way to use compact serialization is to implement the `hz_serializer<T> : compact::compact_serializer` specialization for a `T`. A basic serializer could look like:
+You need to implement the `hz_serializer<T> : compact::compact_serializer` specialization for a `T` to use compact serialization for object type `T`. A basic serializer could look like:
 
 ``` C++
 class PersonDTO

--- a/hazelcast/include/hazelcast/client/serialization/pimpl/compact/compact.h
+++ b/hazelcast/include/hazelcast/client/serialization/pimpl/compact/compact.h
@@ -69,8 +69,7 @@ namespace compact {
  *      static void write(const T& object, compact_writer &out);
  *      static T read(compact_reader &in);
  *
- * @Beta
- * @since 5.1
+ * @since 5.6
  */
 class compact_serializer
 {};
@@ -84,8 +83,7 @@ class compact_serializer
  * return it. Providing default values might be especially useful if the class
  * might evolve in the future, either by adding or removing fields.
  *
- * @Beta
- * @since 5.1
+ * @since 5.6
  */
 class HAZELCAST_API compact_reader
 {
@@ -762,8 +760,7 @@ private:
 /**
  *  Provides means of writing compact serialized fields to the binary data.
  *
- * @Beta
- * @since 5.1
+ * @since 5.6
  */
 class HAZELCAST_API compact_writer
 {


### PR DESCRIPTION
Remove the `Beta` annotation from the compact serialization.

fixes #1009