### PR TITLE
Fix AWS token used in tests

### DIFF
--- a/.github/actions/build-test/unix/action.yml
+++ b/.github/actions/build-test/unix/action.yml
@@ -46,12 +46,22 @@ runs:
             -DBUILD_TESTS=ON                                             \
             -DBUILD_EXAMPLES=OFF
 
+    - name: Configure AWS credentials
+      if: ${{ inputs.RUN_TESTS == 'true' }}
+      id: aws-credentials
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+        aws-region: 'us-east-1'
+        output-credentials: true
+
     - name: Test
       if: ${{ inputs.RUN_TESTS == 'true' }}
       env:
         BUILD_DIR: build
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         BUILD_TYPE: ${{ inputs.BUILD_TYPE }}
       shell: bash

--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -147,13 +147,23 @@ runs:
             -DBUILD_TESTS=ON `
             -DBUILD_EXAMPLES=OFF
 
+    - name: Configure AWS credentials
+      if: ${{ inputs.RUN_TESTS == 'true' }}
+      id: aws-credentials
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+        aws-region: 'us-east-1'
+        output-credentials: true
+
     - name: Test
       if: ${{ inputs.RUN_TESTS == 'true' }}
       env:
         BUILD_DIR: build
         BUILD_CONFIGURATION: ${{ inputs.BUILD_TYPE }}
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         SSL_CERT_FILE: 'C:\cacert.pem'
       shell: pwsh

--- a/.github/actions/coverage-report/action.yml
+++ b/.github/actions/coverage-report/action.yml
@@ -69,12 +69,22 @@ runs:
             -DBUILD_TESTS=ON           \
             -DBUILD_EXAMPLES=OFF
 
+    - name: Configure AWS credentials
+      if: ${{ inputs.RUN_TESTS == 'true' }}
+      id: aws-credentials
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+        aws-region: 'us-east-1'
+        output-credentials: true
+
     - name: Test
       if: ${{ inputs.RUN_TESTS == 'true' }}
       env:
         BUILD_DIR: build
         HAZELCAST_ENTERPRISE_KEY: ${{ inputs.HAZELCAST_ENTERPRISE_KEY }}
-        AWS_ROLE_TO_ASSUME: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
         HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ inputs.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
         BUILD_TYPE: ${{ env.BUILD_TYPE }}
       shell: bash


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-cpp-client/pull/1393 was not correct - although it exposed the new role, it never _used_ it anywhere and the net result was that the tests failed due to missing environment variables: https://github.com/hazelcast/hazelcast-cpp-client/blob/eb19e7f9f8789be79d79fbc1b29a3cf6f2bb98ad/hazelcast/test/src/HazelcastTests7.cpp#L1558-L1566

Added step to generate the required credentials, but still _without_ any hardcoded tokens.

From the [PR job logs](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/21203887140/job/60995646608) I can see the credentials are now being passed through:
<img width="961" height="953" alt="image" src="https://github.com/user-attachments/assets/f5078623-7f9f-4c04-9ec0-cf5711722649" />
