### PR TITLE
fix: make RC logs visible in Windows GitHub Actions [HZ-5386]

### DIFF
--- a/scripts/start-rc.bat
+++ b/scripts/start-rc.bat
@@ -82,4 +82,4 @@ set CLASSPATH="hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar;hazelcast-
 echo "Starting Remote Controller ... enterprise ...Using classpath: %CLASSPATH%"
 
 echo "Starting hazelcast-remote-controller"
-start "hazelcast-remote-controller" /MIN cmd /c "java -Dhazelcast.enterprise.license.key=%HAZELCAST_ENTERPRISE_KEY% -Dhazelcast.phone.home.enabled=false -cp %CLASSPATH% com.hazelcast.remotecontroller.Main --use-simple-server"
+start "hazelcast-remote-controller" /MIN cmd /c "java -Dhazelcast.enterprise.license.key=%HAZELCAST_ENTERPRISE_KEY% -Dhazelcast.phone.home.enabled=false -cp %CLASSPATH% com.hazelcast.remotecontroller.Main --use-simple-server > rc_stdout.log 2>&1"

--- a/scripts/test-windows.bat
+++ b/scripts/test-windows.bat
@@ -42,6 +42,7 @@ echo "Waiting for the test server to start. Timeout: %timeout% seconds"
 :server_failed_to_start
 echo "The test server did not start in %RC_START_TIMEOUT_IN_SECS% seconds. Test FAILED."
 call taskkill /F /FI "WINDOWTITLE eq hazelcast-remote-controller"
+if exist rc_stdout.log type rc_stdout.log
 exit /b 1
 
 :server_started
@@ -64,5 +65,9 @@ echo %TEST_EXECUTABLE%
 set result=%errorlevel%
 
 taskkill /T /F /FI "WINDOWTITLE eq hazelcast-remote-controller"
+
+echo "========== Remote Controller Output =========="
+if exist rc_stdout.log type rc_stdout.log
+echo "========== End Remote Controller Output =========="
 
 exit /b %result%


### PR DESCRIPTION
## Summary

- Redirect Windows remote controller stdout/stderr to `rc_stdout.log` (RC runs in a separate minimized console window via `start /MIN`, so output is lost in CI)
- Print RC log contents after tests complete in both success and failure paths of `test-windows.bat`

## Test plan

- [ ] Verify Windows CI workflow runs successfully
- [ ] Confirm RC logs appear in GitHub Actions output after test completion
- [ ] Verify RC startup failure path also prints logs