### PR TITLE
fix: make RC logs visible in Windows GitHub Actions [HZ-5387]

### DIFF
--- a/scripts/start-rc.bat
+++ b/scripts/start-rc.bat
@@ -82,4 +82,4 @@ set CLASSPATH="hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar;hazelcast-
 echo "Starting Remote Controller ... enterprise ...Using classpath: %CLASSPATH%"
 
 echo "Starting hazelcast-remote-controller"
-start "hazelcast-remote-controller" /MIN cmd /c "java -Dhazelcast.enterprise.license.key=%HAZELCAST_ENTERPRISE_KEY% -Dhazelcast.phone.home.enabled=false -cp %CLASSPATH% com.hazelcast.remotecontroller.Main --use-simple-server"
+start /B java -Dhazelcast.enterprise.license.key=%HAZELCAST_ENTERPRISE_KEY% -Dhazelcast.phone.home.enabled=false -cp %CLASSPATH% com.hazelcast.remotecontroller.Main --use-simple-server

--- a/scripts/test-windows.bat
+++ b/scripts/test-windows.bat
@@ -41,7 +41,7 @@ echo "Waiting for the test server to start. Timeout: %timeout% seconds"
 
 :server_failed_to_start
 echo "The test server did not start in %RC_START_TIMEOUT_IN_SECS% seconds. Test FAILED."
-call taskkill /F /FI "WINDOWTITLE eq hazelcast-remote-controller"
+wmic process where "commandline like '%%com.hazelcast.remotecontroller.Main%%'" call terminate >nul 2>&1
 exit /b 1
 
 :server_started
@@ -63,6 +63,6 @@ echo %TEST_EXECUTABLE%
 %TEST_EXECUTABLE% --gtest_output="xml:CPP_Client_Test_Report.xml"
 set result=%errorlevel%
 
-taskkill /T /F /FI "WINDOWTITLE eq hazelcast-remote-controller"
+wmic process where "commandline like '%%com.hazelcast.remotecontroller.Main%%'" call terminate >nul 2>&1
 
 exit /b %result%


### PR DESCRIPTION
Use `start /B` instead of `start /MIN cmd /c` so RC stdout/stderr appear in the same console — visible in CI in real-time. Replace taskkill window-title filter with wmic command-line match since `start /B` does not create a titled window.

replaces #1413 