### PR TITLE
Rescope AWS ARN from `secret` to `var`

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -114,7 +114,7 @@ jobs:
           THRIFT_VERSION: ${{ env.THRIFT_VERSION }}
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   shared-matrix:
@@ -152,7 +152,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   Windows:
@@ -195,7 +195,7 @@ jobs:
           INSTALL_THRIFT: true
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   macOS-x86_64:
@@ -231,7 +231,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ env.RUN_TESTS }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
   enforce-code-formatting:

--- a/.github/workflows/coverage-report.yaml
+++ b/.github/workflows/coverage-report.yaml
@@ -23,7 +23,7 @@ jobs:
           THRIFT_VERSION: 0.13.0
           RUN_TESTS: true
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Publish on Codecov

--- a/.github/workflows/nightly-macos-x86_64.yml
+++ b/.github/workflows/nightly-macos-x86_64.yml
@@ -49,7 +49,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.RUN_TESTS || github.event_name == 'schedule' }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Verify Installation

--- a/.github/workflows/nightly-ubuntu-x86_64.yml
+++ b/.github/workflows/nightly-ubuntu-x86_64.yml
@@ -60,7 +60,7 @@ jobs:
           OPENSSL_TOGGLE: ${{ matrix.with_openssl.toggle }}
           RUN_TESTS: ${{ inputs.RUN_TESTS || github.event_name == 'schedule' }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Verify Installation

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -86,7 +86,7 @@ jobs:
           INSTALL_THRIFT: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
           RUN_TESTS: ${{ inputs.RUN_TESTS || github.event_name == 'schedule' }}
           HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
           HZ_TEST_AWS_INSTANCE_PRIVATE_IP: ${{ secrets.HZ_TEST_AWS_INSTANCE_PRIVATE_IP }}
 
       - name: Verify Installation


### PR DESCRIPTION
The name of the role isn't a `secret`, so storing at such means it's masked logs etc which makes debugging difficult. More specifically, authentication is handled via [OIDC](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws), on it's own the role does nothing.

Instead, it should be rescoped as a `var`.