### PR TITLE
Update PR builder membership test to use `triggering_actor` to make community PR execution easier

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -46,7 +46,7 @@ jobs:
         id: test-membership
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
-          member-name: ${{ github.actor }}
+          member-name: ${{ github.triggering_actor }}
           token: ${{ secrets.GH_TOKEN }}
           
   # ensure PR is trusted
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Report
         shell: bash
-        run: echo "User ${{ github.actor }} is trusted for test execution"          
+        run: echo "User ${{ github.triggering_actor }} is trusted for test execution"          
 
 
   # get


### PR DESCRIPTION
PR builder execution is restricted to `hazelcast` users, validating by checking the `github.actor`.

In the case of non-`hazelcast` user, execution is rejected... but what's _supposed_ to happen next is unclear.

The action can be executed manually via `workflow_dispatch` with a community PR input suggesting this is the route for community PR execution - but this won't satisfy branch protection rules as it won't map back to the PR.

The `github.actor` [always evaluates to the original actor](https://github.blog/changelog/2022-07-19-differentiating-triggering-actor-from-executing-actor/) regardless of re-execution. By updating it to `triggering_actor` instead, if a Hazelcast user merely re-runs the action it will be allowed to execute, which is much more obvious.