### PR TITLE
Replace explicit AWS token with tokenless-OIDC authentication [DI-706]

### DIFF
--- a/.github/actions/build-test/macos-x86_64/action.yml
+++ b/.github/actions/build-test/macos-x86_64/action.yml
@@ -15,9 +15,7 @@ inputs:
     required: true
   HAZELCAST_ENTERPRISE_KEY:
     required: true
-  AWS_ACCESS_KEY_ID:
-    required: true
-  AWS_SECRET_ACCESS_KEY:
+  AWS_ROLE_TO_ASSUME:
     required: true
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
@@ -51,6 +49,5 @@ runs:
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}
         RUN_TESTS: ${{ inputs.RUN_TESTS }}
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}

--- a/.github/actions/build-test/ubuntu-x86_64/action.yml
+++ b/.github/actions/build-test/ubuntu-x86_64/action.yml
@@ -17,9 +17,7 @@ inputs:
     required: true
   HAZELCAST_ENTERPRISE_KEY:
     required: true
-  AWS_ACCESS_KEY_ID:
-    required: true
-  AWS_SECRET_ACCESS_KEY:
+  AWS_ROLE_TO_ASSUME:
     required: true
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
@@ -72,6 +70,5 @@ runs:
         OPENSSL_TOGGLE: ${{ inputs.OPENSSL_TOGGLE }}
         RUN_TESTS: ${{ inputs.RUN_TESTS }}
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}

--- a/.github/actions/build-test/unix/action.yml
+++ b/.github/actions/build-test/unix/action.yml
@@ -17,9 +17,7 @@ inputs:
     required: true
   HAZELCAST_ENTERPRISE_KEY:
     required: true
-  AWS_ACCESS_KEY_ID:
-    required: true
-  AWS_SECRET_ACCESS_KEY:
+  AWS_ROLE_TO_ASSUME:
     required: true
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
@@ -53,8 +51,7 @@ runs:
       env:
         BUILD_DIR: build
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
       shell: bash

--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -35,9 +35,7 @@ inputs:
     required: true
   HAZELCAST_ENTERPRISE_KEY:
     required: true
-  AWS_ACCESS_KEY_ID:
-    required: true
-  AWS_SECRET_ACCESS_KEY:
+  AWS_ROLE_TO_ASSUME:
     required: true
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
@@ -155,8 +153,7 @@ runs:
         BUILD_DIR: build
         BUILD_CONFIGURATION: ${{ inputs.BUILD_TYPE }}
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         SSL_CERT_FILE: 'C:\cacert.pem'
       shell: pwsh

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -11,9 +11,7 @@ inputs:
     required: true
   HAZELCAST_ENTERPRISE_KEY:
     required: true
-  AWS_ACCESS_KEY_ID:
-    required: true
-  AWS_SECRET_ACCESS_KEY:
+  AWS_ROLE_TO_ASSUME:
     required: true
   HZ_TEST_AWS_INSTANCE_PRIVATE_IP:
     required: true
@@ -76,8 +74,7 @@ runs:
       env:
         BUILD_DIR: build
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         BUILD_TYPE: ${{ env.BUILD_TYPE }}
       shell: bash

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -99,6 +99,8 @@ jobs:
   # run for code-coverage and upload the result as an artifact.
   code-coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     needs: get-refs
     
     name: Code Coverage
@@ -116,8 +118,7 @@ jobs:
           THRIFT_VERSION: ${{ env.THRIFT_VERSION }}
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   shared-matrix:
@@ -135,6 +136,8 @@ jobs:
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     name: ubuntu-x64-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     steps:
@@ -154,8 +157,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   Windows:
@@ -171,6 +173,8 @@ jobs:
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}
 
     runs-on: 'windows-latest'
+    permissions:
+      id-token: write
     name: windows-${{ matrix.options.address_model }}-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     steps:
       - uses: actions/checkout@v5
@@ -197,8 +201,7 @@ jobs:
           INSTALL_THRIFT: true
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   macOS-x86_64:
@@ -213,6 +216,8 @@ jobs:
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}
 
     runs-on: macos-latest
+    permissions:
+      id-token: write
 
     name: macOS-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     env:
@@ -233,8 +238,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   enforce-code-formatting:

--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     name: Create and upload coverage
     steps:
@@ -21,8 +23,7 @@ jobs:
           THRIFT_VERSION: 0.13.0
           RUN_TESTS: true
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Publish on Codecov

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -27,6 +27,8 @@ jobs:
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}
 
     runs-on: macos-latest
+    permissions:
+      id-token: write
 
     name: >-
       macOS-x86_64
@@ -47,8 +49,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.RUN_TESTS || github.event_name == 'schedule' }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Verify Installation

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -40,6 +40,8 @@ jobs:
             name: SSL
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     name: >-
       Ubuntu-x86_64
@@ -58,8 +60,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.RUN_TESTS || github.event_name == 'schedule' }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Verify Installation

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -38,6 +38,8 @@ jobs:
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}
 
     runs-on: ${{ matrix.vc_boost.image }}
+    permissions:
+      id-token: write
     env:
       JOB_NAME: Windows_(${{ matrix.vc_boost.name }},${{ matrix.options.address_model }},${{ matrix.build_type }},${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})
     name: >-
@@ -84,8 +86,7 @@ jobs:
           INSTALL_THRIFT: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
           RUN_TESTS: ${{ inputs.RUN_TESTS || github.event_name == 'schedule' }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Verify Installation


### PR DESCRIPTION
See:
- https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws
- [ADR](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/6645022721/ADR-00089-+Type+2+-Migrate+GitHub+Actions+to+use+tokenless+OIDC+authentication)
- [reference `hazelcast-docker` implementation](https://github.com/hazelcast/hazelcast-docker/pull/1197)


Note - the PR builder fails because it's mixing the code from my branch with `master` due to `pull_request_target`, hence:
> Warning: Unexpected input(s) 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', valid inputs are ['GH_TOKEN', 'BOOST_VERSION', 'THRIFT_VERSION', 'RUN_TESTS', 'HAZELCAST_ENTERPRISE_KEY', 'AWS_ROLE_TO_ASSUME', 'HZ_TEST_AWS_INSTANCE_PRIVATE_IP']



Fixes: [DI-706](https://hazelcast.atlassian.net/browse/DI-706)

[DI-706]: https://hazelcast.atlassian.net/browse/DI-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ