### PR TITLE
Enforce code formatting in PR via `git-clang-client`

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -296,11 +296,14 @@ jobs:
 
       - name: Check formatting
         run: |
+          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+
           git-clang-format \
             ${{ needs.get-refs.outputs.base-sha }} \
             -- \
             hazelcast
 
           if ! git --no-pager diff; then
+            echoerr "Code not formatted as expected"
             exit 1
           fi


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-cpp-client/pull/946 the codebase was reformatted for consistency, but as this was not enforced the codebase has drifted since then.

To avoid this happening again, enforce this at the PR stage.

Testing:
- [example failure](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/20455944532/job/58777930370)
- [example success
](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/20455961135/job/58777982668)

This is alternative implementation addressing feedback from https://github.com/hazelcast/hazelcast-cpp-client/pull/1342#issuecomment-3580258782

Closes https://github.com/hazelcast/hazelcast-cpp-client/pull/1342

Post-merge:
- [x] make a [mandatory check](https://github.com/hazelcast/hazelcast-cpp-client/settings/branch_protection_rules/43907)