### PR TITLE
Pin Windows CI to the windows-2022 runner image

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -167,7 +167,9 @@ jobs:
         shared_libs: ${{ fromJSON(needs.shared-matrix.outputs.shared-libs) }}
         with_openssl: ${{ fromJSON(needs.shared-matrix.outputs.openssl) }}
 
-    runs-on: 'windows-latest'
+    # windows-latest ships Visual Studio 2026, which the b2 in Boost 1.90 and
+    # older cannot detect (it falls back to msvc-6.0 and builds nothing).
+    runs-on: 'windows-2022'
     permissions:
       id-token: write
     name: windows-${{ matrix.options.address_model }}-(${{ matrix.build_type }}, ${{ matrix.shared_libs.name }}, ${{ matrix.with_openssl.name }})

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         vc_boost:
           - name: msvc-latest_boost_1830
-            image: 'windows-latest'
+            image: 'windows-2022'
             boost_url: 'https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz'
             boost_archive_name: 'boost_1_83_0.tar.gz'
             boost_folder_name: 'boost_1_83_0'
             boost_include_folder: 'C:\Boost\include\boost-1_83'
           - name: msvc-latest_boost_1900
-            image: 'windows-latest'
+            image: 'windows-2022'
             boost_url: 'https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.gz'
             boost_archive_name: 'boost_1_90_0.tar.gz'
             boost_folder_name: 'boost_1_90_0'


### PR DESCRIPTION
## Problem

`windows-latest` now resolves to the `windows-2025-vs2026` image, which only ships Visual Studio 2026 (MSVC 14.5). The `b2` bundled with Boost 1.90 (B2 5.3.2) knows MSVC versions up to 14.3 and queries `vswhere` for Visual Studio `[17.0,18.0)`, so `toolset=msvc` auto-detection finds no compiler and falls back to a bogus configuration:

```
Performing configuration checks
    - default address-model    : 32-bit [1]
    - default architecture     : arm [1]
[1] msvc-6.0
...
...failed updating 0 target...
Error: Process completed with exit code 1.
```

Every Windows job in `build-pr.yml` and in the Windows nightly (both the Boost 1.83 and 1.90 legs) has failed this way since the label moved, at least since 2026-08-30. Example: https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/33849953437

## Change

Pin the Windows jobs in `build-pr.yml` and `nightly-windows.yml` to `windows-2022`, which still provides Visual Studio 2022 Enterprise at the path the Boost install step already looks for first.

Supporting VS 2026 properly needs a `b2` that knows MSVC 14.5 (B2 5.4+, shipped from Boost 1.91), which is a separate change since the nightly also builds against Boost 1.83.

## Testing

Nightly Windows workflow dispatched on this branch; link in the comments.
