### PR TITLE
Allow fork PR checkout in the pull_request_target build workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -106,6 +106,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - uses: ./.github/actions/coverage-report
         with:
@@ -141,6 +142,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - uses: ./.github/actions/build-test/ubuntu-x86_64
         with:
@@ -175,6 +177,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - uses: ./.github/actions/build-test/windows
         with:
@@ -221,6 +224,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
+          allow-unsafe-pr-checkout: true
 
       - uses: ./.github/actions/build-test/macos-x86_64
         with:
@@ -256,6 +260,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-refs.outputs.ref }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0          
 
       - name: Check formatting


### PR DESCRIPTION
## Problem

`actions/checkout` v6.1.0 (2026-07-20) refuses to check out fork pull request code from a `pull_request_target` workflow unless the step opts in:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow. ... To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

`build-pr.yml` uses the floating `@v6` tag, so since that release every external contributor PR fails in the checkout step of all build, coverage and formatting jobs once a member re-runs it. PRs from branches in this repository are unaffected, which is why it went unnoticed. Example: https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/33777102057 (re-run of #1487).

## Change

Add `allow-unsafe-pr-checkout: true` to the five `actions/checkout@v6` steps in `build-pr.yml`.

All of these steps run downstream of the `ensure-membership` job, so untrusted fork code is only checked out when a Hazelcast organisation member triggered or re-ran the workflow, or on a manual dispatch with a verified commit. That is the gating the checkout documentation asks for before opting in.

## Testing

YAML parses. The behaviour can only be verified by re-running an external PR's workflow after this lands on master, since `pull_request_target` reads the workflow from the base branch.
