### PR TITLE
Fix SqlTest.select Windows flake: move bounds-check EXPECT_THROWs outside the row loop [HZ-5424]

### DIFF
--- a/hazelcast/test/src/sql_test.cpp
+++ b/hazelcast/test/src/sql_test.cpp
@@ -1870,8 +1870,34 @@ TEST_F(SqlTest, select)
 
     std::unordered_set<int64_t> unique_keys;
 
-    for (auto itr = res->iterator(); itr.has_next();) {
-        auto page = itr.next().get();
+    // Fetch the first page up front so we can verify the bounds-checking API
+    // on a single representative row before the main loop.
+    // Background: on Windows, C++ exceptions are built on SEH. When ProcDump
+    // is attached as a debugger (CI step: procdump -e -ma -w client_test.exe),
+    // every throw raises SEH code 0xE06D7363, which the OS delivers as a
+    // first-chance debug event to ProcDump before the C++ catch handler runs.
+    // ProcDump logs the line "[HH:MM:SS]Exception: E06D7363.?AV..." and then
+    // calls ContinueDebugEvent so execution can proceed. This is a mandatory
+    // two-kernel-mode-transition round-trip for every single throw.
+    // With the EXPECT_THROW calls inside the 4096-row loop that is ~12 000
+    // round-trips, stalling the loop long enough to trigger connection
+    // timeouts on the server side (Windows-only flaky failure).
+    auto itr = res->iterator();
+    ASSERT_TRUE(itr.has_next());
+    auto page = itr.next().get();
+    ASSERT_FALSE(page->rows().empty());
+    {
+        const auto& first_row = page->rows().front();
+        EXPECT_THROW(first_row.get_object<int>(-1),
+                     exception::index_out_of_bounds);
+        EXPECT_THROW(
+          first_row.get_object<int>(first_row.row_metadata().column_count()),
+          exception::index_out_of_bounds);
+        EXPECT_THROW(first_row.get_object<int>("unknown_field"),
+                     exception::illegal_argument);
+    }
+
+    for (;;) {
         for (const auto& row : page->rows()) {
             ASSERT_EQ(row_metadata, res->row_metadata());
 
@@ -1903,14 +1929,10 @@ TEST_F(SqlTest, select)
               sql_column_type::varchar, val.varchar_val, row, "varcharVal");
 
             unique_keys.emplace(*key0);
-
-            EXPECT_THROW(row.get_object<int>(-1),
-                         exception::index_out_of_bounds);
-            EXPECT_THROW(row.get_object<int>(row.row_metadata().column_count()),
-                         exception::index_out_of_bounds);
-            EXPECT_THROW(row.get_object<int>("unknown_field"),
-                         exception::illegal_argument);
         }
+        if (!itr.has_next())
+            break;
+        page = itr.next().get();
     }
 
     EXPECT_THROW(res->iterator(), exception::illegal_state);


### PR DESCRIPTION
Fixes #1470

## Summary

- `SqlTest.select` was iterating over 4 096 SQL rows and calling `EXPECT_THROW` three times per row to verify `get_object()` raises `index_out_of_bounds` / `illegal_argument`.  That is **~12 000 C++ exception throws** per test run.
- On Windows the CI step runs ProcDump as a debugger (`procdump -e -ma -w client_test.exe`).  Every C++ `throw` raises SEH code `0xE06D7363`; the OS delivers this as a *first-chance debug event* to ProcDump **before** the C++ `catch` handler can run.  ProcDump logs `[HH:MM:SS]Exception: E06D7363.?AVindex_out_of_bounds@...`, then calls `ContinueDebugEvent()` — **two mandatory kernel-mode round-trips per throw**.  12 000 throws × 2 = 24 000 kernel transitions, combined with 4 096 synchronous `map->get()` server calls, made the loop slow enough for the server-side connection health-check to fire and cancel the SQL cursor (`Client cannot be reached`).
- Fix: fetch the first page before the main loop, run the three `EXPECT_THROW` checks on its first row only, then iterate all pages in a `for(;;)` loop starting from the already-fetched first page.  Exception count drops from **12 000 to 3**.  The `bounds_checked` flag is eliminated.

## Why it was Windows-only

Linux/macOS CI does not use ProcDump.  Without a debugger attached, `throw` → `catch` is entirely in-process with zero kernel transitions, so the loop completes well within any timeout.

## Root cause detail

On Windows, C++ exceptions are built on SEH.  When a debugger is attached via `DebugActiveProcess()`, the kernel suspends the target process's threads and delivers an `EXCEPTION_DEBUG_EVENT` to the debugger through the kernel debug port.  The debugger must call `WaitForDebugEvent()`, process the event, and call `ContinueDebugEvent()` before the target resumes.  This happens for *every* throw, even ones that are immediately caught — ProcDump cannot skip them.  Under heavy exception load (12 000 throws), the cumulative stall is enough to trigger server-side timeouts.

## Test plan

- [x] The three `EXPECT_THROW` boundary checks still execute (on the first row of the first page).
- [x] All 4 096 rows are still visited and verified through the restructured `for(;;)` loop.
- [ ] CI `build-pr` Windows jobs pass without the `SqlTest.select` failure.