### PR TITLE
Remove redundant `actions/checkout` token

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -92,8 +92,6 @@ jobs:
             echo "merged-ref=''" >> $GITHUB_OUTPUT
             echo "base-sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           
   # run for code-coverage and upload the result as an artifact.
   code-coverage:
@@ -108,7 +106,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
-          token: ${{ secrets.GH_TOKEN }}
 
       - uses: ./.github/actions/coverage-report
         with:
@@ -144,7 +141,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
-          token: ${{ secrets.GH_TOKEN }}
 
       - uses: ./.github/actions/build-test/ubuntu-x86_64
         with:
@@ -179,7 +175,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
-          token: ${{ secrets.GH_TOKEN }}
 
       - uses: ./.github/actions/build-test/windows
         with:
@@ -226,7 +221,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
-          token: ${{ secrets.GH_TOKEN }}
 
       - uses: ./.github/actions/build-test/macos-x86_64
         with:
@@ -253,7 +247,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
-          token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0          
 
       - name: Check formatting


### PR DESCRIPTION
We don't need to supply a token to `actions/checkout`, the implicit `${{ github.token }}` is fine and preferable to a long-lived PAT.