### PR TITLE
Fix Thrift 0.13.0 build failure on Windows with Boost 1.83.0 (NOMINMAX) [HZ-5424]

### DIFF
--- a/.github/actions/build-test/windows/action.yml
+++ b/.github/actions/build-test/windows/action.yml
@@ -118,7 +118,8 @@ runs:
                   -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON `
                   -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF `
                   -DBUILD_HASKELL=OFF -DWITH_OPENSSL=OFF -DWITH_LIBEVENT=OFF -DWITH_ZLIB=OFF `
-                  -DWITH_QT5=OFF -DBoost_INCLUDE_DIR=${{ inputs.BOOST_INCLUDE_FOLDER }} -DCMAKE_INSTALL_PREFIX=C:\Thrift
+                  -DWITH_QT5=OFF -DBoost_INCLUDE_DIR=${{ inputs.BOOST_INCLUDE_FOLDER }} -DCMAKE_INSTALL_PREFIX=C:\Thrift `
+                  "-DCMAKE_CXX_FLAGS=/DNOMINMAX"
         cmake --build . --target install --config ${{ inputs.BUILD_TYPE }}
         mkdir C:\Thrift\bin
         cd ../..


### PR DESCRIPTION
## Summary

- Adds `/DNOMINMAX` to `CMAKE_CXX_FLAGS` when building Thrift 0.13.0 on Windows, fixing a compile error introduced by Boost 1.83.0.

Closes #1461

## Root Cause

Boost 1.83.0 introduced `boost/locale/util/string.hpp`, which calls `std::numeric_limits<char>::max()` inside a `constexpr` function (`to_char`). On Windows, `windows.h` defines `max` as a macro unless `NOMINMAX` is defined first. Thrift 0.13.0 does not define `NOMINMAX`, so the macro corrupts the `numeric_limits` call at the preprocessor level, producing C2589 / C2059 / C3615 errors.

**Failing job:** https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/26226738709/job/77175714903

## Fix

```diff
  cmake .. -A ${{ inputs.ARCH_CMAKE }} \
            ...
-           -DWITH_QT5=OFF -DBoost_INCLUDE_DIR=... -DCMAKE_INSTALL_PREFIX=C:\Thrift
+           -DWITH_QT5=OFF -DBoost_INCLUDE_DIR=... -DCMAKE_INSTALL_PREFIX=C:\Thrift \
+           "-DCMAKE_CXX_FLAGS=/DNOMINMAX"
```

Defining `NOMINMAX` via the CMake command line ensures it is set before any header is processed. It suppresses the `min`/`max` macros from `windows.h` and is otherwise a no-op — safe for all Boost versions and build configurations.

## Test plan

- [ ] Nightly Windows · Boost 1.83.0 · Debug · noSSL job passes
- [ ] All other Windows nightly and PR matrix jobs continue to pass
