### PR TITLE
Revert back the max boost version to 1.90.0 [HZ-5424]

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,11 +24,11 @@ on:
         description: Enter guest PR verified HEAD commit SHA.
         required: true
 env:
-  BOOST_VERSION: 1.91.0
-  BOOST_ARCHIVE_NAME: 'boost_1_91_0.tar.gz'
-  BOOST_FOLDER_NAME: 'boost_1_91_0'
-  BOOST_INCLUDE_FOLDER: 'C:\Boost\include\boost-1_91'
-  BOOST_URL: 'https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.gz'
+  BOOST_VERSION: 1.90.0
+  BOOST_ARCHIVE_NAME: 'boost_1_90_0.tar.gz'
+  BOOST_FOLDER_NAME: 'boost_1_90_0'
+  BOOST_INCLUDE_FOLDER: 'C:\Boost\include\boost-1_90'
+  BOOST_URL: 'https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.gz'
   THRIFT_VERSION: 0.13.0
   RUN_TESTS: true
   

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         boost:
             - version: 1.88.0 # MacOS issue (https://github.com/boostorg/thread/issues/402) fixed at 1.88.0
-            - version: 1.91.0
+            - version: 1.90.0
         build_type: ${{ fromJSON(needs.shared-matrix.outputs.build-type) }}
         shared_libs: ${{ fromJSON(needs.shared-matrix.outputs.shared-libs) }}
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         boost:
           - version: 1.83.0
-          - version: 1.91.0
+          - version: 1.90.0
 
         build_type:
           - Debug

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -28,10 +28,10 @@ jobs:
             boost_include_folder: 'C:\Boost\include\boost-1_83'
           - name: msvc-latest_boost_1910
             image: 'windows-latest'
-            boost_url: 'https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.gz'
-            boost_archive_name: 'boost_1_91_0.tar.gz'
-            boost_folder_name: 'boost_1_91_0'
-            boost_include_folder: 'C:\Boost\include\boost-1_91'
+            boost_url: 'https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.gz'
+            boost_archive_name: 'boost_1_90_0.tar.gz'
+            boost_folder_name: 'boost_1_90_0'
+            boost_include_folder: 'C:\Boost\include\boost-1_90'
         options: ${{ fromJSON(needs.shared-matrix.outputs.windows-options) }}
         build_type: ${{ fromJSON(needs.shared-matrix.outputs.build-type) }}
         shared_libs: ${{ fromJSON(needs.shared-matrix.outputs.shared-libs) }}


### PR DESCRIPTION
Revert back the max boost version to 1.90.0 as this is the highest that exists at the latest released code base https://github.com/microsoft/vcpkg/releases/tag/2026.04.27. We only use the released vcpkg versions. The higher 1.91.0 exists at vcpkg master but it is not released yet. This caused the nightly builds (e.g. https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/26135100539/job/76868494624) fail, since we had the

```
"builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
```
at vcpkg.json file which is 2026.04.27 release commit id and it does not have 1.91 versions of boost ports.