### PR TITLE
Suppress the Clang compiler warnings language level independent if the -Werror compile flag is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if (MSVC)
 endif ()
 
 # AppleClang-specific compiler flags, we set for all targets since we want these flags also for tests and examples
-if (CMAKE_CXX_STANDARD EQUAL 11 AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+if (CMAKE_CXX_FLAGS MATCHES "-Werror" AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion -Wno-deprecated-declarations -Wno-deprecated-builtins -Wno-unused-but-set-variable")
 endif ()
 


### PR DESCRIPTION
We need to suppress the Clang compiler warnings for known warnings in newer boost libraries even when the project uses C++14 as the language standard and if the warnings are treated as errors (`Werror` flag exists). Failing to do this causes compilation failure when using newest boost 1.90.0.

e.g.:
```
cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DWITH_OPENSSL=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_TOOLCHAIN_FILE=/Users/ihsan/Desktop/work/src/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_MANIFEST_FEATURES='build-tests' "-DCMAKE_CXX_FLAGS=-Werror -m64 -Wall" -DCMAKE_INSTALL_PREFIX=/Users/ihsan/Desktop/work/src/hazelcast-cpp-client/cpp_install -G "Unix Makefiles" -S /Users/ihsan/Desktop/work/src/hazelcast-cpp-client -B /Users/ihsan/Desktop/work/src/hazelcast-cpp-client/cmake-build-arm-debug-vcpkg
```
Failures:

```
/Users/ihsan/Applications/CLion.app/Contents/bin/cmake/mac/aarch64/bin/cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DWITH_OPENSSL=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_TOOLCHAIN_FILE=/Users/ihsan/Desktop/work/src/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_MANIFEST_FEATURES='build-tests' "-DCMAKE_CXX_FLAGS=-Werror -m64 -Wall" -DCMAKE_INSTALL_PREFIX=/Users/ihsan/Desktop/work/src/hazelcast-cpp-client/cpp_install -G "Unix Makefiles" -S /Users/ihsan/Desktop/work/src/hazelcast-cpp-client -B /Users/ihsan/Desktop/work/src/hazelcast-cpp-client/cmake-build-arm-debug-vcpkg
```