### PR TITLE
Replace deprecated boost::asio strand::wrap with bind_executor [HZ-5424]

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -224,7 +224,8 @@ protected:
         socket_.async_read_some(
           boost::asio::buffer(connection->read_handler.byte_buffer.ix(),
                               connection->read_handler.byte_buffer.remaining()),
-          socket_strand_.wrap(
+          boost::asio::bind_executor(
+            socket_strand_,
             [=](const boost::system::error_code& ec, std::size_t bytes_read) {
                 if (ec) {
                     // prevent any exceptions
@@ -282,7 +283,8 @@ protected:
         boost::asio::async_write(
           socket_,
           batch_buffers_,
-          socket_strand_.wrap(
+          boost::asio::bind_executor(
+            socket_strand_,
             [this, connection](const boost::system::error_code& ec,
                                std::size_t /* bytes_written */) {
                 write_in_progress_ = false;


### PR DESCRIPTION
## Summary
- `boost::asio::io_context::strand::wrap()` was deprecated in recent Boost releases and emits `-Wdeprecated-declarations`. Combined with `-Wall -Werror` (auto-enabled for Debug builds), this fails the Ubuntu CI job — see [run 26226751590](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/26226751590/job/77175758625).
- Both call sites in `BaseSocket.h` (`do_read` read completion handler and `flush_write_queue` write completion handler) were updated to use the documented replacement `boost::asio::bind_executor(socket_strand_, ...)`, which produces an equivalent strand-bound completion handler with no behavior change.

## Test plan
- [x] Local Debug build passes with `-Werror=deprecated-declarations` explicitly enabled
- [ ] CI Ubuntu Debug build (was previously failing) passes
- [ ] Existing test suite still green