### PR TITLE
Fix rfc2818_verification build failure on Windows with Boost 1.83.0 and OpenSSL 3.x [HZ-5424]

### DIFF
--- a/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/BaseSocket.h
@@ -19,7 +19,15 @@
 #include <boost/format.hpp>
 #include <boost/lockfree/queue.hpp>
 #ifdef HZ_BUILD_WITH_SSL
-#include <boost/asio/ssl.hpp>
+// Avoid <boost/asio/ssl.hpp> because in Boost <= 1.83 it transitively
+// includes rfc2818_verification, whose .ipp dereferences private
+// ASN1_STRING fields that became opaque in OpenSSL 3.x and breaks the
+// MSVC build. We use the modern host_name_verification instead, so pull
+// in only the specific subheaders we actually need.
+#include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/error.hpp>
+#include <boost/asio/ssl/host_name_verification.hpp>
+#include <boost/asio/ssl/stream.hpp>
 #endif
 
 #include "hazelcast/client/socket.h"

--- a/hazelcast/include/hazelcast/client/internal/socket/SSLSocket.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SSLSocket.h
@@ -18,7 +18,13 @@
 #ifdef HZ_BUILD_WITH_SSL
 
 #include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
+// See BaseSocket.h: <boost/asio/ssl.hpp> in Boost <= 1.83 transitively
+// pulls in rfc2818_verification, which fails to compile against
+// OpenSSL 3.x (opaque ASN1_STRING). Use specific subheaders instead.
+#include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/error.hpp>
+#include <boost/asio/ssl/host_name_verification.hpp>
+#include <boost/asio/ssl/stream.hpp>
 
 #include "hazelcast/client/internal/socket/BaseSocket.h"
 

--- a/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
+++ b/hazelcast/include/hazelcast/client/internal/socket/SocketFactory.h
@@ -22,7 +22,13 @@
 #ifdef HZ_BUILD_WITH_SSL
 
 #include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
+// See BaseSocket.h: <boost/asio/ssl.hpp> in Boost <= 1.83 transitively
+// pulls in rfc2818_verification, which fails to compile against
+// OpenSSL 3.x (opaque ASN1_STRING). Use specific subheaders instead.
+#include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/error.hpp>
+#include <boost/asio/ssl/host_name_verification.hpp>
+#include <boost/asio/ssl/stream.hpp>
 
 #endif // HZ_BUILD_WITH_SSL
 


### PR DESCRIPTION
Closes #1463

## Summary

- The Boost 1.83.0 + OpenSSL 3.x matrix entry of the `nightly-Windows` workflow fails to compile `rfc2818_verification.ipp`: `error C2027: use of undefined type 'asn1_string_st'` (followed by a cascading `C2660` on `memcmp`).
- The client never references `boost::asio::ssl::rfc2818_verification`; it uses the modern `host_name_verification` (`hazelcast/src/hazelcast/util/util.cpp`). The broken `.ipp` was being dragged in transitively through the umbrella `<boost/asio/ssl.hpp>` include in three internal socket headers.
- Replaced the umbrella include in `BaseSocket.h`, `SSLSocket.h`, and `SocketFactory.h` with the specific subheaders the codebase actually uses (`context.hpp`, `error.hpp`, `host_name_verification.hpp`, `stream.hpp`) — matching the include pattern already used in `util.cpp`. This avoids `rfc2818_verification.hpp` entirely.

## Root cause

In Boost 1.83.0, `<boost/asio/ssl.hpp>` lists `<boost/asio/ssl/rfc2818_verification.hpp>` among its includes. In Boost.Asio's default header-only mode that pulls in `rfc2818_verification.ipp`, whose hostname-matching code dereferences `ASN1_STRING` fields directly (`domain->data`, `domain->length`). OpenSSL 3.0 made `ASN1_STRING` an opaque type whose layout is no longer exposed by the public headers, so MSVC refuses to compile the field accesses (hence `C2027`; the `C2660` is a follow-on because `domain->data` collapses to a non-pointer expression). GCC/Clang on Linux/macOS happen to accept the opaque-struct dereference more leniently on this path, which is why only the Windows + MSVC + OpenSSL 3.x combination breaks.

Upstream Boost dropped `rfc2818_verification` from `<boost/asio/ssl.hpp>` after 1.83.0; it is no longer present in 1.90.0. That is why only the 1.83.0 matrix entry is affected.

## Test plan

- [x] Local build of the `hazelcast-cpp-client` library with `HZ_BUILD_WITH_SSL=ON` succeeds on macOS arm64 (vcpkg toolchain, Boost 1.90.0, OpenSSL 3.x).
- [x] Local build of the `client_test` binary with `HZ_BUILD_WITH_SSL=ON` succeeds (all `boost::asio::ssl::context` / `verify_peer` / `verify_callback` uses in test files compile cleanly).
- [ ] CI `nightly-Windows` workflow with `msvc-latest_boost_1830` + `with_openssl: ON` now compiles (verified by re-running the workflow on this branch).
- [ ] CI `nightly-Windows` workflow with `msvc-latest_boost_1900` + `with_openssl: ON` still compiles (no regression).
- [ ] CI `build-pr` Windows / Ubuntu / macOS matrices remain green.

Tracking: HZ-5424