### PR TITLE
Make workflow re-runs safer by avoiding exclusive use of `github.run_id` for uniqueness [DI-818]

### DIFF
--- a/.github/actions/update-project-version/action.yml
+++ b/.github/actions/update-project-version/action.yml
@@ -30,6 +30,6 @@ runs:
       # https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.1
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
       with:
-        branch: Update_version_to_${{ inputs.NEXT_VERSION }}_run_${{ github.run_id }}
+        branch: Update_version_to_${{ inputs.NEXT_VERSION }}_run_${{ github.run_id }}_${{ job.check_run_id }}
         title: Update version to `${{ inputs.NEXT_VERSION }}` in `${{ steps.get-current-branch-name.outputs.name }}`
         body: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         # https://github.com/peter-evans/create-pull-request/releases/tag/v8.1.1
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          branch: ${{ needs.prepare.outputs.tag_name }}_doc_update_run_${{ github.run_id }}
+          branch: ${{ needs.prepare.outputs.tag_name }}_doc_update_run_${{ github.run_id }}_${{ job.check_run_id }}
           title: Add the new C++ client release (`${{ needs.prepare.outputs.tag_name }}`) documentation
           body: ""
           path: ${{ env.GH_PAGES_BRANCH}}


### PR DESCRIPTION
[`github.run_id` is not unique when the workflow is re-run](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context), would could mean re-execution uses the same remote branch.

Updated to qualify with something that _is_ unique for re-executions.

Fixes: [DI-818](https://hazelcast.atlassian.net/browse/DI-818)

[DI-818]: https://hazelcast.atlassian.net/browse/DI-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ