### PR TITLE
Harden `curl` usage - add retries and error logging

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Check formatting
         run: |
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           git-clang-format \
             ${{ needs.get-refs.outputs.base-sha }} \

--- a/scripts/install-boost.sh
+++ b/scripts/install-boost.sh
@@ -12,7 +12,7 @@ fi
 
 TARBALL_NAME=boost_$(echo "$1" | tr . _)
 
-curl --fail --silent --show-error --location "https://archives.boost.io/release/${1}/source/${TARBALL_NAME}.tar.gz" | tar xzf -
+curl --fail --retry 5 --retry-all-errors --show-error --silent --show-error --location "https://archives.boost.io/release/${1}/source/${TARBALL_NAME}.tar.gz" | tar xzf -
 pushd "${TARBALL_NAME}"
 ./bootstrap.sh
 # Build the libs for:

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -13,7 +13,7 @@ fi
 # Ideally we would download directly from Apache:
 # https://www.apache.org/dyn/closer.lua/thrift/$1/thrift-$1.tar.gz?action=download
 # But this has intermittent failures in GitHub Actions
-curl --fail --silent --show-error --location "https://deb.debian.org/debian/pool/main/t/thrift/thrift_$1.orig.tar.gz" | tar xzf -
+curl --fail --retry 5 --retry-all-errors --show-error --silent --show-error --location "https://deb.debian.org/debian/pool/main/t/thrift/thrift_$1.orig.tar.gz" | tar xzf -
 pushd thrift-$1/build
 cmake .. -DBUILD_COMPILER=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_LIBRARIES=ON \
          -DBUILD_CPP=ON -DBUILD_AS3=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_PYTHON=OFF \


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-docker/pull/1284 ensured failure was reported and the execution was halted, but the error message [wasn't clear](https://github.com/hazelcast/hazelcast-docker/actions/runs/28910263431/job/85765974279#step:6:31):
> Error: Process completed with exit code 22.

By adding the [`--show-error` option](https://curl.se/docs/manpage.html#--show-error) we can ensure the human readable error is printed to stderr, e.g.:
> curl: (56) The requested URL returned error: 404


In addition, the root cause of the failure is _probably_ an intermittent blip on the GitHub side ([related discussion](https://github.com/orgs/community/discussions/53538)) - so adding a simple retry-on-failure seems sensible.