### PR TITLE
Disable ttl based tests in ClientMapTest suite for near cache client [HZ-5308] [HZ-5310]

### DIFF
--- a/hazelcast/test/src/HazelcastTests5.cpp
+++ b/hazelcast/test/src/HazelcastTests5.cpp
@@ -1189,8 +1189,8 @@ TEST_P(ClientMapTest, testPutTtl)
 
 TEST_P(ClientMapTest, testPutConfigTtl)
 {
-    if (client_.get_client_config().get_near_cache_config(ONE_SECOND_MAP_NAME) !=
-        nullptr) {
+    if (client_.get_client_config().get_near_cache_config(
+          ONE_SECOND_MAP_NAME) != nullptr) {
         GTEST_SKIP_(
           "Server side expiry does not send near cache invalidations. "
           "See https://github.com/hazelcast/hazelcast/issues/10975");
@@ -1278,8 +1278,8 @@ TEST_P(ClientMapTest, testSetTtl)
 
 TEST_P(ClientMapTest, testSetConfigTtl)
 {
-    if (client_.get_client_config().get_near_cache_config(ONE_SECOND_MAP_NAME) !=
-        nullptr) {
+    if (client_.get_client_config().get_near_cache_config(
+          ONE_SECOND_MAP_NAME) != nullptr) {
         GTEST_SKIP_(
           "Server side expiry does not send near cache invalidations. "
           "See https://github.com/hazelcast/hazelcast/issues/10975");


### PR DESCRIPTION
Disabled ttl based tests for near cache based test cases due to an issue at server side https://github.com/hazelcast/hazelcast/issues/10975

Fixed ClientMapTest.testPutIfAbsentTtl so that it is in sync with Java test https://github.com/hazelcast/hazelcast-mono/blob/aad45696a4bb784c6a538e22d26f183973ace9c4/hazelcast/hazelcast/src/test/java/com/hazelcast/client/map/ClientMapTest.java#L542. The problem was that we dependent on timing on the entry expiry and 1 second may not be enough in busy times. Hence, it is changed to 10 seconds. We also re-put the entry with 10 seconds ttl in the send put also to avoid expiry when we checked the value in the next step.
    
opened #1390 so that we do not forget to re-open these tests.
 
fixes #1145
fixes #1181
