### PR TITLE
fix: use explicit boost::optional construction for Boost 1.91 compatibility

### DIFF
--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1189,7 +1189,7 @@ ClientClusterServiceImpl::get_member(boost::uuids::uuid uuid) const
     if (it == members_view_ptr->members.end()) {
         return boost::none;
     }
-    return { it->second };
+    return boost::optional<member>(it->second);
 }
 
 std::vector<member>


### PR DESCRIPTION
Boost 1.91.0 made `boost::optional`'s converting constructor from `U&&` explicit.
This breaks copy-list-initialization like `return { it->second }` which relies on
implicit conversion.

Fix by using direct-initialization `boost::optional<member>(it->second)`, which
works with both explicit and implicit constructors, maintaining backward
compatibility with older Boost versions.

References:
- Commit that introduced the explicit converting constructor in the new constexpr path:
  https://github.com/boostorg/optional/commit/046357ce54e43d48fc9c40e23dd79603a6d09a1d
- The explicit constructor in union_optional.hpp:
  https://github.com/boostorg/optional/blob/boost-1.91.0/include/boost/optional/detail/union_optional.hpp#L395