### PR TITLE
Update `membership` check implementation to avoid PAT requirement

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,9 +46,8 @@ jobs:
         id: test-membership
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
-          organization-name: hazelcast
           member-name: ${{ github.actor }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ github.token }}
           
   # ensure PR is trusted
   ensure-membership:


### PR DESCRIPTION
See (and is blocked by) https://github.com/hazelcast/hazelcast-tpm/pull/71