### PR TITLE
Make the schema replication executor pool size configurable

### DIFF
--- a/hazelcast/include/hazelcast/client/client_properties.h
+++ b/hazelcast/include/hazelcast/client/client_properties.h
@@ -82,6 +82,8 @@ public:
 
     const client_property& get_response_thread_count() const;
 
+    const client_property& get_schema_replication_pool_size() const;
+
     const client_property& get_shuffle_member_list() const;
 
     const client_property& get_max_concurrent_invocations() const;
@@ -215,6 +217,20 @@ public:
      */
     static const std::string RESPONSE_THREAD_COUNT;
     static const std::string RESPONSE_THREAD_COUNT_DEFAULT;
+
+    /**
+     * Number of threads which replicate compact schemas to the cluster.
+     * <p/>
+     * Every task on this pool blocks: replicate_schema_in_cluster() waits on
+     * invoke().get(), and on the retry path it sleeps for the invocation retry
+     * pause between attempts. A schema is replicated at most once per client,
+     * so this pool is idle in steady state and only a handful of threads are
+     * needed; sizing it any larger simply reserves threads that never run.
+     * Because the tasks block, a value of 1 makes concurrent writes of
+     * distinct unseen schemas serialize behind one another.
+     */
+    static const std::string SCHEMA_REPLICATION_POOL_SIZE;
+    static const std::string SCHEMA_REPLICATION_POOL_SIZE_DEFAULT;
 
     /**
      * Client shuffles the given member list to prevent all clients to connect
@@ -352,6 +368,7 @@ private:
     client_property internal_executor_pool_size_;
     client_property io_thread_count_;
     client_property response_thread_count_;
+    client_property schema_replication_pool_size_;
     client_property shuffle_member_list_;
     client_property max_concurrent_invocations_;
     client_property backpressure_backoff_timeout_millis_;

--- a/hazelcast/src/hazelcast/client/client_impl.cpp
+++ b/hazelcast/src/hazelcast/client/client_impl.cpp
@@ -998,6 +998,10 @@ const std::string client_properties::RESPONSE_THREAD_COUNT =
   "hazelcast.client.response.thread.count";
 const std::string client_properties::RESPONSE_THREAD_COUNT_DEFAULT = "2";
 
+const std::string client_properties::SCHEMA_REPLICATION_POOL_SIZE =
+  "hazelcast.client.schema.replication.pool.size";
+const std::string client_properties::SCHEMA_REPLICATION_POOL_SIZE_DEFAULT = "3";
+
 const std::string client_properties::SHUFFLE_MEMBER_LIST =
   "hazelcast.client.shuffle.member.list";
 const std::string client_properties::SHUFFLE_MEMBER_LIST_DEFAULT = "true";
@@ -1071,6 +1075,8 @@ client_properties::client_properties(
                                  INTERNAL_EXECUTOR_POOL_SIZE_DEFAULT)
   , io_thread_count_(IO_THREAD_COUNT, IO_THREAD_COUNT_DEFAULT)
   , response_thread_count_(RESPONSE_THREAD_COUNT, RESPONSE_THREAD_COUNT_DEFAULT)
+  , schema_replication_pool_size_(SCHEMA_REPLICATION_POOL_SIZE,
+                                  SCHEMA_REPLICATION_POOL_SIZE_DEFAULT)
   , shuffle_member_list_(SHUFFLE_MEMBER_LIST, SHUFFLE_MEMBER_LIST_DEFAULT)
   , max_concurrent_invocations_(MAX_CONCURRENT_INVOCATIONS,
                                 MAX_CONCURRENT_INVOCATIONS_DEFAULT)
@@ -1143,6 +1149,12 @@ const client_property&
 client_properties::get_response_thread_count() const
 {
     return response_thread_count_;
+}
+
+const client_property&
+client_properties::get_schema_replication_pool_size() const
+{
+    return schema_replication_pool_size_;
 }
 
 const client_property&

--- a/hazelcast/src/hazelcast/client/spi.cpp
+++ b/hazelcast/src/hazelcast/client/spi.cpp
@@ -1629,7 +1629,15 @@ ClientExecutionServiceImpl::start()
           new hazelcast::util::hz_thread_pool(user_pool_size_));
     }
 
-    schema_replication_executor_.reset(new hazelcast::util::hz_thread_pool());
+    int schemaReplicationPoolSize = client_properties_.get_integer(
+      client_properties_.get_schema_replication_pool_size());
+    if (schemaReplicationPoolSize <= 0) {
+        schemaReplicationPoolSize = util::IOUtil::to_value<int>(
+          client_properties::SCHEMA_REPLICATION_POOL_SIZE_DEFAULT);
+    }
+
+    schema_replication_executor_.reset(
+      new hazelcast::util::hz_thread_pool(schemaReplicationPoolSize));
 }
 
 void

--- a/hazelcast/test/src/HazelcastTests8.cpp
+++ b/hazelcast/test/src/HazelcastTests8.cpp
@@ -2767,9 +2767,66 @@ TEST_P(ThreadPoolTest, testEqualThreadAndJobs)
     ASSERT_EQ(expected_thread_num, state->thread_ids.size());
 }
 
+// Submits twice as many jobs as the configured pool size, so the assertion is
+// an exact thread count rather than min(jobs, size). Each parameter differs
+// from SCHEMA_REPLICATION_POOL_SIZE_DEFAULT, so every case fails if the
+// property is ignored.
+TEST_P(ThreadPoolTest, testSchemaReplicationPoolSizeIsHonoured)
+{
+    int32_t num_of_thread = GetParam();
+    int32_t num_of_jobs = num_of_thread * 2;
+
+    client_config config;
+    config.set_property(client_properties::SCHEMA_REPLICATION_POOL_SIZE,
+                        std::to_string(num_of_thread));
+
+    auto local_client = new_client(std::move(config)).get();
+
+    spi::ClientContext ctx(local_client);
+    auto state = std::make_shared<ThreadState>(num_of_jobs);
+    std::mutex mutex_for_thread_id;
+    boost::barrier sync_barrier(num_of_thread);
+
+    ASSERT_EQ(0, state->thread_ids.size());
+    for (int i = 0; i < num_of_jobs; i++) {
+        ctx.get_client_execution_service()
+          .get_schema_replication_executor()
+          .submit([state, &mutex_for_thread_id, &sync_barrier]() {
+              sync_barrier.count_down_and_wait();
+              auto curr_thread_id = boost::this_thread::get_id();
+              {
+                  std::lock_guard<std::mutex> lg(mutex_for_thread_id);
+                  state->thread_ids.insert(curr_thread_id);
+              }
+              state->latch1.count_down();
+          });
+    }
+    ASSERT_OPEN_EVENTUALLY(state->latch1);
+    ASSERT_EQ(static_cast<size_t>(num_of_thread), state->thread_ids.size());
+
+    local_client.shutdown().get();
+}
+
 INSTANTIATE_TEST_SUITE_P(ThreadPoolTestSuite,
                          ThreadPoolTest,
                          ::testing::Values(5, 10, 2));
+
+TEST(schema_replication_pool_size_test, resolves_to_default_when_unset)
+{
+    client_properties properties({});
+
+    ASSERT_EQ(
+      3, properties.get_integer(properties.get_schema_replication_pool_size()));
+}
+
+TEST(schema_replication_pool_size_test, configured_value_overrides_default)
+{
+    client_properties properties(
+      { { client_properties::SCHEMA_REPLICATION_POOL_SIZE, "7" } });
+
+    ASSERT_EQ(
+      7, properties.get_integer(properties.get_schema_replication_pool_size()));
+}
 
 } // namespace thread_pool
 } // namespace test


### PR DESCRIPTION
## Problem

`ClientExecutionServiceImpl::start()` created the schema replication thread pool with the no-argument constructor:

```cpp
schema_replication_executor_.reset(new hazelcast::util::hz_thread_pool());
```

`hz_thread_pool()` delegates to `boost::asio::thread_pool()`, which sizes itself at `hardware_concurrency() * 2` — 192 threads on a 96-core host. The pool's only consumer is `ClientInvocation::replicate_schemas`, which performs occasional compact schema replication, and a given schema is replicated at most once per client. The pool was therefore far larger than the workload warrants, sat idle in steady state, and there was no way to change it.

## Change

Adds a `client_properties` entry:

| | |
|---|---|
| Name | `hazelcast.client.schema.replication.pool.size` |
| Default | `3` |
| Resolution | `client_config::set_property()` > environment variable > default |

`start()` resolves it exactly as it already resolves the internal executor pool size, clamping a non-positive value to the default.

```cpp
hazelcast::client::client_config config;
config.set_property("hazelcast.client.schema.replication.pool.size", "2");

auto client = hazelcast::new_client(std::move(config)).get();
```

This follows every other pool knob in the client — `IO_THREAD_COUNT`, `INTERNAL_EXECUTOR_POOL_SIZE`, `RESPONSE_THREAD_COUNT`, `EVENT_THREAD_COUNT` — all of which are properties with small constant defaults. No public API is added, `ClientExecutionServiceImpl`'s constructor is unchanged, and nothing is added to `client_config`, so there is no ABI impact.

The default of `3` replaces `2 * hardware_concurrency` for **every** user, not only those who discover the knob. Tasks on this pool block — `replicate_schema_in_cluster` waits on `invoke().get()` and sleeps for the invocation retry pause on the retry path — so the property documents that a value of 1 makes concurrent writes of distinct unseen schemas serialize behind one another.

## Testing

- `schema_replication_pool_size_test` — offline; asserts the property resolves to the default when unset and that a configured value overrides it.
- `ThreadPoolTest.testSchemaReplicationPoolSizeIsHonoured` — added to the existing `ThreadPoolTest` fixture, so it reuses that suite's member and adds no second `HazelcastServer`. Each parameter configures the pool to `GetParam()` and submits `2 * GetParam()` jobs, asserting *exactly* `GetParam()` distinct thread ids. Every parameter differs from the default of 3, so each case fails if the property is ignored. The test uses a local `hazelcast_client` rather than the fixture's static raw pointer.