### PR TITLE
Fix PR builder post merge conflict in #1412

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -47,7 +47,7 @@ jobs:
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
           member-name: ${{ github.actor }}
-          token: ${{ github.token }}
+          token: ${{ secrets.GH_TOKEN }}
           
   # ensure PR is trusted
   ensure-membership:


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast-cpp-client/pull/1412 inadvertently reverted https://github.com/hazelcast/hazelcast-cpp-client/pull/1431, which caused the [PR builder to stop working again](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/24265361516/job/70859003057#step:2:32):
> gh: User does not exist or is not a public member of the organization (HTTP 404)

This was extra confusing because https://github.com/hazelcast/hazelcast-cpp-client/pull/1431 was itself (partially) reverting https://github.com/hazelcast/hazelcast-cpp-client/pull/1427.

Because `pull_request_target` this will require a manual force-merge.